### PR TITLE
Bugfix: crash on Ubuntu in pya:qtbinding

### DIFF
--- a/scripts/mkqtdecl_common/produce.rb
+++ b/scripts/mkqtdecl_common/produce.rb
@@ -1693,7 +1693,7 @@ END
 
       if ia < n_min_args || !t.init
 
-        ofile.puts("  #{tn} = args.read<#{ta} > (heap);")
+        ofile.puts("  #{tn} = gsi::arg_reader<#{ta} >() (args, heap);")
 
       else
 
@@ -1704,7 +1704,7 @@ END
           init_expr = init_expr.gsub("%HEAP%", "heap")
         end
 
-        ofile.puts("  #{tn} = args ? args.read<#{ta} > (heap) : (#{ta})(#{init_expr});")
+        ofile.puts("  #{tn} = args ? gsi::arg_reader<#{ta} >() (args, heap) : gsi::arg_maker<#{ta} >() (#{init_expr}, heap);")
 
       end
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQAbstractItemModel.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQAbstractItemModel.cc
@@ -72,7 +72,7 @@ static void _call_f_buddy_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractItemModel *)cls)->buddy (arg1));
 }
 
@@ -91,7 +91,7 @@ static void _call_f_canFetchMore_c2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->canFetchMore (arg1));
 }
 
@@ -110,7 +110,7 @@ static void _call_f_columnCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QAbstractItemModel *)cls)->columnCount (arg1));
 }
 
@@ -131,8 +131,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QAbstractItemModel *)cls)->data (arg1, arg2));
 }
 
@@ -159,11 +159,11 @@ static void _call_f_dropMimeData_7425 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QModelIndex &arg5 = args.read<const QModelIndex & > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg5 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->dropMimeData (arg1, qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg2).cref(), arg3, arg4, arg5));
 }
 
@@ -182,7 +182,7 @@ static void _call_f_fetchMore_2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel *)cls)->fetchMore (arg1);
 }
@@ -202,7 +202,7 @@ static void _call_f_flags_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFlags<Qt::ItemFlag> > ((QFlags<Qt::ItemFlag>)((QAbstractItemModel *)cls)->flags (arg1));
 }
 
@@ -221,7 +221,7 @@ static void _call_f_hasChildren_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->hasChildren (arg1));
 }
 
@@ -244,9 +244,9 @@ static void _call_f_hasIndex_c3713 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->hasIndex (arg1, arg2, arg3));
 }
 
@@ -269,9 +269,9 @@ static void _call_f_headerData_c3231 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QAbstractItemModel *)cls)->headerData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3));
 }
 
@@ -294,9 +294,9 @@ static void _call_f_index_c3713 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractItemModel *)cls)->index (arg1, arg2, arg3));
 }
 
@@ -317,8 +317,8 @@ static void _call_f_insertColumn_3054 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->insertColumn (arg1, arg2));
 }
 
@@ -341,9 +341,9 @@ static void _call_f_insertColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->insertColumns (arg1, arg2, arg3));
 }
 
@@ -364,8 +364,8 @@ static void _call_f_insertRow_3054 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->insertRow (arg1, arg2));
 }
 
@@ -388,9 +388,9 @@ static void _call_f_insertRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->insertRows (arg1, arg2, arg3));
 }
 
@@ -409,7 +409,7 @@ static void _call_f_itemData_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QMap<int, QVariant> > ((QMap<int, QVariant>)((QAbstractItemModel *)cls)->itemData (arg1));
 }
 
@@ -436,11 +436,11 @@ static void _call_f_match_c7932 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(1);
-  QFlags<Qt::MatchFlag> arg5 = args ? args.read<QFlags<Qt::MatchFlag> > (heap) : (QFlags<Qt::MatchFlag>)(Qt::MatchFlags(Qt::MatchStartsWith|Qt::MatchWrap));
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
+  QFlags<Qt::MatchFlag> arg5 = args ? gsi::arg_reader<QFlags<Qt::MatchFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::MatchFlag> >() (Qt::MatchFlags(Qt::MatchStartsWith|Qt::MatchWrap), heap);
   ret.write<QList<QModelIndex> > ((QList<QModelIndex>)((QAbstractItemModel *)cls)->match (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -459,7 +459,7 @@ static void _call_f_mimeData_c3010 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   ret.write<QMimeData * > ((QMimeData *)((QAbstractItemModel *)cls)->mimeData (arg1));
 }
 
@@ -493,7 +493,7 @@ static void _call_f_parent_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractItemModel *)cls)->parent (arg1));
 }
 
@@ -529,8 +529,8 @@ static void _call_f_removeColumn_3054 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->removeColumn (arg1, arg2));
 }
 
@@ -553,9 +553,9 @@ static void _call_f_removeColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->removeColumns (arg1, arg2, arg3));
 }
 
@@ -576,8 +576,8 @@ static void _call_f_removeRow_3054 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->removeRow (arg1, arg2));
 }
 
@@ -600,9 +600,9 @@ static void _call_f_removeRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->removeRows (arg1, arg2, arg3));
 }
 
@@ -652,7 +652,7 @@ static void _call_f_rowCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QAbstractItemModel *)cls)->rowCount (arg1));
 }
 
@@ -675,9 +675,9 @@ static void _call_f_setData_5065 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->setData (arg1, arg2, arg3));
 }
 
@@ -702,10 +702,10 @@ static void _call_f_setHeaderData_5242 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->setHeaderData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3, arg4));
 }
 
@@ -726,8 +726,8 @@ static void _call_f_setItemData_5414 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QMap<int, QVariant> &arg2 = args.read<const QMap<int, QVariant> & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QMap<int, QVariant> &arg2 = gsi::arg_reader<const QMap<int, QVariant> & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractItemModel *)cls)->setItemData (arg1, arg2));
 }
 
@@ -746,7 +746,7 @@ static void _call_f_setSupportedDragActions_2456 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DropAction> arg1 = args.read<QFlags<Qt::DropAction> > (heap);
+  QFlags<Qt::DropAction> arg1 = gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel *)cls)->setSupportedDragActions (arg1);
 }
@@ -770,9 +770,9 @@ static void _call_f_sibling_c3713 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractItemModel *)cls)->sibling (arg1, arg2, arg3));
 }
 
@@ -793,8 +793,8 @@ static void _call_f_sort_2340 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SortOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel *)cls)->sort (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -814,7 +814,7 @@ static void _call_f_span_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QSize > ((QSize)((QAbstractItemModel *)cls)->span (arg1));
 }
 
@@ -880,8 +880,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractItemModel::tr (arg1, arg2));
 }
 
@@ -904,9 +904,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractItemModel::tr (arg1, arg2, arg3));
 }
 
@@ -927,8 +927,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractItemModel::trUtf8 (arg1, arg2));
 }
 
@@ -951,9 +951,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractItemModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1772,7 +1772,7 @@ static void _call_ctor_QAbstractItemModel_Adaptor_1302 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QAbstractItemModel_Adaptor *> (new QAbstractItemModel_Adaptor (arg1));
 }
 
@@ -1794,9 +1794,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -1819,9 +1819,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1848,11 +1848,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1878,11 +1878,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1904,9 +1904,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -1929,9 +1929,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -2013,8 +2013,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -2035,8 +2035,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -2106,9 +2106,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -2130,9 +2130,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -2154,9 +2154,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -2226,8 +2226,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractItemModel_Adaptor *)cls)->emitter_QAbstractItemModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -2251,10 +2251,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -2272,7 +2272,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractItemModel_Adaptor *)cls)->emitter_QAbstractItemModel_destroyed_1302 (arg1);
 }
 
@@ -2351,8 +2351,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_encodeData_c4599 (arg1, arg2);
 }
@@ -2628,9 +2628,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractItemModel_Adaptor *)cls)->emitter_QAbstractItemModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -2900,7 +2900,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_receivers_c1731 (arg1));
 }
 
@@ -3135,7 +3135,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemModel_Adaptor *)cls)->fp_QAbstractItemModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQAbstractListModel.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQAbstractListModel.cc
@@ -80,11 +80,11 @@ static void _call_f_dropMimeData_7425 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QModelIndex &arg5 = args.read<const QModelIndex & > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg5 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractListModel *)cls)->dropMimeData (arg1, qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg2).cref(), arg3, arg4, arg5));
 }
 
@@ -107,9 +107,9 @@ static void _call_f_index_c3713 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractListModel *)cls)->index (arg1, arg2, arg3));
 }
 
@@ -130,8 +130,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractListModel::tr (arg1, arg2));
 }
 
@@ -154,9 +154,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractListModel::tr (arg1, arg2, arg3));
 }
 
@@ -177,8 +177,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractListModel::trUtf8 (arg1, arg2));
 }
 
@@ -201,9 +201,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractListModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -933,7 +933,7 @@ static void _call_ctor_QAbstractListModel_Adaptor_1302 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QAbstractListModel_Adaptor *> (new QAbstractListModel_Adaptor (arg1));
 }
 
@@ -955,9 +955,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -980,9 +980,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1009,11 +1009,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1039,11 +1039,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1065,9 +1065,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -1090,9 +1090,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -1174,8 +1174,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -1196,8 +1196,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -1244,9 +1244,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -1268,9 +1268,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -1292,9 +1292,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -1364,8 +1364,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractListModel_Adaptor *)cls)->emitter_QAbstractListModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -1389,10 +1389,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -1410,7 +1410,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractListModel_Adaptor *)cls)->emitter_QAbstractListModel_destroyed_1302 (arg1);
 }
 
@@ -1489,8 +1489,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_encodeData_c4599 (arg1, arg2);
 }
@@ -1743,9 +1743,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractListModel_Adaptor *)cls)->emitter_QAbstractListModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -1992,7 +1992,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_receivers_c1731 (arg1));
 }
 
@@ -2227,7 +2227,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractListModel_Adaptor *)cls)->fp_QAbstractListModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQAbstractTableModel.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQAbstractTableModel.cc
@@ -80,11 +80,11 @@ static void _call_f_dropMimeData_7425 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QModelIndex &arg5 = args.read<const QModelIndex & > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg5 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractTableModel *)cls)->dropMimeData (arg1, qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg2).cref(), arg3, arg4, arg5));
 }
 
@@ -107,9 +107,9 @@ static void _call_f_index_c3713 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractTableModel *)cls)->index (arg1, arg2, arg3));
 }
 
@@ -130,8 +130,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractTableModel::tr (arg1, arg2));
 }
 
@@ -154,9 +154,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractTableModel::tr (arg1, arg2, arg3));
 }
 
@@ -177,8 +177,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractTableModel::trUtf8 (arg1, arg2));
 }
 
@@ -201,9 +201,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractTableModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -950,7 +950,7 @@ static void _call_ctor_QAbstractTableModel_Adaptor_1302 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QAbstractTableModel_Adaptor *> (new QAbstractTableModel_Adaptor (arg1));
 }
 
@@ -972,9 +972,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -997,9 +997,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1026,11 +1026,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1056,11 +1056,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1082,9 +1082,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -1107,9 +1107,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -1191,8 +1191,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -1213,8 +1213,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -1284,9 +1284,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -1308,9 +1308,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -1332,9 +1332,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -1404,8 +1404,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractTableModel_Adaptor *)cls)->emitter_QAbstractTableModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -1429,10 +1429,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -1450,7 +1450,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractTableModel_Adaptor *)cls)->emitter_QAbstractTableModel_destroyed_1302 (arg1);
 }
 
@@ -1529,8 +1529,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_encodeData_c4599 (arg1, arg2);
 }
@@ -1783,9 +1783,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractTableModel_Adaptor *)cls)->emitter_QAbstractTableModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -2032,7 +2032,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_receivers_c1731 (arg1));
 }
 
@@ -2267,7 +2267,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTableModel_Adaptor *)cls)->fp_QAbstractTableModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQBasicTimer.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQBasicTimer.cc
@@ -83,8 +83,8 @@ static void _call_f_start_1961 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBasicTimer *)cls)->start (arg1, arg2);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQBuffer.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQBuffer.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QBuffer_1302 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QBuffer *> (new QBuffer (arg1));
 }
 
@@ -87,8 +87,8 @@ static void _call_ctor_QBuffer_2812 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QByteArray *arg1 = args.read<QByteArray * > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QByteArray *arg1 = gsi::arg_reader<QByteArray * >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QBuffer *> (new QBuffer (arg1, arg2));
 }
 
@@ -198,7 +198,7 @@ static void _call_f_open_3242 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QIODevice::OpenModeFlag> arg1 = args.read<QFlags<QIODevice::OpenModeFlag> > (heap);
+  QFlags<QIODevice::OpenModeFlag> arg1 = gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap);
   ret.write<bool > ((bool)((QBuffer *)cls)->open (arg1));
 }
 
@@ -232,7 +232,7 @@ static void _call_f_seek_986 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<bool > ((bool)((QBuffer *)cls)->seek (arg1));
 }
 
@@ -251,7 +251,7 @@ static void _call_f_setBuffer_1618 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QByteArray *arg1 = args.read<QByteArray * > (heap);
+  QByteArray *arg1 = gsi::arg_reader<QByteArray * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBuffer *)cls)->setBuffer (arg1);
 }
@@ -271,7 +271,7 @@ static void _call_f_setData_2309 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBuffer *)cls)->setData (arg1);
 }
@@ -293,8 +293,8 @@ static void _call_f_setData_2390 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  int arg2 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBuffer *)cls)->setData (arg1, arg2);
 }
@@ -331,8 +331,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QBuffer::tr (arg1, arg2));
 }
 
@@ -355,9 +355,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QBuffer::tr (arg1, arg2, arg3));
 }
 
@@ -378,8 +378,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QBuffer::trUtf8 (arg1, arg2));
 }
 
@@ -402,9 +402,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QBuffer::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQByteArrayMatcher.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQByteArrayMatcher.cc
@@ -65,7 +65,7 @@ static void _call_ctor_QByteArrayMatcher_2309 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QByteArrayMatcher *> (new QByteArrayMatcher (arg1));
 }
 
@@ -86,8 +86,8 @@ static void _call_ctor_QByteArrayMatcher_2390 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  int arg2 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QByteArrayMatcher *> (new QByteArrayMatcher (arg1, arg2));
 }
 
@@ -106,7 +106,7 @@ static void _call_ctor_QByteArrayMatcher_3017 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArrayMatcher &arg1 = args.read<const QByteArrayMatcher & > (heap);
+  const QByteArrayMatcher &arg1 = gsi::arg_reader<const QByteArrayMatcher & >() (args, heap);
   ret.write<QByteArrayMatcher *> (new QByteArrayMatcher (arg1));
 }
 
@@ -129,9 +129,9 @@ static void _call_f_indexIn_c3049 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<int > ((int)((QByteArrayMatcher *)cls)->indexIn (arg1, arg2, arg3));
 }
 
@@ -150,7 +150,7 @@ static void _call_f_operator_eq__3017 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArrayMatcher &arg1 = args.read<const QByteArrayMatcher & > (heap);
+  const QByteArrayMatcher &arg1 = gsi::arg_reader<const QByteArrayMatcher & >() (args, heap);
   ret.write<QByteArrayMatcher & > ((QByteArrayMatcher &)((QByteArrayMatcher *)cls)->operator= (arg1));
 }
 
@@ -184,7 +184,7 @@ static void _call_f_setPattern_2309 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QByteArrayMatcher *)cls)->setPattern (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQChildEvent.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQChildEvent.cc
@@ -187,8 +187,8 @@ static void _call_ctor_QChildEvent_Adaptor_2759 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QChildEvent_Adaptor *> (new QChildEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQCoreApplication.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQCoreApplication.cc
@@ -71,8 +71,8 @@ static void _call_f_filterEvent_2477 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  void *arg1 = args.read<void * > (heap);
-  long int *arg2 = args.read<long int * > (heap);
+  void *arg1 = gsi::arg_reader<void * >() (args, heap);
+  long int *arg2 = gsi::arg_reader<long int * >() (args, heap);
   ret.write<bool > ((bool)((QCoreApplication *)cls)->filterEvent (arg1, arg2));
 }
 
@@ -93,8 +93,8 @@ static void _call_f_notify_2411 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  QEvent *arg2 = args.read<QEvent * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  QEvent *arg2 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QCoreApplication *)cls)->notify (arg1, arg2));
 }
 
@@ -113,7 +113,7 @@ static void _call_f_addLibraryPath_2025 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::addLibraryPath (arg1);
 }
@@ -253,7 +253,7 @@ static void _call_f_exit_767 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi:
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::exit (arg1);
 }
@@ -304,7 +304,7 @@ static void _call_f_installTranslator_1769 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTranslator *arg1 = args.read<QTranslator * > (heap);
+  QTranslator *arg1 = gsi::arg_reader<QTranslator * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::installTranslator (arg1);
 }
@@ -386,8 +386,8 @@ static void _call_f_postEvent_2411 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  QEvent *arg2 = args.read<QEvent * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  QEvent *arg2 = gsi::arg_reader<QEvent * >() (args, heap);
   qt_gsi::qt_keep (arg2);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::postEvent (arg1, arg2);
@@ -412,10 +412,10 @@ static void _call_f_postEvent_3070 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  QEvent *arg2 = args.read<QEvent * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  QEvent *arg2 = gsi::arg_reader<QEvent * >() (args, heap);
   qt_gsi::qt_keep (arg2);
-  int arg3 = args.read<int > (heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::postEvent (arg1, arg2, arg3);
 }
@@ -435,7 +435,7 @@ static void _call_f_processEvents_3995 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QEventLoop::ProcessEventsFlag> arg1 = args ? args.read<QFlags<QEventLoop::ProcessEventsFlag> > (heap) : (QFlags<QEventLoop::ProcessEventsFlag>)(QEventLoop::AllEvents);
+  QFlags<QEventLoop::ProcessEventsFlag> arg1 = args ? gsi::arg_reader<QFlags<QEventLoop::ProcessEventsFlag> >() (args, heap) : gsi::arg_maker<QFlags<QEventLoop::ProcessEventsFlag> >() (QEventLoop::AllEvents, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::processEvents (arg1);
 }
@@ -457,8 +457,8 @@ static void _call_f_processEvents_4654 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QEventLoop::ProcessEventsFlag> arg1 = args.read<QFlags<QEventLoop::ProcessEventsFlag> > (heap);
-  int arg2 = args.read<int > (heap);
+  QFlags<QEventLoop::ProcessEventsFlag> arg1 = gsi::arg_reader<QFlags<QEventLoop::ProcessEventsFlag> >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::processEvents (arg1, arg2);
 }
@@ -494,7 +494,7 @@ static void _call_f_removeLibraryPath_2025 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::removeLibraryPath (arg1);
 }
@@ -514,7 +514,7 @@ static void _call_f_removePostedEvents_1302 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::removePostedEvents (arg1);
 }
@@ -536,8 +536,8 @@ static void _call_f_removePostedEvents_1961 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  int arg2 = args.read<int > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::removePostedEvents (arg1, arg2);
 }
@@ -557,7 +557,7 @@ static void _call_f_removeTranslator_1769 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTranslator *arg1 = args.read<QTranslator * > (heap);
+  QTranslator *arg1 = gsi::arg_reader<QTranslator * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::removeTranslator (arg1);
 }
@@ -579,8 +579,8 @@ static void _call_f_sendEvent_2411 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  QEvent *arg2 = args.read<QEvent * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  QEvent *arg2 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)QCoreApplication::sendEvent (arg1, arg2));
 }
 
@@ -601,8 +601,8 @@ static void _call_f_sendPostedEvents_1961 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  int arg2 = args.read<int > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::sendPostedEvents (arg1, arg2);
 }
@@ -638,7 +638,7 @@ static void _call_f_setApplicationName_2025 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::setApplicationName (arg1);
 }
@@ -658,7 +658,7 @@ static void _call_f_setApplicationVersion_2025 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::setApplicationVersion (arg1);
 }
@@ -680,8 +680,8 @@ static void _call_f_setAttribute_3593 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ApplicationAttribute>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ApplicationAttribute>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<Qt::ApplicationAttribute>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ApplicationAttribute>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::setAttribute (qt_gsi::QtToCppAdaptor<Qt::ApplicationAttribute>(arg1).cref(), arg2);
 }
@@ -701,7 +701,7 @@ static void _call_f_setLibraryPaths_2437 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::setLibraryPaths (arg1);
 }
@@ -721,7 +721,7 @@ static void _call_f_setOrganizationDomain_2025 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::setOrganizationDomain (arg1);
 }
@@ -741,7 +741,7 @@ static void _call_f_setOrganizationName_2025 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCoreApplication::setOrganizationName (arg1);
 }
@@ -776,7 +776,7 @@ static void _call_f_testAttribute_2837 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ApplicationAttribute>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ApplicationAttribute>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ApplicationAttribute>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ApplicationAttribute>::target_type & >() (args, heap);
   ret.write<bool > ((bool)QCoreApplication::testAttribute (qt_gsi::QtToCppAdaptor<Qt::ApplicationAttribute>(arg1).cref()));
 }
 
@@ -797,8 +797,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCoreApplication::tr (arg1, arg2));
 }
 
@@ -821,9 +821,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCoreApplication::tr (arg1, arg2, arg3));
 }
 
@@ -844,8 +844,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCoreApplication::trUtf8 (arg1, arg2));
 }
 
@@ -868,9 +868,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCoreApplication::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -895,10 +895,10 @@ static void _call_f_translate_7842 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  const char *arg3 = args ? args.read<const char * > (heap) : (const char *)(0);
-  const qt_gsi::Converter<QCoreApplication::Encoding>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QCoreApplication::Encoding>::target_type & > (heap) : (const qt_gsi::Converter<QCoreApplication::Encoding>::target_type &)(qt_gsi::CppToQtReadAdaptor<QCoreApplication::Encoding>(heap, QCoreApplication::CodecForTr));
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg3 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  const qt_gsi::Converter<QCoreApplication::Encoding>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QCoreApplication::Encoding>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QCoreApplication::Encoding>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QCoreApplication::Encoding>(heap, QCoreApplication::CodecForTr), heap);
   ret.write<QString > ((QString)QCoreApplication::translate (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<QCoreApplication::Encoding>(arg4).cref()));
 }
 
@@ -925,11 +925,11 @@ static void _call_f_translate_8501 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  const char *arg3 = args.read<const char * > (heap);
-  const qt_gsi::Converter<QCoreApplication::Encoding>::target_type & arg4 = args.read<const qt_gsi::Converter<QCoreApplication::Encoding>::target_type & > (heap);
-  int arg5 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
+  const qt_gsi::Converter<QCoreApplication::Encoding>::target_type & arg4 = gsi::arg_reader<const qt_gsi::Converter<QCoreApplication::Encoding>::target_type & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCoreApplication::translate (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<QCoreApplication::Encoding>(arg4).cref(), arg5));
 }
 
@@ -1248,7 +1248,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QCoreApplication_Adaptor *)cls)->emitter_QCoreApplication_destroyed_1302 (arg1);
 }
 
@@ -1365,7 +1365,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QCoreApplication_Adaptor *)cls)->fp_QCoreApplication_receivers_c1731 (arg1));
 }
 
@@ -1421,7 +1421,7 @@ static void _call_emitter_unixSignal_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QCoreApplication_Adaptor *)cls)->emitter_QCoreApplication_unixSignal_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQCryptographicHash.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQCryptographicHash.cc
@@ -50,7 +50,7 @@ static void _call_ctor_QCryptographicHash_3331 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & arg1 = args.read<const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & > (heap);
+  const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & >() (args, heap);
   ret.write<QCryptographicHash *> (new QCryptographicHash (qt_gsi::QtToCppAdaptor<QCryptographicHash::Algorithm>(arg1).cref()));
 }
 
@@ -71,8 +71,8 @@ static void _call_f_addData_2390 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  int arg2 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCryptographicHash *)cls)->addData (arg1, arg2);
 }
@@ -92,7 +92,7 @@ static void _call_f_addData_2309 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCryptographicHash *)cls)->addData (arg1);
 }
@@ -145,8 +145,8 @@ static void _call_f_hash_5532 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & arg2 = args.read<const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)QCryptographicHash::hash (arg1, qt_gsi::QtToCppAdaptor<QCryptographicHash::Algorithm>(arg2).cref()));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQDataStream.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQDataStream.cc
@@ -335,7 +335,7 @@ static void _call_f_setByteOrder_2543 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDataStream::ByteOrder>::target_type & arg1 = args.read<const qt_gsi::Converter<QDataStream::ByteOrder>::target_type & > (heap);
+  const qt_gsi::Converter<QDataStream::ByteOrder>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDataStream::ByteOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataStream *)cls)->setByteOrder (qt_gsi::QtToCppAdaptor<QDataStream::ByteOrder>(arg1).cref());
 }
@@ -355,7 +355,7 @@ static void _call_f_setDevice_1447 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataStream *)cls)->setDevice (arg1);
 }
@@ -375,7 +375,7 @@ static void _call_f_setFloatingPointPrecision_3913 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDataStream::FloatingPointPrecision>::target_type & arg1 = args.read<const qt_gsi::Converter<QDataStream::FloatingPointPrecision>::target_type & > (heap);
+  const qt_gsi::Converter<QDataStream::FloatingPointPrecision>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDataStream::FloatingPointPrecision>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataStream *)cls)->setFloatingPointPrecision (qt_gsi::QtToCppAdaptor<QDataStream::FloatingPointPrecision>(arg1).cref());
 }
@@ -395,7 +395,7 @@ static void _call_f_setStatus_2275 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDataStream::Status>::target_type & arg1 = args.read<const qt_gsi::Converter<QDataStream::Status>::target_type & > (heap);
+  const qt_gsi::Converter<QDataStream::Status>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDataStream::Status>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataStream *)cls)->setStatus (qt_gsi::QtToCppAdaptor<QDataStream::Status>(arg1).cref());
 }
@@ -415,7 +415,7 @@ static void _call_f_setVersion_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataStream *)cls)->setVersion (arg1);
 }
@@ -435,7 +435,7 @@ static void _call_f_skipRawData_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QDataStream *)cls)->skipRawData (arg1));
 }
 
@@ -502,8 +502,8 @@ static void _call_f_writeBytes_3395 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  unsigned int arg2 = args.read<unsigned int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  unsigned int arg2 = gsi::arg_reader<unsigned int >() (args, heap);
   ret.write<QDataStream & > ((QDataStream &)((QDataStream *)cls)->writeBytes (arg1, arg2));
 }
 
@@ -524,8 +524,8 @@ static void _call_f_writeRawData_2390 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  int arg2 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QDataStream *)cls)->writeRawData (arg1, arg2));
 }
 
@@ -658,7 +658,7 @@ static void _call_ctor_QDataStream_Adaptor_1447 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   ret.write<QDataStream_Adaptor *> (new QDataStream_Adaptor (arg1));
 }
 
@@ -678,8 +678,8 @@ static void _call_ctor_QDataStream_Adaptor_4752 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QByteArray *arg1 = args.read<QByteArray * > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg2 = args.read<QFlags<QIODevice::OpenModeFlag> > (heap);
+  QByteArray *arg1 = gsi::arg_reader<QByteArray * >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg2 = gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap);
   ret.write<QDataStream_Adaptor *> (new QDataStream_Adaptor (arg1, arg2));
 }
 
@@ -697,7 +697,7 @@ static void _call_ctor_QDataStream_Adaptor_2309 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QDataStream_Adaptor *> (new QDataStream_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQDate.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQDate.cc
@@ -69,9 +69,9 @@ static void _call_ctor_QDate_2085 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDate *> (new QDate (arg1, arg2, arg3));
 }
 
@@ -90,7 +90,7 @@ static void _call_f_addDays_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDate > ((QDate)((QDate *)cls)->addDays (arg1));
 }
 
@@ -109,7 +109,7 @@ static void _call_f_addMonths_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDate > ((QDate)((QDate *)cls)->addMonths (arg1));
 }
 
@@ -128,7 +128,7 @@ static void _call_f_addYears_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDate > ((QDate)((QDate *)cls)->addYears (arg1));
 }
 
@@ -222,7 +222,7 @@ static void _call_f_daysTo_c1776 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ret.write<int > ((int)((QDate *)cls)->daysTo (arg1));
 }
 
@@ -245,9 +245,9 @@ static void _call_f_getDate_2643 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDate *)cls)->getDate (arg1, arg2, arg3);
 }
@@ -312,7 +312,7 @@ static void _call_f_operator_excl__eq__c1776 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ret.write<bool > ((bool)((QDate *)cls)->operator!= (arg1));
 }
 
@@ -331,7 +331,7 @@ static void _call_f_operator_lt__c1776 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ret.write<bool > ((bool)((QDate *)cls)->operator< (arg1));
 }
 
@@ -350,7 +350,7 @@ static void _call_f_operator_lt__eq__c1776 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ret.write<bool > ((bool)((QDate *)cls)->operator<= (arg1));
 }
 
@@ -369,7 +369,7 @@ static void _call_f_operator_eq__eq__c1776 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ret.write<bool > ((bool)((QDate *)cls)->operator== (arg1));
 }
 
@@ -388,7 +388,7 @@ static void _call_f_operator_gt__c1776 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ret.write<bool > ((bool)((QDate *)cls)->operator> (arg1));
 }
 
@@ -407,7 +407,7 @@ static void _call_f_operator_gt__eq__c1776 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ret.write<bool > ((bool)((QDate *)cls)->operator>= (arg1));
 }
 
@@ -430,9 +430,9 @@ static void _call_f_setDate_2085 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QDate *)cls)->setDate (arg1, arg2, arg3));
 }
 
@@ -455,9 +455,9 @@ static void _call_f_setYMD_2085 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QDate *)cls)->setYMD (arg1, arg2, arg3));
 }
 
@@ -491,7 +491,7 @@ static void _call_f_toString_c1748 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::DateFormat>::target_type & > (heap) : (const qt_gsi::Converter<Qt::DateFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate));
+  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate), heap);
   ret.write<QString > ((QString)((QDate *)cls)->toString (qt_gsi::QtToCppAdaptor<Qt::DateFormat>(arg1).cref()));
 }
 
@@ -510,7 +510,7 @@ static void _call_f_toString_c2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QDate *)cls)->toString (arg1));
 }
 
@@ -529,7 +529,7 @@ static void _call_f_weekNumber_c953 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args ? args.read<int * > (heap) : (int *)(0);
+  int *arg1 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<int > ((int)((QDate *)cls)->weekNumber (arg1));
 }
 
@@ -578,7 +578,7 @@ static void _call_f_fromJulianDay_767 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDate > ((QDate)QDate::fromJulianDay (arg1));
 }
 
@@ -599,8 +599,8 @@ static void _call_f_fromString_3665 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::DateFormat>::target_type & > (heap) : (const qt_gsi::Converter<Qt::DateFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate), heap);
   ret.write<QDate > ((QDate)QDate::fromString (arg1, qt_gsi::QtToCppAdaptor<Qt::DateFormat>(arg2).cref()));
 }
 
@@ -621,8 +621,8 @@ static void _call_f_fromString_3942 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDate > ((QDate)QDate::fromString (arg1, arg2));
 }
 
@@ -645,9 +645,9 @@ static void _call_f_gregorianToJulian_2085 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<unsigned int > ((unsigned int)QDate::gregorianToJulian (arg1, arg2, arg3));
 }
 
@@ -666,7 +666,7 @@ static void _call_f_isLeapYear_767 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)QDate::isLeapYear (arg1));
 }
 
@@ -689,9 +689,9 @@ static void _call_f_isValid_2085 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)QDate::isValid (arg1, arg2, arg3));
 }
 
@@ -716,10 +716,10 @@ static void _call_f_julianToGregorian_4295 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
-  int &arg2 = args.read<int & > (heap);
-  int &arg3 = args.read<int & > (heap);
-  int &arg4 = args.read<int & > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
+  int &arg2 = gsi::arg_reader<int & >() (args, heap);
+  int &arg3 = gsi::arg_reader<int & >() (args, heap);
+  int &arg4 = gsi::arg_reader<int & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QDate::julianToGregorian (arg1, arg2, arg3, arg4);
 }
@@ -739,7 +739,7 @@ static void _call_f_longDayName_767 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDate::longDayName (arg1));
 }
 
@@ -760,8 +760,8 @@ static void _call_f_longDayName_2995 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QDate::MonthNameType>::target_type & arg2 = args.read<const qt_gsi::Converter<QDate::MonthNameType>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QDate::MonthNameType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QDate::MonthNameType>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QDate::longDayName (arg1, qt_gsi::QtToCppAdaptor<QDate::MonthNameType>(arg2).cref()));
 }
 
@@ -780,7 +780,7 @@ static void _call_f_longMonthName_767 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDate::longMonthName (arg1));
 }
 
@@ -801,8 +801,8 @@ static void _call_f_longMonthName_2995 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QDate::MonthNameType>::target_type & arg2 = args.read<const qt_gsi::Converter<QDate::MonthNameType>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QDate::MonthNameType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QDate::MonthNameType>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QDate::longMonthName (arg1, qt_gsi::QtToCppAdaptor<QDate::MonthNameType>(arg2).cref()));
 }
 
@@ -821,7 +821,7 @@ static void _call_f_shortDayName_767 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDate::shortDayName (arg1));
 }
 
@@ -842,8 +842,8 @@ static void _call_f_shortDayName_2995 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QDate::MonthNameType>::target_type & arg2 = args.read<const qt_gsi::Converter<QDate::MonthNameType>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QDate::MonthNameType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QDate::MonthNameType>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QDate::shortDayName (arg1, qt_gsi::QtToCppAdaptor<QDate::MonthNameType>(arg2).cref()));
 }
 
@@ -862,7 +862,7 @@ static void _call_f_shortMonthName_767 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDate::shortMonthName (arg1));
 }
 
@@ -883,8 +883,8 @@ static void _call_f_shortMonthName_2995 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QDate::MonthNameType>::target_type & arg2 = args.read<const qt_gsi::Converter<QDate::MonthNameType>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QDate::MonthNameType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QDate::MonthNameType>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QDate::shortMonthName (arg1, qt_gsi::QtToCppAdaptor<QDate::MonthNameType>(arg2).cref()));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQDateTime.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQDateTime.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QDateTime_1776 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ret.write<QDateTime *> (new QDateTime (arg1));
 }
 
@@ -90,9 +90,9 @@ static void _call_ctor_QDateTime_4896 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
-  const QTime &arg2 = args.read<const QTime & > (heap);
-  const qt_gsi::Converter<Qt::TimeSpec>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<Qt::TimeSpec>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TimeSpec>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TimeSpec>(heap, Qt::LocalTime));
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
+  const QTime &arg2 = gsi::arg_reader<const QTime & >() (args, heap);
+  const qt_gsi::Converter<Qt::TimeSpec>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TimeSpec>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TimeSpec>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TimeSpec>(heap, Qt::LocalTime), heap);
   ret.write<QDateTime *> (new QDateTime (arg1, arg2, qt_gsi::QtToCppAdaptor<Qt::TimeSpec>(arg3).cref()));
 }
 
@@ -111,7 +111,7 @@ static void _call_ctor_QDateTime_2175 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<QDateTime *> (new QDateTime (arg1));
 }
 
@@ -130,7 +130,7 @@ static void _call_f_addDays_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDateTime > ((QDateTime)((QDateTime *)cls)->addDays (arg1));
 }
 
@@ -149,7 +149,7 @@ static void _call_f_addMSecs_c986 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<QDateTime > ((QDateTime)((QDateTime *)cls)->addMSecs (arg1));
 }
 
@@ -168,7 +168,7 @@ static void _call_f_addMonths_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDateTime > ((QDateTime)((QDateTime *)cls)->addMonths (arg1));
 }
 
@@ -187,7 +187,7 @@ static void _call_f_addSecs_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDateTime > ((QDateTime)((QDateTime *)cls)->addSecs (arg1));
 }
 
@@ -206,7 +206,7 @@ static void _call_f_addYears_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDateTime > ((QDateTime)((QDateTime *)cls)->addYears (arg1));
 }
 
@@ -240,7 +240,7 @@ static void _call_f_daysTo_c2175 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<int > ((int)((QDateTime *)cls)->daysTo (arg1));
 }
 
@@ -289,7 +289,7 @@ static void _call_f_operator_excl__eq__c2175 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<bool > ((bool)((QDateTime *)cls)->operator!= (arg1));
 }
 
@@ -308,7 +308,7 @@ static void _call_f_operator_lt__c2175 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<bool > ((bool)((QDateTime *)cls)->operator< (arg1));
 }
 
@@ -327,7 +327,7 @@ static void _call_f_operator_lt__eq__c2175 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<bool > ((bool)((QDateTime *)cls)->operator<= (arg1));
 }
 
@@ -346,7 +346,7 @@ static void _call_f_operator_eq__2175 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<QDateTime & > ((QDateTime &)((QDateTime *)cls)->operator= (arg1));
 }
 
@@ -365,7 +365,7 @@ static void _call_f_operator_eq__eq__c2175 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<bool > ((bool)((QDateTime *)cls)->operator== (arg1));
 }
 
@@ -384,7 +384,7 @@ static void _call_f_operator_gt__c2175 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<bool > ((bool)((QDateTime *)cls)->operator> (arg1));
 }
 
@@ -403,7 +403,7 @@ static void _call_f_operator_gt__eq__c2175 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<bool > ((bool)((QDateTime *)cls)->operator>= (arg1));
 }
 
@@ -422,7 +422,7 @@ static void _call_f_secsTo_c2175 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ret.write<int > ((int)((QDateTime *)cls)->secsTo (arg1));
 }
 
@@ -441,7 +441,7 @@ static void _call_f_setDate_1776 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTime *)cls)->setDate (arg1);
 }
@@ -461,7 +461,7 @@ static void _call_f_setTime_1793 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTime *)cls)->setTime (arg1);
 }
@@ -481,7 +481,7 @@ static void _call_f_setTimeSpec_1543 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TimeSpec>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TimeSpec>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TimeSpec>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TimeSpec>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTime *)cls)->setTimeSpec (qt_gsi::QtToCppAdaptor<Qt::TimeSpec>(arg1).cref());
 }
@@ -501,7 +501,7 @@ static void _call_f_setTime_t_1772 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTime *)cls)->setTime_t (arg1);
 }
@@ -521,7 +521,7 @@ static void _call_f_setUtcOffset_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTime *)cls)->setUtcOffset (arg1);
 }
@@ -586,7 +586,7 @@ static void _call_f_toString_c1748 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::DateFormat>::target_type & > (heap) : (const qt_gsi::Converter<Qt::DateFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate));
+  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate), heap);
   ret.write<QString > ((QString)((QDateTime *)cls)->toString (qt_gsi::QtToCppAdaptor<Qt::DateFormat>(arg1).cref()));
 }
 
@@ -605,7 +605,7 @@ static void _call_f_toString_c2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QDateTime *)cls)->toString (arg1));
 }
 
@@ -624,7 +624,7 @@ static void _call_f_toTimeSpec_c1543 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TimeSpec>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TimeSpec>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TimeSpec>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TimeSpec>::target_type & >() (args, heap);
   ret.write<QDateTime > ((QDateTime)((QDateTime *)cls)->toTimeSpec (qt_gsi::QtToCppAdaptor<Qt::TimeSpec>(arg1).cref()));
 }
 
@@ -705,8 +705,8 @@ static void _call_f_fromString_3665 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::DateFormat>::target_type & > (heap) : (const qt_gsi::Converter<Qt::DateFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate), heap);
   ret.write<QDateTime > ((QDateTime)QDateTime::fromString (arg1, qt_gsi::QtToCppAdaptor<Qt::DateFormat>(arg2).cref()));
 }
 
@@ -727,8 +727,8 @@ static void _call_f_fromString_3942 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDateTime > ((QDateTime)QDateTime::fromString (arg1, arg2));
 }
 
@@ -747,7 +747,7 @@ static void _call_f_fromTime_t_1772 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   ret.write<QDateTime > ((QDateTime)QDateTime::fromTime_t (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQDir.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQDir.cc
@@ -51,7 +51,7 @@ static void _call_ctor_QDir_1681 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDir &arg1 = args.read<const QDir & > (heap);
+  const QDir &arg1 = gsi::arg_reader<const QDir & >() (args, heap);
   ret.write<QDir *> (new QDir (arg1));
 }
 
@@ -70,7 +70,7 @@ static void _call_ctor_QDir_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QDir *> (new QDir (arg1));
 }
 
@@ -95,10 +95,10 @@ static void _call_ctor_QDir_8374 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QFlags<QDir::SortFlag> arg3 = args ? args.read<QFlags<QDir::SortFlag> > (heap) : (QFlags<QDir::SortFlag>)(QDir::SortFlags(QDir::Name | QDir::IgnoreCase));
-  QFlags<QDir::Filter> arg4 = args ? args.read<QFlags<QDir::Filter> > (heap) : (QFlags<QDir::Filter>)(QDir::AllEntries);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QDir::SortFlag> arg3 = args ? gsi::arg_reader<QFlags<QDir::SortFlag> >() (args, heap) : gsi::arg_maker<QFlags<QDir::SortFlag> >() (QDir::SortFlags(QDir::Name | QDir::IgnoreCase), heap);
+  QFlags<QDir::Filter> arg4 = args ? gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap) : gsi::arg_maker<QFlags<QDir::Filter> >() (QDir::AllEntries, heap);
   ret.write<QDir *> (new QDir (arg1, arg2, arg3, arg4));
 }
 
@@ -117,7 +117,7 @@ static void _call_f_absoluteFilePath_c2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QDir *)cls)->absoluteFilePath (arg1));
 }
 
@@ -166,7 +166,7 @@ static void _call_f_cd_2025 (const qt_gsi::GenericMethod * /*decl*/, void *cls, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->cd (arg1));
 }
 
@@ -232,8 +232,8 @@ static void _call_f_entryInfoList_c4540 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDir::Filter> arg1 = args ? args.read<QFlags<QDir::Filter> > (heap) : (QFlags<QDir::Filter>)(QDir::NoFilter);
-  QFlags<QDir::SortFlag> arg2 = args ? args.read<QFlags<QDir::SortFlag> > (heap) : (QFlags<QDir::SortFlag>)(QDir::NoSort);
+  QFlags<QDir::Filter> arg1 = args ? gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap) : gsi::arg_maker<QFlags<QDir::Filter> >() (QDir::NoFilter, heap);
+  QFlags<QDir::SortFlag> arg2 = args ? gsi::arg_reader<QFlags<QDir::SortFlag> >() (args, heap) : gsi::arg_maker<QFlags<QDir::SortFlag> >() (QDir::NoSort, heap);
   ret.write<QList<QFileInfo> > ((QList<QFileInfo>)((QDir *)cls)->entryInfoList (arg1, arg2));
 }
 
@@ -256,9 +256,9 @@ static void _call_f_entryInfoList_c6869 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
-  QFlags<QDir::Filter> arg2 = args ? args.read<QFlags<QDir::Filter> > (heap) : (QFlags<QDir::Filter>)(QDir::NoFilter);
-  QFlags<QDir::SortFlag> arg3 = args ? args.read<QFlags<QDir::SortFlag> > (heap) : (QFlags<QDir::SortFlag>)(QDir::NoSort);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
+  QFlags<QDir::Filter> arg2 = args ? gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap) : gsi::arg_maker<QFlags<QDir::Filter> >() (QDir::NoFilter, heap);
+  QFlags<QDir::SortFlag> arg3 = args ? gsi::arg_reader<QFlags<QDir::SortFlag> >() (args, heap) : gsi::arg_maker<QFlags<QDir::SortFlag> >() (QDir::NoSort, heap);
   ret.write<QList<QFileInfo> > ((QList<QFileInfo>)((QDir *)cls)->entryInfoList (arg1, arg2, arg3));
 }
 
@@ -279,8 +279,8 @@ static void _call_f_entryList_c4540 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDir::Filter> arg1 = args ? args.read<QFlags<QDir::Filter> > (heap) : (QFlags<QDir::Filter>)(QDir::NoFilter);
-  QFlags<QDir::SortFlag> arg2 = args ? args.read<QFlags<QDir::SortFlag> > (heap) : (QFlags<QDir::SortFlag>)(QDir::NoSort);
+  QFlags<QDir::Filter> arg1 = args ? gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap) : gsi::arg_maker<QFlags<QDir::Filter> >() (QDir::NoFilter, heap);
+  QFlags<QDir::SortFlag> arg2 = args ? gsi::arg_reader<QFlags<QDir::SortFlag> >() (args, heap) : gsi::arg_maker<QFlags<QDir::SortFlag> >() (QDir::NoSort, heap);
   ret.write<QStringList > ((QStringList)((QDir *)cls)->entryList (arg1, arg2));
 }
 
@@ -303,9 +303,9 @@ static void _call_f_entryList_c6869 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
-  QFlags<QDir::Filter> arg2 = args ? args.read<QFlags<QDir::Filter> > (heap) : (QFlags<QDir::Filter>)(QDir::NoFilter);
-  QFlags<QDir::SortFlag> arg3 = args ? args.read<QFlags<QDir::SortFlag> > (heap) : (QFlags<QDir::SortFlag>)(QDir::NoSort);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
+  QFlags<QDir::Filter> arg2 = args ? gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap) : gsi::arg_maker<QFlags<QDir::Filter> >() (QDir::NoFilter, heap);
+  QFlags<QDir::SortFlag> arg3 = args ? gsi::arg_reader<QFlags<QDir::SortFlag> >() (args, heap) : gsi::arg_maker<QFlags<QDir::SortFlag> >() (QDir::NoSort, heap);
   ret.write<QStringList > ((QStringList)((QDir *)cls)->entryList (arg1, arg2, arg3));
 }
 
@@ -339,7 +339,7 @@ static void _call_f_exists_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->exists (arg1));
 }
 
@@ -358,7 +358,7 @@ static void _call_f_filePath_c2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QDir *)cls)->filePath (arg1));
 }
 
@@ -467,7 +467,7 @@ static void _call_f_mkdir_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->mkdir (arg1));
 }
 
@@ -486,7 +486,7 @@ static void _call_f_mkpath_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->mkpath (arg1));
 }
 
@@ -520,7 +520,7 @@ static void _call_f_operator_excl__eq__c1681 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDir &arg1 = args.read<const QDir & > (heap);
+  const QDir &arg1 = gsi::arg_reader<const QDir & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->operator!= (arg1));
 }
 
@@ -539,7 +539,7 @@ static void _call_f_operator_eq__1681 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDir &arg1 = args.read<const QDir & > (heap);
+  const QDir &arg1 = gsi::arg_reader<const QDir & >() (args, heap);
   ret.write<QDir & > ((QDir &)((QDir *)cls)->operator= (arg1));
 }
 
@@ -558,7 +558,7 @@ static void _call_f_operator_eq__2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDir & > ((QDir &)((QDir *)cls)->operator= (arg1));
 }
 
@@ -577,7 +577,7 @@ static void _call_f_operator_eq__eq__c1681 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDir &arg1 = args.read<const QDir & > (heap);
+  const QDir &arg1 = gsi::arg_reader<const QDir & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->operator== (arg1));
 }
 
@@ -596,7 +596,7 @@ static void _call_f_operator_index__c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QDir *)cls)->operator[] (arg1));
 }
 
@@ -646,7 +646,7 @@ static void _call_f_relativeFilePath_c2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QDir *)cls)->relativeFilePath (arg1));
 }
 
@@ -665,7 +665,7 @@ static void _call_f_remove_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->remove (arg1));
 }
 
@@ -686,8 +686,8 @@ static void _call_f_rename_3942 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->rename (arg1, arg2));
 }
 
@@ -706,7 +706,7 @@ static void _call_f_rmdir_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->rmdir (arg1));
 }
 
@@ -725,7 +725,7 @@ static void _call_f_rmpath_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDir *)cls)->rmpath (arg1));
 }
 
@@ -744,7 +744,7 @@ static void _call_f_setFilter_2230 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDir::Filter> arg1 = args.read<QFlags<QDir::Filter> > (heap);
+  QFlags<QDir::Filter> arg1 = gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDir *)cls)->setFilter (arg1);
 }
@@ -764,7 +764,7 @@ static void _call_f_setNameFilters_2437 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDir *)cls)->setNameFilters (arg1);
 }
@@ -784,7 +784,7 @@ static void _call_f_setPath_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDir *)cls)->setPath (arg1);
 }
@@ -804,7 +804,7 @@ static void _call_f_setSorting_2418 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDir::SortFlag> arg1 = args.read<QFlags<QDir::SortFlag> > (heap);
+  QFlags<QDir::SortFlag> arg1 = gsi::arg_reader<QFlags<QDir::SortFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDir *)cls)->setSorting (arg1);
 }
@@ -839,7 +839,7 @@ static void _call_f_addResourceSearchPath_2025 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QDir::addResourceSearchPath (arg1);
 }
@@ -861,8 +861,8 @@ static void _call_f_addSearchPath_3942 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QDir::addSearchPath (arg1, arg2);
 }
@@ -882,7 +882,7 @@ static void _call_f_cleanPath_2025 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QDir::cleanPath (arg1));
 }
 
@@ -901,7 +901,7 @@ static void _call_f_convertSeparators_2025 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QDir::convertSeparators (arg1));
 }
 
@@ -965,7 +965,7 @@ static void _call_f_fromNativeSeparators_2025 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QDir::fromNativeSeparators (arg1));
 }
 
@@ -1014,7 +1014,7 @@ static void _call_f_isAbsolutePath_2025 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QDir::isAbsolutePath (arg1));
 }
 
@@ -1033,7 +1033,7 @@ static void _call_f_isRelativePath_2025 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QDir::isRelativePath (arg1));
 }
 
@@ -1054,8 +1054,8 @@ static void _call_f_match_4354 (const qt_gsi::GenericStaticMethod * /*decl*/, gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QDir::match (arg1, arg2));
 }
 
@@ -1076,8 +1076,8 @@ static void _call_f_match_3942 (const qt_gsi::GenericStaticMethod * /*decl*/, gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QDir::match (arg1, arg2));
 }
 
@@ -1096,7 +1096,7 @@ static void _call_f_nameFiltersFromString_2025 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStringList > ((QStringList)QDir::nameFiltersFromString (arg1));
 }
 
@@ -1145,7 +1145,7 @@ static void _call_f_searchPaths_2025 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStringList > ((QStringList)QDir::searchPaths (arg1));
 }
 
@@ -1179,7 +1179,7 @@ static void _call_f_setCurrent_2025 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QDir::setCurrent (arg1));
 }
 
@@ -1200,8 +1200,8 @@ static void _call_f_setSearchPaths_4354 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QDir::setSearchPaths (arg1, arg2);
 }
@@ -1251,7 +1251,7 @@ static void _call_f_toNativeSeparators_2025 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QDir::toNativeSeparators (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQDynamicPropertyChangeEvent.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQDynamicPropertyChangeEvent.cc
@@ -101,7 +101,7 @@ static void _call_ctor_QDynamicPropertyChangeEvent_Adaptor_2309 (const qt_gsi::G
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QDynamicPropertyChangeEvent_Adaptor *> (new QDynamicPropertyChangeEvent_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQEasingCurve.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQEasingCurve.cc
@@ -50,7 +50,7 @@ static void _call_ctor_QEasingCurve_2167 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEasingCurve::Type>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QEasingCurve::Type>::target_type & > (heap) : (const qt_gsi::Converter<QEasingCurve::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QEasingCurve::Type>(heap, QEasingCurve::Linear));
+  const qt_gsi::Converter<QEasingCurve::Type>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QEasingCurve::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QEasingCurve::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QEasingCurve::Type>(heap, QEasingCurve::Linear), heap);
   ret.write<QEasingCurve *> (new QEasingCurve (qt_gsi::QtToCppAdaptor<QEasingCurve::Type>(arg1).cref()));
 }
 
@@ -69,7 +69,7 @@ static void _call_ctor_QEasingCurve_2510 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QEasingCurve &arg1 = args.read<const QEasingCurve & > (heap);
+  const QEasingCurve &arg1 = gsi::arg_reader<const QEasingCurve & >() (args, heap);
   ret.write<QEasingCurve *> (new QEasingCurve (arg1));
 }
 
@@ -103,7 +103,7 @@ static void _call_f_operator_excl__eq__c2510 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QEasingCurve &arg1 = args.read<const QEasingCurve & > (heap);
+  const QEasingCurve &arg1 = gsi::arg_reader<const QEasingCurve & >() (args, heap);
   ret.write<bool > ((bool)((QEasingCurve *)cls)->operator!= (arg1));
 }
 
@@ -122,7 +122,7 @@ static void _call_f_operator_eq__2510 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QEasingCurve &arg1 = args.read<const QEasingCurve & > (heap);
+  const QEasingCurve &arg1 = gsi::arg_reader<const QEasingCurve & >() (args, heap);
   ret.write<QEasingCurve & > ((QEasingCurve &)((QEasingCurve *)cls)->operator= (arg1));
 }
 
@@ -141,7 +141,7 @@ static void _call_f_operator_eq__eq__c2510 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QEasingCurve &arg1 = args.read<const QEasingCurve & > (heap);
+  const QEasingCurve &arg1 = gsi::arg_reader<const QEasingCurve & >() (args, heap);
   ret.write<bool > ((bool)((QEasingCurve *)cls)->operator== (arg1));
 }
 
@@ -190,7 +190,7 @@ static void _call_f_setAmplitude_1071 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QEasingCurve *)cls)->setAmplitude (arg1);
 }
@@ -210,7 +210,7 @@ static void _call_f_setOvershoot_1071 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QEasingCurve *)cls)->setOvershoot (arg1);
 }
@@ -230,7 +230,7 @@ static void _call_f_setPeriod_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QEasingCurve *)cls)->setPeriod (arg1);
 }
@@ -250,7 +250,7 @@ static void _call_f_setType_2167 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEasingCurve::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEasingCurve::Type>::target_type & > (heap);
+  const qt_gsi::Converter<QEasingCurve::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEasingCurve::Type>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QEasingCurve *)cls)->setType (qt_gsi::QtToCppAdaptor<QEasingCurve::Type>(arg1).cref());
 }
@@ -285,7 +285,7 @@ static void _call_f_valueForProgress_c1071 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QEasingCurve *)cls)->valueForProgress (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQEvent.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQEvent.cc
@@ -97,7 +97,7 @@ static void _call_f_setAccepted_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QEvent *)cls)->setAccepted (arg1);
 }
@@ -147,7 +147,7 @@ static void _call_f_registerEventType_767 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(-1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<int > ((int)QEvent::registerEventType (arg1));
 }
 
@@ -206,7 +206,7 @@ static void _call_ctor_QEvent_Adaptor_1565 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
   ret.write<QEvent_Adaptor *> (new QEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQEventLoop.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQEventLoop.cc
@@ -68,7 +68,7 @@ static void _call_f_exec_3995 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QEventLoop::ProcessEventsFlag> arg1 = args ? args.read<QFlags<QEventLoop::ProcessEventsFlag> > (heap) : (QFlags<QEventLoop::ProcessEventsFlag>)(QEventLoop::AllEvents);
+  QFlags<QEventLoop::ProcessEventsFlag> arg1 = args ? gsi::arg_reader<QFlags<QEventLoop::ProcessEventsFlag> >() (args, heap) : gsi::arg_maker<QFlags<QEventLoop::ProcessEventsFlag> >() (QEventLoop::AllEvents, heap);
   ret.write<int > ((int)((QEventLoop *)cls)->exec (arg1));
 }
 
@@ -87,7 +87,7 @@ static void _call_f_exit_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QEventLoop *)cls)->exit (arg1);
 }
@@ -122,7 +122,7 @@ static void _call_f_processEvents_3995 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QEventLoop::ProcessEventsFlag> arg1 = args ? args.read<QFlags<QEventLoop::ProcessEventsFlag> > (heap) : (QFlags<QEventLoop::ProcessEventsFlag>)(QEventLoop::AllEvents);
+  QFlags<QEventLoop::ProcessEventsFlag> arg1 = args ? gsi::arg_reader<QFlags<QEventLoop::ProcessEventsFlag> >() (args, heap) : gsi::arg_maker<QFlags<QEventLoop::ProcessEventsFlag> >() (QEventLoop::AllEvents, heap);
   ret.write<bool > ((bool)((QEventLoop *)cls)->processEvents (arg1));
 }
 
@@ -143,8 +143,8 @@ static void _call_f_processEvents_4654 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QEventLoop::ProcessEventsFlag> arg1 = args.read<QFlags<QEventLoop::ProcessEventsFlag> > (heap);
-  int arg2 = args.read<int > (heap);
+  QFlags<QEventLoop::ProcessEventsFlag> arg1 = gsi::arg_reader<QFlags<QEventLoop::ProcessEventsFlag> >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QEventLoop *)cls)->processEvents (arg1, arg2);
 }
@@ -198,8 +198,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QEventLoop::tr (arg1, arg2));
 }
 
@@ -222,9 +222,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QEventLoop::tr (arg1, arg2, arg3));
 }
 
@@ -245,8 +245,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QEventLoop::trUtf8 (arg1, arg2));
 }
 
@@ -269,9 +269,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QEventLoop::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -455,7 +455,7 @@ static void _call_ctor_QEventLoop_Adaptor_1302 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QEventLoop_Adaptor *> (new QEventLoop_Adaptor (arg1));
 }
 
@@ -521,7 +521,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QEventLoop_Adaptor *)cls)->emitter_QEventLoop_destroyed_1302 (arg1);
 }
 
@@ -612,7 +612,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QEventLoop_Adaptor *)cls)->fp_QEventLoop_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQFile.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQFile.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QFile_2025 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QFile *> (new QFile (arg1));
 }
 
@@ -100,7 +100,7 @@ static void _call_ctor_QFile_1302 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QFile *> (new QFile (arg1));
 }
 
@@ -121,8 +121,8 @@ static void _call_ctor_QFile_3219 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QFile *> (new QFile (arg1, arg2));
 }
 
@@ -172,7 +172,7 @@ static void _call_f_copy_2025 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QFile *)cls)->copy (arg1));
 }
 
@@ -281,7 +281,7 @@ static void _call_f_link_2025 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QFile *)cls)->link (arg1));
 }
 
@@ -300,7 +300,7 @@ static void _call_f_open_3242 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QIODevice::OpenModeFlag> arg1 = args.read<QFlags<QIODevice::OpenModeFlag> > (heap);
+  QFlags<QIODevice::OpenModeFlag> arg1 = gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap);
   ret.write<bool > ((bool)((QFile *)cls)->open (arg1));
 }
 
@@ -379,7 +379,7 @@ static void _call_f_rename_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QFile *)cls)->rename (arg1));
 }
 
@@ -398,7 +398,7 @@ static void _call_f_resize_986 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<bool > ((bool)((QFile *)cls)->resize (arg1));
 }
 
@@ -417,7 +417,7 @@ static void _call_f_seek_986 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<bool > ((bool)((QFile *)cls)->seek (arg1));
 }
 
@@ -436,7 +436,7 @@ static void _call_f_setFileName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFile *)cls)->setFileName (arg1);
 }
@@ -456,7 +456,7 @@ static void _call_f_setPermissions_2778 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QFile::Permission> arg1 = args.read<QFlags<QFile::Permission> > (heap);
+  QFlags<QFile::Permission> arg1 = gsi::arg_reader<QFlags<QFile::Permission> >() (args, heap);
   ret.write<bool > ((bool)((QFile *)cls)->setPermissions (arg1));
 }
 
@@ -523,8 +523,8 @@ static void _call_f_copy_3942 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QFile::copy (arg1, arg2));
 }
 
@@ -543,7 +543,7 @@ static void _call_f_decodeName_1731 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QString > ((QString)QFile::decodeName (arg1));
 }
 
@@ -562,7 +562,7 @@ static void _call_f_encodeName_2025 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)QFile::encodeName (arg1));
 }
 
@@ -581,7 +581,7 @@ static void _call_f_exists_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QFile::exists (arg1));
 }
 
@@ -602,8 +602,8 @@ static void _call_f_link_3942 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QFile::link (arg1, arg2));
 }
 
@@ -622,7 +622,7 @@ static void _call_f_permissions_2025 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QFlags<QFile::Permission> > ((QFlags<QFile::Permission>)QFile::permissions (arg1));
 }
 
@@ -641,7 +641,7 @@ static void _call_f_readLink_2025 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QFile::readLink (arg1));
 }
 
@@ -660,7 +660,7 @@ static void _call_f_remove_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QFile::remove (arg1));
 }
 
@@ -681,8 +681,8 @@ static void _call_f_rename_3942 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QFile::rename (arg1, arg2));
 }
 
@@ -703,8 +703,8 @@ static void _call_f_resize_2903 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  qint64 arg2 = args.read<qint64 > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  qint64 arg2 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<bool > ((bool)QFile::resize (arg1, arg2));
 }
 
@@ -725,8 +725,8 @@ static void _call_f_setPermissions_4695 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<QFile::Permission> arg2 = args.read<QFlags<QFile::Permission> > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QFile::Permission> arg2 = gsi::arg_reader<QFlags<QFile::Permission> >() (args, heap);
   ret.write<bool > ((bool)QFile::setPermissions (arg1, arg2));
 }
 
@@ -745,7 +745,7 @@ static void _call_f_symLinkTarget_2025 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QFile::symLinkTarget (arg1));
 }
 
@@ -766,8 +766,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFile::tr (arg1, arg2));
 }
 
@@ -790,9 +790,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFile::tr (arg1, arg2, arg3));
 }
 
@@ -813,8 +813,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFile::trUtf8 (arg1, arg2));
 }
 
@@ -837,9 +837,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFile::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQFileInfo.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQFileInfo.cc
@@ -68,7 +68,7 @@ static void _call_ctor_QFileInfo_2025 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QFileInfo *> (new QFileInfo (arg1));
 }
 
@@ -87,7 +87,7 @@ static void _call_ctor_QFileInfo_1778 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFile &arg1 = args.read<const QFile & > (heap);
+  const QFile &arg1 = gsi::arg_reader<const QFile & >() (args, heap);
   ret.write<QFileInfo *> (new QFileInfo (arg1));
 }
 
@@ -108,8 +108,8 @@ static void _call_ctor_QFileInfo_3598 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDir &arg1 = args.read<const QDir & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QDir &arg1 = gsi::arg_reader<const QDir & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QFileInfo *> (new QFileInfo (arg1, arg2));
 }
 
@@ -128,7 +128,7 @@ static void _call_ctor_QFileInfo_2174 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFileInfo &arg1 = args.read<const QFileInfo & > (heap);
+  const QFileInfo &arg1 = gsi::arg_reader<const QFileInfo & >() (args, heap);
   ret.write<QFileInfo *> (new QFileInfo (arg1));
 }
 
@@ -628,7 +628,7 @@ static void _call_f_operator_excl__eq__2174 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFileInfo &arg1 = args.read<const QFileInfo & > (heap);
+  const QFileInfo &arg1 = gsi::arg_reader<const QFileInfo & >() (args, heap);
   ret.write<bool > ((bool)((QFileInfo *)cls)->operator!= (arg1));
 }
 
@@ -647,7 +647,7 @@ static void _call_f_operator_excl__eq__c2174 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFileInfo &arg1 = args.read<const QFileInfo & > (heap);
+  const QFileInfo &arg1 = gsi::arg_reader<const QFileInfo & >() (args, heap);
   ret.write<bool > ((bool)((QFileInfo *)cls)->operator!= (arg1));
 }
 
@@ -666,7 +666,7 @@ static void _call_f_operator_eq__2174 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFileInfo &arg1 = args.read<const QFileInfo & > (heap);
+  const QFileInfo &arg1 = gsi::arg_reader<const QFileInfo & >() (args, heap);
   ret.write<QFileInfo & > ((QFileInfo &)((QFileInfo *)cls)->operator= (arg1));
 }
 
@@ -685,7 +685,7 @@ static void _call_f_operator_eq__eq__2174 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFileInfo &arg1 = args.read<const QFileInfo & > (heap);
+  const QFileInfo &arg1 = gsi::arg_reader<const QFileInfo & >() (args, heap);
   ret.write<bool > ((bool)((QFileInfo *)cls)->operator== (arg1));
 }
 
@@ -704,7 +704,7 @@ static void _call_f_operator_eq__eq__c2174 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFileInfo &arg1 = args.read<const QFileInfo & > (heap);
+  const QFileInfo &arg1 = gsi::arg_reader<const QFileInfo & >() (args, heap);
   ret.write<bool > ((bool)((QFileInfo *)cls)->operator== (arg1));
 }
 
@@ -768,7 +768,7 @@ static void _call_f_permission_c2778 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QFile::Permission> arg1 = args.read<QFlags<QFile::Permission> > (heap);
+  QFlags<QFile::Permission> arg1 = gsi::arg_reader<QFlags<QFile::Permission> >() (args, heap);
   ret.write<bool > ((bool)((QFileInfo *)cls)->permission (arg1));
 }
 
@@ -833,7 +833,7 @@ static void _call_f_setCaching_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileInfo *)cls)->setCaching (arg1);
 }
@@ -853,7 +853,7 @@ static void _call_f_setFile_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileInfo *)cls)->setFile (arg1);
 }
@@ -873,7 +873,7 @@ static void _call_f_setFile_1778 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFile &arg1 = args.read<const QFile & > (heap);
+  const QFile &arg1 = gsi::arg_reader<const QFile & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileInfo *)cls)->setFile (arg1);
 }
@@ -895,8 +895,8 @@ static void _call_f_setFile_3598 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDir &arg1 = args.read<const QDir & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QDir &arg1 = gsi::arg_reader<const QDir & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileInfo *)cls)->setFile (arg1, arg2);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQFileSystemWatcher.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQFileSystemWatcher.cc
@@ -68,7 +68,7 @@ static void _call_f_addPath_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemWatcher *)cls)->addPath (arg1);
 }
@@ -88,7 +88,7 @@ static void _call_f_addPaths_2437 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemWatcher *)cls)->addPaths (arg1);
 }
@@ -138,7 +138,7 @@ static void _call_f_removePath_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemWatcher *)cls)->removePath (arg1);
 }
@@ -158,7 +158,7 @@ static void _call_f_removePaths_2437 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemWatcher *)cls)->removePaths (arg1);
 }
@@ -180,8 +180,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFileSystemWatcher::tr (arg1, arg2));
 }
 
@@ -204,9 +204,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFileSystemWatcher::tr (arg1, arg2, arg3));
 }
 
@@ -227,8 +227,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFileSystemWatcher::trUtf8 (arg1, arg2));
 }
 
@@ -251,9 +251,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFileSystemWatcher::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -462,7 +462,7 @@ static void _call_ctor_QFileSystemWatcher_Adaptor_1302 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QFileSystemWatcher_Adaptor *> (new QFileSystemWatcher_Adaptor (arg1));
 }
 
@@ -482,8 +482,8 @@ static void _call_ctor_QFileSystemWatcher_Adaptor_3631 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QFileSystemWatcher_Adaptor *> (new QFileSystemWatcher_Adaptor (arg1, arg2));
 }
 
@@ -549,7 +549,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QFileSystemWatcher_Adaptor *)cls)->emitter_QFileSystemWatcher_destroyed_1302 (arg1);
 }
 
@@ -567,7 +567,7 @@ static void _call_emitter_directoryChanged_2025 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFileSystemWatcher_Adaptor *)cls)->emitter_QFileSystemWatcher_directoryChanged_2025 (arg1);
 }
 
@@ -658,7 +658,7 @@ static void _call_emitter_fileChanged_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFileSystemWatcher_Adaptor *)cls)->emitter_QFileSystemWatcher_fileChanged_2025 (arg1);
 }
 
@@ -676,7 +676,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QFileSystemWatcher_Adaptor *)cls)->fp_QFileSystemWatcher_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQIODevice.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQIODevice.cc
@@ -232,7 +232,7 @@ static void _call_f_open_3242 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QIODevice::OpenModeFlag> arg1 = args.read<QFlags<QIODevice::OpenModeFlag> > (heap);
+  QFlags<QIODevice::OpenModeFlag> arg1 = gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap);
   ret.write<bool > ((bool)((QIODevice *)cls)->open (arg1));
 }
 
@@ -266,7 +266,7 @@ static void _call_f_peek_986 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QIODevice *)cls)->peek (arg1));
 }
 
@@ -300,7 +300,7 @@ static void _call_f_putChar_850 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  char arg1 = args.read<char > (heap);
+  char arg1 = gsi::arg_reader<char >() (args, heap);
   ret.write<bool > ((bool)((QIODevice *)cls)->putChar (arg1));
 }
 
@@ -319,7 +319,7 @@ static void _call_f_read_986 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QIODevice *)cls)->read (arg1));
 }
 
@@ -353,7 +353,7 @@ static void _call_f_readLine_986 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args ? args.read<qint64 > (heap) : (qint64)(0);
+  qint64 arg1 = args ? gsi::arg_reader<qint64 >() (args, heap) : gsi::arg_maker<qint64 >() (0, heap);
   ret.write<QByteArray > ((QByteArray)((QIODevice *)cls)->readLine (arg1));
 }
 
@@ -387,7 +387,7 @@ static void _call_f_seek_986 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<bool > ((bool)((QIODevice *)cls)->seek (arg1));
 }
 
@@ -406,7 +406,7 @@ static void _call_f_setTextModeEnabled_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIODevice *)cls)->setTextModeEnabled (arg1);
 }
@@ -441,7 +441,7 @@ static void _call_f_ungetChar_850 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  char arg1 = args.read<char > (heap);
+  char arg1 = gsi::arg_reader<char >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIODevice *)cls)->ungetChar (arg1);
 }
@@ -461,7 +461,7 @@ static void _call_f_waitForBytesWritten_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QIODevice *)cls)->waitForBytesWritten (arg1));
 }
 
@@ -480,7 +480,7 @@ static void _call_f_waitForReadyRead_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QIODevice *)cls)->waitForReadyRead (arg1));
 }
 
@@ -501,8 +501,8 @@ static void _call_f_write_2609 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  qint64 arg2 = args.read<qint64 > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  qint64 arg2 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<qint64 > ((qint64)((QIODevice *)cls)->write (arg1, arg2));
 }
 
@@ -521,7 +521,7 @@ static void _call_f_write_2309 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<qint64 > ((qint64)((QIODevice *)cls)->write (arg1));
 }
 
@@ -542,8 +542,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QIODevice::tr (arg1, arg2));
 }
 
@@ -566,9 +566,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QIODevice::tr (arg1, arg2, arg3));
 }
 
@@ -589,8 +589,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QIODevice::trUtf8 (arg1, arg2));
 }
 
@@ -613,9 +613,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QIODevice::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQLibrary.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQLibrary.cc
@@ -143,7 +143,7 @@ static void _call_f_resolve_1731 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<void * > ((void *)((QLibrary *)cls)->resolve (arg1));
 }
 
@@ -162,7 +162,7 @@ static void _call_f_setFileName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLibrary *)cls)->setFileName (arg1);
 }
@@ -184,8 +184,8 @@ static void _call_f_setFileNameAndVersion_2684 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args.read<int > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLibrary *)cls)->setFileNameAndVersion (arg1, arg2);
 }
@@ -207,8 +207,8 @@ static void _call_f_setFileNameAndVersion_3942 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLibrary *)cls)->setFileNameAndVersion (arg1, arg2);
 }
@@ -228,7 +228,7 @@ static void _call_f_setLoadHints_2841 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QLibrary::LoadHint> arg1 = args.read<QFlags<QLibrary::LoadHint> > (heap);
+  QFlags<QLibrary::LoadHint> arg1 = gsi::arg_reader<QFlags<QLibrary::LoadHint> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLibrary *)cls)->setLoadHints (arg1);
 }
@@ -263,7 +263,7 @@ static void _call_f_isLibrary_2025 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QLibrary::isLibrary (arg1));
 }
 
@@ -284,8 +284,8 @@ static void _call_f_resolve_3648 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<void * > ((void *)QLibrary::resolve (arg1, arg2));
 }
 
@@ -308,9 +308,9 @@ static void _call_f_resolve_4307 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args.read<int > (heap);
-  const char *arg3 = args.read<const char * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<void * > ((void *)QLibrary::resolve (arg1, arg2, arg3));
 }
 
@@ -333,9 +333,9 @@ static void _call_f_resolve_5565 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const char *arg3 = args.read<const char * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<void * > ((void *)QLibrary::resolve (arg1, arg2, arg3));
 }
 
@@ -356,8 +356,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLibrary::tr (arg1, arg2));
 }
 
@@ -380,9 +380,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLibrary::tr (arg1, arg2, arg3));
 }
 
@@ -403,8 +403,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLibrary::trUtf8 (arg1, arg2));
 }
 
@@ -427,9 +427,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLibrary::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -657,7 +657,7 @@ static void _call_ctor_QLibrary_Adaptor_1302 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QLibrary_Adaptor *> (new QLibrary_Adaptor (arg1));
 }
 
@@ -677,8 +677,8 @@ static void _call_ctor_QLibrary_Adaptor_3219 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QLibrary_Adaptor *> (new QLibrary_Adaptor (arg1, arg2));
 }
 
@@ -700,9 +700,9 @@ static void _call_ctor_QLibrary_Adaptor_3878 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args.read<int > (heap);
-  QObject *arg3 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QObject *arg3 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QLibrary_Adaptor *> (new QLibrary_Adaptor (arg1, arg2, arg3));
 }
 
@@ -724,9 +724,9 @@ static void _call_ctor_QLibrary_Adaptor_5136 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QObject *arg3 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg3 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QLibrary_Adaptor *> (new QLibrary_Adaptor (arg1, arg2, arg3));
 }
 
@@ -792,7 +792,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QLibrary_Adaptor *)cls)->emitter_QLibrary_destroyed_1302 (arg1);
 }
 
@@ -883,7 +883,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QLibrary_Adaptor *)cls)->fp_QLibrary_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQLibraryInfo.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQLibraryInfo.cc
@@ -111,7 +111,7 @@ static void _call_f_location_3304 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLibraryInfo::LibraryLocation>::target_type & arg1 = args.read<const qt_gsi::Converter<QLibraryInfo::LibraryLocation>::target_type & > (heap);
+  const qt_gsi::Converter<QLibraryInfo::LibraryLocation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLibraryInfo::LibraryLocation>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QLibraryInfo::location (qt_gsi::QtToCppAdaptor<QLibraryInfo::LibraryLocation>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQLine.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQLine.cc
@@ -68,8 +68,8 @@ static void _call_ctor_QLine_3724 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QLine *> (new QLine (arg1, arg2));
 }
 
@@ -94,10 +94,10 @@ static void _call_ctor_QLine_2744 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLine *> (new QLine (arg1, arg2, arg3, arg4));
 }
 
@@ -161,7 +161,7 @@ static void _call_f_operator_excl__eq__c1786 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLine &arg1 = args.read<const QLine & > (heap);
+  const QLine &arg1 = gsi::arg_reader<const QLine & >() (args, heap);
   ret.write<bool > ((bool)((QLine *)cls)->operator!= (arg1));
 }
 
@@ -180,7 +180,7 @@ static void _call_f_operator_eq__eq__c1786 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLine &arg1 = args.read<const QLine & > (heap);
+  const QLine &arg1 = gsi::arg_reader<const QLine & >() (args, heap);
   ret.write<bool > ((bool)((QLine *)cls)->operator== (arg1));
 }
 
@@ -235,10 +235,10 @@ static void _call_f_setLine_2744 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLine *)cls)->setLine (arg1, arg2, arg3, arg4);
 }
@@ -258,7 +258,7 @@ static void _call_f_setP1_1916 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLine *)cls)->setP1 (arg1);
 }
@@ -278,7 +278,7 @@ static void _call_f_setP2_1916 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLine *)cls)->setP2 (arg1);
 }
@@ -300,8 +300,8 @@ static void _call_f_setPoints_3724 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLine *)cls)->setPoints (arg1, arg2);
 }
@@ -321,7 +321,7 @@ static void _call_f_translate_1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLine *)cls)->translate (arg1);
 }
@@ -343,8 +343,8 @@ static void _call_f_translate_1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLine *)cls)->translate (arg1, arg2);
 }
@@ -364,7 +364,7 @@ static void _call_f_translated_c1916 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QLine > ((QLine)((QLine *)cls)->translated (arg1));
 }
 
@@ -385,8 +385,8 @@ static void _call_f_translated_c1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLine > ((QLine)((QLine *)cls)->translated (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQLineF.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQLineF.cc
@@ -69,8 +69,8 @@ static void _call_ctor_QLineF_3864 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QLineF *> (new QLineF (arg1, arg2));
 }
 
@@ -95,10 +95,10 @@ static void _call_ctor_QLineF_3960 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QLineF *> (new QLineF (arg1, arg2, arg3, arg4));
 }
 
@@ -117,7 +117,7 @@ static void _call_ctor_QLineF_1786 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLine &arg1 = args.read<const QLine & > (heap);
+  const QLine &arg1 = gsi::arg_reader<const QLine & >() (args, heap);
   ret.write<QLineF *> (new QLineF (arg1));
 }
 
@@ -151,7 +151,7 @@ static void _call_f_angle_c1856 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
   ret.write<double > ((double)((QLineF *)cls)->angle (arg1));
 }
 
@@ -170,7 +170,7 @@ static void _call_f_angleTo_c1856 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
   ret.write<double > ((double)((QLineF *)cls)->angleTo (arg1));
 }
 
@@ -221,8 +221,8 @@ static void _call_f_intersect_c3043 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
-  QPointF *arg2 = args.read<QPointF * > (heap);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
+  QPointF *arg2 = gsi::arg_reader<QPointF * >() (args, heap);
   ret.write<qt_gsi::Converter<QLineF::IntersectType>::target_type > ((qt_gsi::Converter<QLineF::IntersectType>::target_type)qt_gsi::CppToQtAdaptor<QLineF::IntersectType>(((QLineF *)cls)->intersect (arg1, arg2)));
 }
 
@@ -286,7 +286,7 @@ static void _call_f_operator_excl__eq__c1856 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
   ret.write<bool > ((bool)((QLineF *)cls)->operator!= (arg1));
 }
 
@@ -305,7 +305,7 @@ static void _call_f_operator_eq__eq__c1856 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
   ret.write<bool > ((bool)((QLineF *)cls)->operator== (arg1));
 }
 
@@ -354,7 +354,7 @@ static void _call_f_pointAt_c1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF > ((QPointF)((QLineF *)cls)->pointAt (arg1));
 }
 
@@ -373,7 +373,7 @@ static void _call_f_setAngle_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineF *)cls)->setAngle (arg1);
 }
@@ -393,7 +393,7 @@ static void _call_f_setLength_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineF *)cls)->setLength (arg1);
 }
@@ -419,10 +419,10 @@ static void _call_f_setLine_3960 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineF *)cls)->setLine (arg1, arg2, arg3, arg4);
 }
@@ -442,7 +442,7 @@ static void _call_f_setP1_1986 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineF *)cls)->setP1 (arg1);
 }
@@ -462,7 +462,7 @@ static void _call_f_setP2_1986 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineF *)cls)->setP2 (arg1);
 }
@@ -484,8 +484,8 @@ static void _call_f_setPoints_3864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineF *)cls)->setPoints (arg1, arg2);
 }
@@ -520,7 +520,7 @@ static void _call_f_translate_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineF *)cls)->translate (arg1);
 }
@@ -542,8 +542,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineF *)cls)->translate (arg1, arg2);
 }
@@ -563,7 +563,7 @@ static void _call_f_translated_c1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QLineF > ((QLineF)((QLineF *)cls)->translated (arg1));
 }
 
@@ -584,8 +584,8 @@ static void _call_f_translated_c2034 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QLineF > ((QLineF)((QLineF *)cls)->translated (arg1, arg2));
 }
 
@@ -681,8 +681,8 @@ static void _call_f_fromPolar_2034 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QLineF > ((QLineF)QLineF::fromPolar (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQLocale.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQLocale.cc
@@ -68,7 +68,7 @@ static void _call_ctor_QLocale_2025 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QLocale *> (new QLocale (arg1));
 }
 
@@ -89,8 +89,8 @@ static void _call_ctor_QLocale_3902 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLocale::Language>::target_type & arg1 = args.read<const qt_gsi::Converter<QLocale::Language>::target_type & > (heap);
-  const qt_gsi::Converter<QLocale::Country>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::Country>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::Country>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::Country>(heap, QLocale::AnyCountry));
+  const qt_gsi::Converter<QLocale::Language>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLocale::Language>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QLocale::Country>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::Country>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::Country>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::Country>(heap, QLocale::AnyCountry), heap);
   ret.write<QLocale *> (new QLocale (qt_gsi::QtToCppAdaptor<QLocale::Language>(arg1).cref(), qt_gsi::QtToCppAdaptor<QLocale::Country>(arg2).cref()));
 }
 
@@ -109,7 +109,7 @@ static void _call_ctor_QLocale_1986 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLocale &arg1 = args.read<const QLocale & > (heap);
+  const QLocale &arg1 = gsi::arg_reader<const QLocale & >() (args, heap);
   ret.write<QLocale *> (new QLocale (arg1));
 }
 
@@ -158,7 +158,7 @@ static void _call_f_dateFormat_c2260 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->dateFormat (qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg1).cref()));
 }
 
@@ -177,7 +177,7 @@ static void _call_f_dateTimeFormat_c2260 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->dateTimeFormat (qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg1).cref()));
 }
 
@@ -198,8 +198,8 @@ static void _call_f_dayName_c2919 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->dayName (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -295,8 +295,8 @@ static void _call_f_monthName_c2919 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->monthName (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -360,7 +360,7 @@ static void _call_f_operator_excl__eq__c1986 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLocale &arg1 = args.read<const QLocale & > (heap);
+  const QLocale &arg1 = gsi::arg_reader<const QLocale & >() (args, heap);
   ret.write<bool > ((bool)((QLocale *)cls)->operator!= (arg1));
 }
 
@@ -379,7 +379,7 @@ static void _call_f_operator_eq__1986 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLocale &arg1 = args.read<const QLocale & > (heap);
+  const QLocale &arg1 = gsi::arg_reader<const QLocale & >() (args, heap);
   ret.write<QLocale & > ((QLocale &)((QLocale *)cls)->operator= (arg1));
 }
 
@@ -398,7 +398,7 @@ static void _call_f_operator_eq__eq__c1986 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLocale &arg1 = args.read<const QLocale & > (heap);
+  const QLocale &arg1 = gsi::arg_reader<const QLocale & >() (args, heap);
   ret.write<bool > ((bool)((QLocale *)cls)->operator== (arg1));
 }
 
@@ -462,7 +462,7 @@ static void _call_f_setNumberOptions_3171 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QLocale::NumberOption> arg1 = args.read<QFlags<QLocale::NumberOption> > (heap);
+  QFlags<QLocale::NumberOption> arg1 = gsi::arg_reader<QFlags<QLocale::NumberOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLocale *)cls)->setNumberOptions (arg1);
 }
@@ -484,8 +484,8 @@ static void _call_f_standaloneDayName_c2919 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->standaloneDayName (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -506,8 +506,8 @@ static void _call_f_standaloneMonthName_c2919 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->standaloneMonthName (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -526,7 +526,7 @@ static void _call_f_timeFormat_c2260 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->timeFormat (qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg1).cref()));
 }
 
@@ -547,8 +547,8 @@ static void _call_f_toDate_c4177 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QDate > ((QDate)((QLocale *)cls)->toDate (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -569,8 +569,8 @@ static void _call_f_toDate_c3942 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDate > ((QDate)((QLocale *)cls)->toDate (arg1, arg2));
 }
 
@@ -591,8 +591,8 @@ static void _call_f_toDateTime_c4177 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QDateTime > ((QDateTime)((QLocale *)cls)->toDateTime (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -613,8 +613,8 @@ static void _call_f_toDateTime_c3942 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDateTime > ((QDateTime)((QLocale *)cls)->toDateTime (arg1, arg2));
 }
 
@@ -635,8 +635,8 @@ static void _call_f_toDouble_c2967 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<double > ((double)((QLocale *)cls)->toDouble (arg1, arg2));
 }
 
@@ -657,8 +657,8 @@ static void _call_f_toFloat_c2967 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<float > ((float)((QLocale *)cls)->toFloat (arg1, arg2));
 }
 
@@ -681,9 +681,9 @@ static void _call_f_toInt_c3626 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<int > ((int)((QLocale *)cls)->toInt (arg1, arg2, arg3));
 }
 
@@ -706,9 +706,9 @@ static void _call_f_toLongLong_c3626 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<qlonglong > ((qlonglong)((QLocale *)cls)->toLongLong (arg1, arg2, arg3));
 }
 
@@ -731,9 +731,9 @@ static void _call_f_toShort_c3626 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<short int > ((short int)((QLocale *)cls)->toShort (arg1, arg2, arg3));
 }
 
@@ -752,7 +752,7 @@ static void _call_f_toString_c1413 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qlonglong arg1 = args.read<qlonglong > (heap);
+  qlonglong arg1 = gsi::arg_reader<qlonglong >() (args, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1));
 }
 
@@ -771,7 +771,7 @@ static void _call_f_toString_c1530 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qulonglong arg1 = args.read<qulonglong > (heap);
+  qulonglong arg1 = gsi::arg_reader<qulonglong >() (args, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1));
 }
 
@@ -790,7 +790,7 @@ static void _call_f_toString_c1471 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  short int arg1 = args.read<short int > (heap);
+  short int arg1 = gsi::arg_reader<short int >() (args, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1));
 }
 
@@ -809,7 +809,7 @@ static void _call_f_toString_c2476 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned short int arg1 = args.read<unsigned short int > (heap);
+  unsigned short int arg1 = gsi::arg_reader<unsigned short int >() (args, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1));
 }
 
@@ -828,7 +828,7 @@ static void _call_f_toString_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1));
 }
 
@@ -847,7 +847,7 @@ static void _call_f_toString_c1772 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1));
 }
 
@@ -870,9 +870,9 @@ static void _call_f_toString_c2472 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  char arg2 = args ? args.read<char > (heap) : (char)('g');
-  int arg3 = args ? args.read<int > (heap) : (int)(6);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  char arg2 = args ? gsi::arg_reader<char >() (args, heap) : gsi::arg_maker<char >() ('g', heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (6, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1, arg2, arg3));
 }
 
@@ -895,9 +895,9 @@ static void _call_f_toString_c2371 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  float arg1 = args.read<float > (heap);
-  char arg2 = args ? args.read<char > (heap) : (char)('g');
-  int arg3 = args ? args.read<int > (heap) : (int)(6);
+  float arg1 = gsi::arg_reader<float >() (args, heap);
+  char arg2 = args ? gsi::arg_reader<char >() (args, heap) : gsi::arg_maker<char >() ('g', heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (6, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1, arg2, arg3));
 }
 
@@ -918,8 +918,8 @@ static void _call_f_toString_c3693 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1, arg2));
 }
 
@@ -940,8 +940,8 @@ static void _call_f_toString_c3928 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -962,8 +962,8 @@ static void _call_f_toString_c3710 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1, arg2));
 }
 
@@ -984,8 +984,8 @@ static void _call_f_toString_c3945 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -1006,8 +1006,8 @@ static void _call_f_toString_c4327 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -1028,8 +1028,8 @@ static void _call_f_toString_c4092 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QLocale *)cls)->toString (arg1, arg2));
 }
 
@@ -1050,8 +1050,8 @@ static void _call_f_toTime_c4177 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocale::FormatType>::target_type & > (heap) : (const qt_gsi::Converter<QLocale::FormatType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QLocale::FormatType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocale::FormatType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocale::FormatType>(heap, QLocale::LongFormat), heap);
   ret.write<QTime > ((QTime)((QLocale *)cls)->toTime (arg1, qt_gsi::QtToCppAdaptor<QLocale::FormatType>(arg2).cref()));
 }
 
@@ -1072,8 +1072,8 @@ static void _call_f_toTime_c3942 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QTime > ((QTime)((QLocale *)cls)->toTime (arg1, arg2));
 }
 
@@ -1096,9 +1096,9 @@ static void _call_f_toUInt_c3626 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<unsigned int > ((unsigned int)((QLocale *)cls)->toUInt (arg1, arg2, arg3));
 }
 
@@ -1121,9 +1121,9 @@ static void _call_f_toULongLong_c3626 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<qlonglong > ((qlonglong)((QLocale *)cls)->toULongLong (arg1, arg2, arg3));
 }
 
@@ -1146,9 +1146,9 @@ static void _call_f_toUShort_c3626 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<unsigned short int > ((unsigned short int)((QLocale *)cls)->toUShort (arg1, arg2, arg3));
 }
 
@@ -1197,7 +1197,7 @@ static void _call_f_countriesForLanguage_2029 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLocale::Language>::target_type & arg1 = args.read<const qt_gsi::Converter<QLocale::Language>::target_type & > (heap);
+  const qt_gsi::Converter<QLocale::Language>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLocale::Language>::target_type & >() (args, heap);
   ret.write<QList<QLocale::Country> > ((QList<QLocale::Country>)QLocale::countriesForLanguage (qt_gsi::QtToCppAdaptor<QLocale::Language>(arg1).cref()));
 }
 
@@ -1216,7 +1216,7 @@ static void _call_f_countryToString_1981 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLocale::Country>::target_type & arg1 = args.read<const qt_gsi::Converter<QLocale::Country>::target_type & > (heap);
+  const qt_gsi::Converter<QLocale::Country>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLocale::Country>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QLocale::countryToString (qt_gsi::QtToCppAdaptor<QLocale::Country>(arg1).cref()));
 }
 
@@ -1235,7 +1235,7 @@ static void _call_f_languageToString_2029 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLocale::Language>::target_type & arg1 = args.read<const qt_gsi::Converter<QLocale::Language>::target_type & > (heap);
+  const qt_gsi::Converter<QLocale::Language>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLocale::Language>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QLocale::languageToString (qt_gsi::QtToCppAdaptor<QLocale::Language>(arg1).cref()));
 }
 
@@ -1254,7 +1254,7 @@ static void _call_f_setDefault_1986 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLocale &arg1 = args.read<const QLocale & > (heap);
+  const QLocale &arg1 = gsi::arg_reader<const QLocale & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QLocale::setDefault (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQMargins.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQMargins.cc
@@ -71,10 +71,10 @@ static void _call_ctor_QMargins_2744 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<QMargins *> (new QMargins (arg1, arg2, arg3, arg4));
 }
 
@@ -153,7 +153,7 @@ static void _call_f_setBottom_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMargins *)cls)->setBottom (arg1);
 }
@@ -173,7 +173,7 @@ static void _call_f_setLeft_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMargins *)cls)->setLeft (arg1);
 }
@@ -193,7 +193,7 @@ static void _call_f_setRight_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMargins *)cls)->setRight (arg1);
 }
@@ -213,7 +213,7 @@ static void _call_f_setTop_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMargins *)cls)->setTop (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQMetaEnum.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQMetaEnum.cc
@@ -111,7 +111,7 @@ static void _call_f_key_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<const char * > ((const char *)((QMetaEnum *)cls)->key (arg1));
 }
 
@@ -145,7 +145,7 @@ static void _call_f_keyToValue_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMetaEnum *)cls)->keyToValue (arg1));
 }
 
@@ -164,7 +164,7 @@ static void _call_f_keysToValue_c1731 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMetaEnum *)cls)->keysToValue (arg1));
 }
 
@@ -213,7 +213,7 @@ static void _call_f_value_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QMetaEnum *)cls)->value (arg1));
 }
 
@@ -232,7 +232,7 @@ static void _call_f_valueToKey_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<const char * > ((const char *)((QMetaEnum *)cls)->valueToKey (arg1));
 }
 
@@ -251,7 +251,7 @@ static void _call_f_valueToKeys_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QMetaEnum *)cls)->valueToKeys (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQMetaObject.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQMetaObject.cc
@@ -70,7 +70,7 @@ static void _call_f_cast_c1302 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QObject * > ((QObject *)((QMetaObject *)cls)->cast (arg1));
 }
 
@@ -89,7 +89,7 @@ static void _call_f_classInfo_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QMetaClassInfo > ((QMetaClassInfo)((QMetaObject *)cls)->classInfo (arg1));
 }
 
@@ -153,7 +153,7 @@ static void _call_f_constructor_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QMetaMethod > ((QMetaMethod)((QMetaObject *)cls)->constructor (arg1));
 }
 
@@ -187,7 +187,7 @@ static void _call_f_enumerator_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QMetaEnum > ((QMetaEnum)((QMetaObject *)cls)->enumerator (arg1));
 }
 
@@ -236,7 +236,7 @@ static void _call_f_indexOfClassInfo_c1731 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMetaObject *)cls)->indexOfClassInfo (arg1));
 }
 
@@ -255,7 +255,7 @@ static void _call_f_indexOfConstructor_c1731 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMetaObject *)cls)->indexOfConstructor (arg1));
 }
 
@@ -274,7 +274,7 @@ static void _call_f_indexOfEnumerator_c1731 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMetaObject *)cls)->indexOfEnumerator (arg1));
 }
 
@@ -293,7 +293,7 @@ static void _call_f_indexOfMethod_c1731 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMetaObject *)cls)->indexOfMethod (arg1));
 }
 
@@ -312,7 +312,7 @@ static void _call_f_indexOfProperty_c1731 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMetaObject *)cls)->indexOfProperty (arg1));
 }
 
@@ -331,7 +331,7 @@ static void _call_f_indexOfSignal_c1731 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMetaObject *)cls)->indexOfSignal (arg1));
 }
 
@@ -350,7 +350,7 @@ static void _call_f_indexOfSlot_c1731 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMetaObject *)cls)->indexOfSlot (arg1));
 }
 
@@ -369,7 +369,7 @@ static void _call_f_method_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QMetaMethod > ((QMetaMethod)((QMetaObject *)cls)->method (arg1));
 }
 
@@ -418,7 +418,7 @@ static void _call_f_property_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QMetaProperty > ((QMetaProperty)((QMetaObject *)cls)->property (arg1));
 }
 
@@ -484,8 +484,8 @@ static void _call_f_tr_c3354 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QString > ((QString)((QMetaObject *)cls)->tr (arg1, arg2));
 }
 
@@ -508,9 +508,9 @@ static void _call_f_tr_c4013 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QMetaObject *)cls)->tr (arg1, arg2, arg3));
 }
 
@@ -531,8 +531,8 @@ static void _call_f_trUtf8_c3354 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QString > ((QString)((QMetaObject *)cls)->trUtf8 (arg1, arg2));
 }
 
@@ -555,9 +555,9 @@ static void _call_f_trUtf8_c4013 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QMetaObject *)cls)->trUtf8 (arg1, arg2, arg3));
 }
 
@@ -593,8 +593,8 @@ static void _call_f_checkConnectArgs_3354 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<bool > ((bool)QMetaObject::checkConnectArgs (arg1, arg2));
 }
 
@@ -623,12 +623,12 @@ static void _call_f_connect_6708 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args.read<const QObject * > (heap);
-  int arg2 = args.read<int > (heap);
-  const QObject *arg3 = args.read<const QObject * > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args ? args.read<int > (heap) : (int)(0);
-  int *arg6 = args ? args.read<int * > (heap) : (int *)(0);
+  const QObject *arg1 = gsi::arg_reader<const QObject * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QObject *arg3 = gsi::arg_reader<const QObject * >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int *arg6 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<bool > ((bool)QMetaObject::connect (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -647,7 +647,7 @@ static void _call_f_connectSlotsByName_1302 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QMetaObject::connectSlotsByName (arg1);
 }
@@ -673,10 +673,10 @@ static void _call_f_disconnect_5204 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args.read<const QObject * > (heap);
-  int arg2 = args.read<int > (heap);
-  const QObject *arg3 = args.read<const QObject * > (heap);
-  int arg4 = args.read<int > (heap);
+  const QObject *arg1 = gsi::arg_reader<const QObject * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QObject *arg3 = gsi::arg_reader<const QObject * >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)QMetaObject::disconnect (arg1, arg2, arg3, arg4));
 }
 
@@ -701,10 +701,10 @@ static void _call_f_disconnectOne_5204 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args.read<const QObject * > (heap);
-  int arg2 = args.read<int > (heap);
-  const QObject *arg3 = args.read<const QObject * > (heap);
-  int arg4 = args.read<int > (heap);
+  const QObject *arg1 = gsi::arg_reader<const QObject * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QObject *arg3 = gsi::arg_reader<const QObject * >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)QMetaObject::disconnectOne (arg1, arg2, arg3, arg4));
 }
 
@@ -723,7 +723,7 @@ static void _call_f_normalizedSignature_1731 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QByteArray > ((QByteArray)QMetaObject::normalizedSignature (arg1));
 }
 
@@ -742,7 +742,7 @@ static void _call_f_normalizedType_1731 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QByteArray > ((QByteArray)QMetaObject::normalizedType (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQMetaProperty.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQMetaProperty.cc
@@ -144,7 +144,7 @@ static void _call_f_isDesignable_c1997 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args ? args.read<const QObject * > (heap) : (const QObject *)(0);
+  const QObject *arg1 = args ? gsi::arg_reader<const QObject * >() (args, heap) : gsi::arg_maker<const QObject * >() (0, heap);
   ret.write<bool > ((bool)((QMetaProperty *)cls)->isDesignable (arg1));
 }
 
@@ -163,7 +163,7 @@ static void _call_f_isEditable_c1997 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args ? args.read<const QObject * > (heap) : (const QObject *)(0);
+  const QObject *arg1 = args ? gsi::arg_reader<const QObject * >() (args, heap) : gsi::arg_maker<const QObject * >() (0, heap);
   ret.write<bool > ((bool)((QMetaProperty *)cls)->isEditable (arg1));
 }
 
@@ -257,7 +257,7 @@ static void _call_f_isScriptable_c1997 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args ? args.read<const QObject * > (heap) : (const QObject *)(0);
+  const QObject *arg1 = args ? gsi::arg_reader<const QObject * >() (args, heap) : gsi::arg_maker<const QObject * >() (0, heap);
   ret.write<bool > ((bool)((QMetaProperty *)cls)->isScriptable (arg1));
 }
 
@@ -276,7 +276,7 @@ static void _call_f_isStored_c1997 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args ? args.read<const QObject * > (heap) : (const QObject *)(0);
+  const QObject *arg1 = args ? gsi::arg_reader<const QObject * >() (args, heap) : gsi::arg_maker<const QObject * >() (0, heap);
   ret.write<bool > ((bool)((QMetaProperty *)cls)->isStored (arg1));
 }
 
@@ -295,7 +295,7 @@ static void _call_f_isUser_c1997 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args ? args.read<const QObject * > (heap) : (const QObject *)(0);
+  const QObject *arg1 = args ? gsi::arg_reader<const QObject * >() (args, heap) : gsi::arg_maker<const QObject * >() (0, heap);
   ret.write<bool > ((bool)((QMetaProperty *)cls)->isUser (arg1));
 }
 
@@ -404,7 +404,7 @@ static void _call_f_read_c1997 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args.read<const QObject * > (heap);
+  const QObject *arg1 = gsi::arg_reader<const QObject * >() (args, heap);
   ret.write<QVariant > ((QVariant)((QMetaProperty *)cls)->read (arg1));
 }
 
@@ -423,7 +423,7 @@ static void _call_f_reset_c1302 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<bool > ((bool)((QMetaProperty *)cls)->reset (arg1));
 }
 
@@ -489,8 +489,8 @@ static void _call_f_write_c3313 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   ret.write<bool > ((bool)((QMetaProperty *)cls)->write (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQMetaType.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQMetaType.cc
@@ -68,8 +68,8 @@ static void _call_f_construct_2410 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const void *arg2 = args ? args.read<const void * > (heap) : (const void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const void *arg2 = args ? gsi::arg_reader<const void * >() (args, heap) : gsi::arg_maker<const void * >() (0, heap);
   ret.write<void * > ((void *)QMetaType::construct (arg1, arg2));
 }
 
@@ -90,8 +90,8 @@ static void _call_f_destroy_1715 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  void *arg2 = args.read<void * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  void *arg2 = gsi::arg_reader<void * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QMetaType::destroy (arg1, arg2);
 }
@@ -111,7 +111,7 @@ static void _call_f_isRegistered_767 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)QMetaType::isRegistered (arg1));
 }
 
@@ -134,9 +134,9 @@ static void _call_f_load_3304 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args.read<void * > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = gsi::arg_reader<void * >() (args, heap);
   ret.write<bool > ((bool)QMetaType::load (arg1, arg2, arg3));
 }
 
@@ -159,9 +159,9 @@ static void _call_f_save_3999 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
-  int arg2 = args.read<int > (heap);
-  const void *arg3 = args.read<const void * > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const void *arg3 = gsi::arg_reader<const void * >() (args, heap);
   ret.write<bool > ((bool)QMetaType::save (arg1, arg2, arg3));
 }
 
@@ -180,7 +180,7 @@ static void _call_f_type_1731 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)QMetaType::type (arg1));
 }
 
@@ -199,7 +199,7 @@ static void _call_f_typeName_767 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<const char * > ((const char *)QMetaType::typeName (arg1));
 }
 
@@ -218,7 +218,7 @@ static void _call_f_unregisterType_1731 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QMetaType::unregisterType (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQMimeData.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQMimeData.cc
@@ -100,7 +100,7 @@ static void _call_f_data_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QMimeData *)cls)->data (arg1));
 }
 
@@ -149,7 +149,7 @@ static void _call_f_hasFormat_c2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QMimeData *)cls)->hasFormat (arg1));
 }
 
@@ -258,7 +258,7 @@ static void _call_f_removeFormat_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMimeData *)cls)->removeFormat (arg1);
 }
@@ -278,7 +278,7 @@ static void _call_f_setColorData_2119 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMimeData *)cls)->setColorData (arg1);
 }
@@ -300,8 +300,8 @@ static void _call_f_setData_4226 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QByteArray &arg2 = args.read<const QByteArray & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QByteArray &arg2 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMimeData *)cls)->setData (arg1, arg2);
 }
@@ -321,7 +321,7 @@ static void _call_f_setHtml_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMimeData *)cls)->setHtml (arg1);
 }
@@ -341,7 +341,7 @@ static void _call_f_setImageData_2119 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMimeData *)cls)->setImageData (arg1);
 }
@@ -361,7 +361,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMimeData *)cls)->setText (arg1);
 }
@@ -381,7 +381,7 @@ static void _call_f_setUrls_2316 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QUrl> &arg1 = args.read<const QList<QUrl> & > (heap);
+  const QList<QUrl> &arg1 = gsi::arg_reader<const QList<QUrl> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMimeData *)cls)->setUrls (arg1);
 }
@@ -433,8 +433,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMimeData::tr (arg1, arg2));
 }
 
@@ -457,9 +457,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMimeData::tr (arg1, arg2, arg3));
 }
 
@@ -480,8 +480,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMimeData::trUtf8 (arg1, arg2));
 }
 
@@ -504,9 +504,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMimeData::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -808,7 +808,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QMimeData_Adaptor *)cls)->emitter_QMimeData_destroyed_1302 (arg1);
 }
 
@@ -941,7 +941,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMimeData_Adaptor *)cls)->fp_QMimeData_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQModelIndex.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQModelIndex.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QModelIndex_2395 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex *> (new QModelIndex (arg1));
 }
 
@@ -87,8 +87,8 @@ static void _call_f_child_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QModelIndex *)cls)->child (arg1, arg2));
 }
 
@@ -122,7 +122,7 @@ static void _call_f_data_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QModelIndex *)cls)->data (arg1));
 }
 
@@ -216,7 +216,7 @@ static void _call_f_operator_excl__eq__c2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QModelIndex *)cls)->operator!= (arg1));
 }
 
@@ -235,7 +235,7 @@ static void _call_f_operator_lt__c2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QModelIndex *)cls)->operator< (arg1));
 }
 
@@ -254,7 +254,7 @@ static void _call_f_operator_eq__eq__c2395 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QModelIndex *)cls)->operator== (arg1));
 }
 
@@ -305,8 +305,8 @@ static void _call_f_sibling_c1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QModelIndex *)cls)->sibling (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQMutex.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQMutex.cc
@@ -50,7 +50,7 @@ static void _call_ctor_QMutex_2507 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMutex::RecursionMode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QMutex::RecursionMode>::target_type & > (heap) : (const qt_gsi::Converter<QMutex::RecursionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QMutex::RecursionMode>(heap, QMutex::NonRecursive));
+  const qt_gsi::Converter<QMutex::RecursionMode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QMutex::RecursionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QMutex::RecursionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QMutex::RecursionMode>(heap, QMutex::NonRecursive), heap);
   ret.write<QMutex *> (new QMutex (qt_gsi::QtToCppAdaptor<QMutex::RecursionMode>(arg1).cref()));
 }
 
@@ -100,7 +100,7 @@ static void _call_f_tryLock_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QMutex *)cls)->tryLock (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQObject.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQObject.cc
@@ -68,7 +68,7 @@ static void _call_f_blockSignals_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ret.write<bool > ((bool)((QObject *)cls)->blockSignals (arg1));
 }
 
@@ -108,10 +108,10 @@ static void _call_f_connect_c7342 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args.read<const QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  const char *arg3 = args.read<const char * > (heap);
-  const qt_gsi::Converter<Qt::ConnectionType>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<Qt::ConnectionType>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ConnectionType>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ConnectionType>(heap, Qt::AutoConnection));
+  const QObject *arg1 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
+  const qt_gsi::Converter<Qt::ConnectionType>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ConnectionType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ConnectionType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ConnectionType>(heap, Qt::AutoConnection), heap);
   ret.write<bool > ((bool)((QObject *)cls)->connect (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<Qt::ConnectionType>(arg4).cref()));
 }
 
@@ -150,9 +150,9 @@ static void _call_f_disconnect_5243 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args ? args.read<const char * > (heap) : (const char *)(0);
-  const QObject *arg2 = args ? args.read<const QObject * > (heap) : (const QObject *)(0);
-  const char *arg3 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  const QObject *arg2 = args ? gsi::arg_reader<const QObject * >() (args, heap) : gsi::arg_maker<const QObject * >() (0, heap);
+  const char *arg3 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<bool > ((bool)((QObject *)cls)->disconnect (arg1, arg2, arg3));
 }
 
@@ -173,8 +173,8 @@ static void _call_f_disconnect_3620 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args.read<const QObject * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QObject *arg1 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<bool > ((bool)((QObject *)cls)->disconnect (arg1, arg2));
 }
 
@@ -240,7 +240,7 @@ static void _call_f_event_1217 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QObject *)cls)->event (arg1));
 }
 
@@ -261,8 +261,8 @@ static void _call_f_eventFilter_2411 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  QEvent *arg2 = args.read<QEvent * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  QEvent *arg2 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QObject *)cls)->eventFilter (arg1, arg2));
 }
 
@@ -281,7 +281,7 @@ static void _call_f_inherits_c1731 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<bool > ((bool)((QObject *)cls)->inherits (arg1));
 }
 
@@ -300,7 +300,7 @@ static void _call_f_installEventFilter_1302 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QObject *)cls)->installEventFilter (arg1);
 }
@@ -335,7 +335,7 @@ static void _call_f_killTimer_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QObject *)cls)->killTimer (arg1);
 }
@@ -355,7 +355,7 @@ static void _call_f_moveToThread_1303 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QThread *arg1 = args.read<QThread * > (heap);
+  QThread *arg1 = gsi::arg_reader<QThread * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QObject *)cls)->moveToThread (arg1);
 }
@@ -405,7 +405,7 @@ static void _call_f_property_c1731 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QVariant > ((QVariant)((QObject *)cls)->property (arg1));
 }
 
@@ -424,7 +424,7 @@ static void _call_f_removeEventFilter_1302 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QObject *)cls)->removeEventFilter (arg1);
 }
@@ -444,7 +444,7 @@ static void _call_f_setObjectName_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QObject *)cls)->setObjectName (arg1);
 }
@@ -464,7 +464,7 @@ static void _call_f_setParent_1302 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QObject *)cls)->setParent (arg1);
 }
@@ -486,8 +486,8 @@ static void _call_f_setProperty_3742 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   ret.write<bool > ((bool)((QObject *)cls)->setProperty (arg1, arg2));
 }
 
@@ -521,7 +521,7 @@ static void _call_f_startTimer_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QObject *)cls)->startTimer (arg1));
 }
 
@@ -563,11 +563,11 @@ static void _call_f_connect_9231 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args.read<const QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  const QObject *arg3 = args.read<const QObject * > (heap);
-  const char *arg4 = args.read<const char * > (heap);
-  const qt_gsi::Converter<Qt::ConnectionType>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<Qt::ConnectionType>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ConnectionType>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ConnectionType>(heap, Qt::AutoConnection));
+  const QObject *arg1 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  const QObject *arg3 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg4 = gsi::arg_reader<const char * >() (args, heap);
+  const qt_gsi::Converter<Qt::ConnectionType>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ConnectionType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ConnectionType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ConnectionType>(heap, Qt::AutoConnection), heap);
   ret.write<bool > ((bool)QObject::connect (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::ConnectionType>(arg5).cref()));
 }
 
@@ -592,10 +592,10 @@ static void _call_f_disconnect_7132 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QObject *arg1 = args.read<const QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  const QObject *arg3 = args.read<const QObject * > (heap);
-  const char *arg4 = args.read<const char * > (heap);
+  const QObject *arg1 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  const QObject *arg3 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg4 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<bool > ((bool)QObject::disconnect (arg1, arg2, arg3, arg4));
 }
 
@@ -631,8 +631,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QObject::tr (arg1, arg2));
 }
 
@@ -655,9 +655,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QObject::tr (arg1, arg2, arg3));
 }
 
@@ -678,8 +678,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QObject::trUtf8 (arg1, arg2));
 }
 
@@ -702,9 +702,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QObject::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -908,7 +908,7 @@ static void _call_ctor_QObject_Adaptor_1302 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QObject_Adaptor *> (new QObject_Adaptor (arg1));
 }
 
@@ -974,7 +974,7 @@ static void _call_fp_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QObject_Adaptor *)cls)->fp_QObject_destroyed_1302 (arg1);
 }
@@ -1066,7 +1066,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QObject_Adaptor *)cls)->fp_QObject_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQPersistentModelIndex.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQPersistentModelIndex.cc
@@ -71,7 +71,7 @@ static void _call_ctor_QPersistentModelIndex_2395 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QPersistentModelIndex *> (new QPersistentModelIndex (arg1));
 }
 
@@ -90,7 +90,7 @@ static void _call_ctor_QPersistentModelIndex_3468 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPersistentModelIndex &arg1 = args.read<const QPersistentModelIndex & > (heap);
+  const QPersistentModelIndex &arg1 = gsi::arg_reader<const QPersistentModelIndex & >() (args, heap);
   ret.write<QPersistentModelIndex *> (new QPersistentModelIndex (arg1));
 }
 
@@ -111,8 +111,8 @@ static void _call_f_child_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QPersistentModelIndex *)cls)->child (arg1, arg2));
 }
 
@@ -146,7 +146,7 @@ static void _call_f_data_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QPersistentModelIndex *)cls)->data (arg1));
 }
 
@@ -240,7 +240,7 @@ static void _call_f_operator_excl__eq__c3468 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPersistentModelIndex &arg1 = args.read<const QPersistentModelIndex & > (heap);
+  const QPersistentModelIndex &arg1 = gsi::arg_reader<const QPersistentModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QPersistentModelIndex *)cls)->operator!= (arg1));
 }
 
@@ -259,7 +259,7 @@ static void _call_f_operator_excl__eq__c2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QPersistentModelIndex *)cls)->operator!= (arg1));
 }
 
@@ -278,7 +278,7 @@ static void _call_f_operator_lt__c3468 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPersistentModelIndex &arg1 = args.read<const QPersistentModelIndex & > (heap);
+  const QPersistentModelIndex &arg1 = gsi::arg_reader<const QPersistentModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QPersistentModelIndex *)cls)->operator< (arg1));
 }
 
@@ -297,7 +297,7 @@ static void _call_f_operator_eq__3468 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPersistentModelIndex &arg1 = args.read<const QPersistentModelIndex & > (heap);
+  const QPersistentModelIndex &arg1 = gsi::arg_reader<const QPersistentModelIndex & >() (args, heap);
   ret.write<QPersistentModelIndex & > ((QPersistentModelIndex &)((QPersistentModelIndex *)cls)->operator= (arg1));
 }
 
@@ -316,7 +316,7 @@ static void _call_f_operator_eq__2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QPersistentModelIndex & > ((QPersistentModelIndex &)((QPersistentModelIndex *)cls)->operator= (arg1));
 }
 
@@ -335,7 +335,7 @@ static void _call_f_operator_eq__eq__c3468 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPersistentModelIndex &arg1 = args.read<const QPersistentModelIndex & > (heap);
+  const QPersistentModelIndex &arg1 = gsi::arg_reader<const QPersistentModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QPersistentModelIndex *)cls)->operator== (arg1));
 }
 
@@ -354,7 +354,7 @@ static void _call_f_operator_eq__eq__c2395 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QPersistentModelIndex *)cls)->operator== (arg1));
 }
 
@@ -405,8 +405,8 @@ static void _call_f_sibling_c1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QPersistentModelIndex *)cls)->sibling (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQPluginLoader.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQPluginLoader.cc
@@ -158,7 +158,7 @@ static void _call_f_setFileName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPluginLoader *)cls)->setFileName (arg1);
 }
@@ -178,7 +178,7 @@ static void _call_f_setLoadHints_2841 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QLibrary::LoadHint> arg1 = args.read<QFlags<QLibrary::LoadHint> > (heap);
+  QFlags<QLibrary::LoadHint> arg1 = gsi::arg_reader<QFlags<QLibrary::LoadHint> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPluginLoader *)cls)->setLoadHints (arg1);
 }
@@ -230,8 +230,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPluginLoader::tr (arg1, arg2));
 }
 
@@ -254,9 +254,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPluginLoader::tr (arg1, arg2, arg3));
 }
 
@@ -277,8 +277,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPluginLoader::trUtf8 (arg1, arg2));
 }
 
@@ -301,9 +301,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPluginLoader::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -502,7 +502,7 @@ static void _call_ctor_QPluginLoader_Adaptor_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QPluginLoader_Adaptor *> (new QPluginLoader_Adaptor (arg1));
 }
 
@@ -522,8 +522,8 @@ static void _call_ctor_QPluginLoader_Adaptor_3219 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QPluginLoader_Adaptor *> (new QPluginLoader_Adaptor (arg1, arg2));
 }
 
@@ -589,7 +589,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPluginLoader_Adaptor *)cls)->emitter_QPluginLoader_destroyed_1302 (arg1);
 }
 
@@ -680,7 +680,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPluginLoader_Adaptor *)cls)->fp_QPluginLoader_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQPoint.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQPoint.cc
@@ -69,8 +69,8 @@ static void _call_ctor_QPoint_1426 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPoint *> (new QPoint (arg1, arg2));
 }
 
@@ -119,7 +119,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPoint & > ((QPoint &)((QPoint *)cls)->operator*= (arg1));
 }
 
@@ -138,7 +138,7 @@ static void _call_f_operator_plus__eq__1916 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint & > ((QPoint &)((QPoint *)cls)->operator+= (arg1));
 }
 
@@ -157,7 +157,7 @@ static void _call_f_operator_minus__eq__1916 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint & > ((QPoint &)((QPoint *)cls)->operator-= (arg1));
 }
 
@@ -176,7 +176,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPoint & > ((QPoint &)((QPoint *)cls)->operator/= (arg1));
 }
 
@@ -225,7 +225,7 @@ static void _call_f_setX_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPoint *)cls)->setX (arg1);
 }
@@ -245,7 +245,7 @@ static void _call_f_setY_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPoint *)cls)->setY (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQPointF.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQPointF.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QPointF_1916 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPointF *> (new QPointF (arg1));
 }
 
@@ -88,8 +88,8 @@ static void _call_ctor_QPointF_2034 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF *> (new QPointF (arg1, arg2));
 }
 
@@ -138,7 +138,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF & > ((QPointF &)((QPointF *)cls)->operator*= (arg1));
 }
 
@@ -157,7 +157,7 @@ static void _call_f_operator_plus__eq__1986 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF & > ((QPointF &)((QPointF *)cls)->operator+= (arg1));
 }
 
@@ -176,7 +176,7 @@ static void _call_f_operator_minus__eq__1986 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF & > ((QPointF &)((QPointF *)cls)->operator-= (arg1));
 }
 
@@ -195,7 +195,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF & > ((QPointF &)((QPointF *)cls)->operator/= (arg1));
 }
 
@@ -244,7 +244,7 @@ static void _call_f_setX_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPointF *)cls)->setX (arg1);
 }
@@ -264,7 +264,7 @@ static void _call_f_setY_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPointF *)cls)->setY (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQProcess.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQProcess.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QProcess_1302 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QProcess *> (new QProcess (arg1));
 }
 
@@ -162,7 +162,7 @@ static void _call_f_closeReadChannel_2800 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QProcess::ProcessChannel>::target_type & arg1 = args.read<const qt_gsi::Converter<QProcess::ProcessChannel>::target_type & > (heap);
+  const qt_gsi::Converter<QProcess::ProcessChannel>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QProcess::ProcessChannel>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->closeReadChannel (qt_gsi::QtToCppAdaptor<QProcess::ProcessChannel>(arg1).cref());
 }
@@ -394,7 +394,7 @@ static void _call_f_setEnvironment_2437 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setEnvironment (arg1);
 }
@@ -414,7 +414,7 @@ static void _call_f_setProcessChannelMode_3189 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QProcess::ProcessChannelMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QProcess::ProcessChannelMode>::target_type & > (heap);
+  const qt_gsi::Converter<QProcess::ProcessChannelMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QProcess::ProcessChannelMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setProcessChannelMode (qt_gsi::QtToCppAdaptor<QProcess::ProcessChannelMode>(arg1).cref());
 }
@@ -434,7 +434,7 @@ static void _call_f_setProcessEnvironment_3302 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QProcessEnvironment &arg1 = args.read<const QProcessEnvironment & > (heap);
+  const QProcessEnvironment &arg1 = gsi::arg_reader<const QProcessEnvironment & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setProcessEnvironment (arg1);
 }
@@ -454,7 +454,7 @@ static void _call_f_setReadChannel_2800 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QProcess::ProcessChannel>::target_type & arg1 = args.read<const qt_gsi::Converter<QProcess::ProcessChannel>::target_type & > (heap);
+  const qt_gsi::Converter<QProcess::ProcessChannel>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QProcess::ProcessChannel>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setReadChannel (qt_gsi::QtToCppAdaptor<QProcess::ProcessChannel>(arg1).cref());
 }
@@ -474,7 +474,7 @@ static void _call_f_setReadChannelMode_3189 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QProcess::ProcessChannelMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QProcess::ProcessChannelMode>::target_type & > (heap);
+  const qt_gsi::Converter<QProcess::ProcessChannelMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QProcess::ProcessChannelMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setReadChannelMode (qt_gsi::QtToCppAdaptor<QProcess::ProcessChannelMode>(arg1).cref());
 }
@@ -496,8 +496,8 @@ static void _call_f_setStandardErrorFile_5159 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg2 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::Truncate);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg2 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::Truncate, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setStandardErrorFile (arg1, arg2);
 }
@@ -517,7 +517,7 @@ static void _call_f_setStandardInputFile_2025 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setStandardInputFile (arg1);
 }
@@ -539,8 +539,8 @@ static void _call_f_setStandardOutputFile_5159 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg2 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::Truncate);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg2 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::Truncate, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setStandardOutputFile (arg1, arg2);
 }
@@ -560,7 +560,7 @@ static void _call_f_setStandardOutputProcess_1438 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QProcess *arg1 = args.read<QProcess * > (heap);
+  QProcess *arg1 = gsi::arg_reader<QProcess * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setStandardOutputProcess (arg1);
 }
@@ -580,7 +580,7 @@ static void _call_f_setWorkingDirectory_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->setWorkingDirectory (arg1);
 }
@@ -604,9 +604,9 @@ static void _call_f_start_7488 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg3 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg3 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->start (arg1, arg2, arg3);
 }
@@ -628,8 +628,8 @@ static void _call_f_start_5159 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg2 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg2 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcess *)cls)->start (arg1, arg2);
 }
@@ -680,7 +680,7 @@ static void _call_f_waitForBytesWritten_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QProcess *)cls)->waitForBytesWritten (arg1));
 }
 
@@ -699,7 +699,7 @@ static void _call_f_waitForFinished_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QProcess *)cls)->waitForFinished (arg1));
 }
 
@@ -718,7 +718,7 @@ static void _call_f_waitForReadyRead_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QProcess *)cls)->waitForReadyRead (arg1));
 }
 
@@ -737,7 +737,7 @@ static void _call_f_waitForStarted_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QProcess *)cls)->waitForStarted (arg1));
 }
 
@@ -773,8 +773,8 @@ static void _call_f_execute_4354 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
   ret.write<int > ((int)QProcess::execute (arg1, arg2));
 }
 
@@ -793,7 +793,7 @@ static void _call_f_execute_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)QProcess::execute (arg1));
 }
 
@@ -818,10 +818,10 @@ static void _call_f_startDetached_7335 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  qint64 *arg4 = args ? args.read<qint64 * > (heap) : (qint64 *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  qint64 *arg4 = args ? gsi::arg_reader<qint64 * >() (args, heap) : gsi::arg_maker<qint64 * >() (0, heap);
   ret.write<bool > ((bool)QProcess::startDetached (arg1, arg2, arg3, arg4));
 }
 
@@ -842,8 +842,8 @@ static void _call_f_startDetached_4354 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
   ret.write<bool > ((bool)QProcess::startDetached (arg1, arg2));
 }
 
@@ -862,7 +862,7 @@ static void _call_f_startDetached_2025 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QProcess::startDetached (arg1));
 }
 
@@ -898,8 +898,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QProcess::tr (arg1, arg2));
 }
 
@@ -922,9 +922,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QProcess::tr (arg1, arg2, arg3));
 }
 
@@ -945,8 +945,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QProcess::trUtf8 (arg1, arg2));
 }
 
@@ -969,9 +969,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QProcess::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQProcessEnvironment.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQProcessEnvironment.cc
@@ -65,7 +65,7 @@ static void _call_ctor_QProcessEnvironment_3302 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QProcessEnvironment &arg1 = args.read<const QProcessEnvironment & > (heap);
+  const QProcessEnvironment &arg1 = gsi::arg_reader<const QProcessEnvironment & >() (args, heap);
   ret.write<QProcessEnvironment *> (new QProcessEnvironment (arg1));
 }
 
@@ -100,7 +100,7 @@ static void _call_f_contains_c2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QProcessEnvironment *)cls)->contains (arg1));
 }
 
@@ -121,8 +121,8 @@ static void _call_f_insert_3942 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcessEnvironment *)cls)->insert (arg1, arg2);
 }
@@ -157,7 +157,7 @@ static void _call_f_operator_excl__eq__c3302 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QProcessEnvironment &arg1 = args.read<const QProcessEnvironment & > (heap);
+  const QProcessEnvironment &arg1 = gsi::arg_reader<const QProcessEnvironment & >() (args, heap);
   ret.write<bool > ((bool)((QProcessEnvironment *)cls)->operator!= (arg1));
 }
 
@@ -176,7 +176,7 @@ static void _call_f_operator_eq__3302 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QProcessEnvironment &arg1 = args.read<const QProcessEnvironment & > (heap);
+  const QProcessEnvironment &arg1 = gsi::arg_reader<const QProcessEnvironment & >() (args, heap);
   ret.write<QProcessEnvironment & > ((QProcessEnvironment &)((QProcessEnvironment *)cls)->operator= (arg1));
 }
 
@@ -195,7 +195,7 @@ static void _call_f_operator_eq__eq__c3302 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QProcessEnvironment &arg1 = args.read<const QProcessEnvironment & > (heap);
+  const QProcessEnvironment &arg1 = gsi::arg_reader<const QProcessEnvironment & >() (args, heap);
   ret.write<bool > ((bool)((QProcessEnvironment *)cls)->operator== (arg1));
 }
 
@@ -214,7 +214,7 @@ static void _call_f_remove_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProcessEnvironment *)cls)->remove (arg1);
 }
@@ -251,8 +251,8 @@ static void _call_f_value_c3942 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QString > ((QString)((QProcessEnvironment *)cls)->value (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQReadLocker.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQReadLocker.cc
@@ -51,7 +51,7 @@ static void _call_ctor_QReadLocker_1999 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QReadWriteLock *arg1 = args.read<QReadWriteLock * > (heap);
+  QReadWriteLock *arg1 = gsi::arg_reader<QReadWriteLock * >() (args, heap);
   ret.write<QReadLocker *> (new QReadLocker (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQReadWriteLock.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQReadWriteLock.cc
@@ -65,7 +65,7 @@ static void _call_ctor_QReadWriteLock_3272 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QReadWriteLock::RecursionMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QReadWriteLock::RecursionMode>::target_type & > (heap);
+  const qt_gsi::Converter<QReadWriteLock::RecursionMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QReadWriteLock::RecursionMode>::target_type & >() (args, heap);
   ret.write<QReadWriteLock *> (new QReadWriteLock (qt_gsi::QtToCppAdaptor<QReadWriteLock::RecursionMode>(arg1).cref()));
 }
 
@@ -131,7 +131,7 @@ static void _call_f_tryLockForRead_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QReadWriteLock *)cls)->tryLockForRead (arg1));
 }
 
@@ -165,7 +165,7 @@ static void _call_f_tryLockForWrite_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QReadWriteLock *)cls)->tryLockForWrite (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQRect.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQRect.cc
@@ -69,8 +69,8 @@ static void _call_ctor_QRect_3724 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QRect *> (new QRect (arg1, arg2));
 }
 
@@ -91,8 +91,8 @@ static void _call_ctor_QRect_3613 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QSize &arg2 = args.read<const QSize & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QSize &arg2 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QRect *> (new QRect (arg1, arg2));
 }
 
@@ -117,10 +117,10 @@ static void _call_ctor_QRect_2744 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRect *> (new QRect (arg1, arg2, arg3, arg4));
 }
 
@@ -145,10 +145,10 @@ static void _call_f_adjust_2744 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->adjust (arg1, arg2, arg3, arg4);
 }
@@ -174,10 +174,10 @@ static void _call_f_adjusted_c2744 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRect > ((QRect)((QRect *)cls)->adjusted (arg1, arg2, arg3, arg4));
 }
 
@@ -258,8 +258,8 @@ static void _call_f_contains_c2672 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<bool > ((bool)((QRect *)cls)->contains (arg1, arg2));
 }
 
@@ -280,8 +280,8 @@ static void _call_f_contains_c1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QRect *)cls)->contains (arg1, arg2));
 }
 
@@ -304,9 +304,9 @@ static void _call_f_contains_c2182 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  bool arg3 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  bool arg3 = gsi::arg_reader<bool >() (args, heap);
   ret.write<bool > ((bool)((QRect *)cls)->contains (arg1, arg2, arg3));
 }
 
@@ -327,8 +327,8 @@ static void _call_f_contains_c2548 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<bool > ((bool)((QRect *)cls)->contains (arg1, arg2));
 }
 
@@ -353,10 +353,10 @@ static void _call_f_getCoords_c3488 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->getCoords (arg1, arg2, arg3, arg4);
 }
@@ -382,10 +382,10 @@ static void _call_f_getRect_c3488 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->getRect (arg1, arg2, arg3, arg4);
 }
@@ -420,7 +420,7 @@ static void _call_f_intersect_c1792 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QRect *)cls)->intersect (arg1));
 }
 
@@ -439,7 +439,7 @@ static void _call_f_intersected_c1792 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QRect *)cls)->intersected (arg1));
 }
 
@@ -458,7 +458,7 @@ static void _call_f_intersects_c1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<bool > ((bool)((QRect *)cls)->intersects (arg1));
 }
 
@@ -537,7 +537,7 @@ static void _call_f_moveBottom_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveBottom (arg1);
 }
@@ -557,7 +557,7 @@ static void _call_f_moveBottomLeft_1916 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveBottomLeft (arg1);
 }
@@ -577,7 +577,7 @@ static void _call_f_moveBottomRight_1916 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveBottomRight (arg1);
 }
@@ -597,7 +597,7 @@ static void _call_f_moveCenter_1916 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveCenter (arg1);
 }
@@ -617,7 +617,7 @@ static void _call_f_moveLeft_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveLeft (arg1);
 }
@@ -637,7 +637,7 @@ static void _call_f_moveRight_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveRight (arg1);
 }
@@ -659,8 +659,8 @@ static void _call_f_moveTo_1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveTo (arg1, arg2);
 }
@@ -680,7 +680,7 @@ static void _call_f_moveTo_1916 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveTo (arg1);
 }
@@ -700,7 +700,7 @@ static void _call_f_moveTop_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveTop (arg1);
 }
@@ -720,7 +720,7 @@ static void _call_f_moveTopLeft_1916 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveTopLeft (arg1);
 }
@@ -740,7 +740,7 @@ static void _call_f_moveTopRight_1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->moveTopRight (arg1);
 }
@@ -775,7 +775,7 @@ static void _call_f_operator_amp__c1792 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QRect *)cls)->operator& (arg1));
 }
 
@@ -794,7 +794,7 @@ static void _call_f_operator_amp__eq__1792 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect & > ((QRect &)((QRect *)cls)->operator&= (arg1));
 }
 
@@ -813,7 +813,7 @@ static void _call_f_operator_pipe__c1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QRect *)cls)->operator| (arg1));
 }
 
@@ -832,7 +832,7 @@ static void _call_f_operator_pipe__eq__1792 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect & > ((QRect &)((QRect *)cls)->operator|= (arg1));
 }
 
@@ -866,7 +866,7 @@ static void _call_f_setBottom_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setBottom (arg1);
 }
@@ -886,7 +886,7 @@ static void _call_f_setBottomLeft_1916 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setBottomLeft (arg1);
 }
@@ -906,7 +906,7 @@ static void _call_f_setBottomRight_1916 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setBottomRight (arg1);
 }
@@ -932,10 +932,10 @@ static void _call_f_setCoords_2744 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setCoords (arg1, arg2, arg3, arg4);
 }
@@ -955,7 +955,7 @@ static void _call_f_setHeight_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setHeight (arg1);
 }
@@ -975,7 +975,7 @@ static void _call_f_setLeft_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setLeft (arg1);
 }
@@ -1001,10 +1001,10 @@ static void _call_f_setRect_2744 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setRect (arg1, arg2, arg3, arg4);
 }
@@ -1024,7 +1024,7 @@ static void _call_f_setRight_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setRight (arg1);
 }
@@ -1044,7 +1044,7 @@ static void _call_f_setSize_1805 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setSize (arg1);
 }
@@ -1064,7 +1064,7 @@ static void _call_f_setTop_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setTop (arg1);
 }
@@ -1084,7 +1084,7 @@ static void _call_f_setTopLeft_1916 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setTopLeft (arg1);
 }
@@ -1104,7 +1104,7 @@ static void _call_f_setTopRight_1916 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setTopRight (arg1);
 }
@@ -1124,7 +1124,7 @@ static void _call_f_setWidth_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setWidth (arg1);
 }
@@ -1144,7 +1144,7 @@ static void _call_f_setX_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setX (arg1);
 }
@@ -1164,7 +1164,7 @@ static void _call_f_setY_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->setY (arg1);
 }
@@ -1246,8 +1246,8 @@ static void _call_f_translate_1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->translate (arg1, arg2);
 }
@@ -1267,7 +1267,7 @@ static void _call_f_translate_1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRect *)cls)->translate (arg1);
 }
@@ -1289,8 +1289,8 @@ static void _call_f_translated_c1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRect > ((QRect)((QRect *)cls)->translated (arg1, arg2));
 }
 
@@ -1309,7 +1309,7 @@ static void _call_f_translated_c1916 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QRect > ((QRect)((QRect *)cls)->translated (arg1));
 }
 
@@ -1328,7 +1328,7 @@ static void _call_f_unite_c1792 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QRect *)cls)->unite (arg1));
 }
 
@@ -1347,7 +1347,7 @@ static void _call_f_united_c1792 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QRect *)cls)->united (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQRectF.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQRectF.cc
@@ -70,8 +70,8 @@ static void _call_ctor_QRectF_3753 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QSizeF &arg2 = args.read<const QSizeF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QSizeF &arg2 = gsi::arg_reader<const QSizeF & >() (args, heap);
   ret.write<QRectF *> (new QRectF (arg1, arg2));
 }
 
@@ -92,8 +92,8 @@ static void _call_ctor_QRectF_3864 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QRectF *> (new QRectF (arg1, arg2));
 }
 
@@ -118,10 +118,10 @@ static void _call_ctor_QRectF_3960 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRectF *> (new QRectF (arg1, arg2, arg3, arg4));
 }
 
@@ -140,7 +140,7 @@ static void _call_ctor_QRectF_1792 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRectF *> (new QRectF (arg1));
 }
 
@@ -165,10 +165,10 @@ static void _call_f_adjust_3960 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->adjust (arg1, arg2, arg3, arg4);
 }
@@ -194,10 +194,10 @@ static void _call_f_adjusted_c3960 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRectF > ((QRectF)((QRectF *)cls)->adjusted (arg1, arg2, arg3, arg4));
 }
 
@@ -276,7 +276,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QRectF *)cls)->contains (arg1));
 }
 
@@ -297,8 +297,8 @@ static void _call_f_contains_c2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<bool > ((bool)((QRectF *)cls)->contains (arg1, arg2));
 }
 
@@ -317,7 +317,7 @@ static void _call_f_contains_c1862 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<bool > ((bool)((QRectF *)cls)->contains (arg1));
 }
 
@@ -342,10 +342,10 @@ static void _call_f_getCoords_c4704 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->getCoords (arg1, arg2, arg3, arg4);
 }
@@ -371,10 +371,10 @@ static void _call_f_getRect_c4704 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->getRect (arg1, arg2, arg3, arg4);
 }
@@ -409,7 +409,7 @@ static void _call_f_intersect_c1862 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QRectF *)cls)->intersect (arg1));
 }
 
@@ -428,7 +428,7 @@ static void _call_f_intersected_c1862 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QRectF *)cls)->intersected (arg1));
 }
 
@@ -447,7 +447,7 @@ static void _call_f_intersects_c1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<bool > ((bool)((QRectF *)cls)->intersects (arg1));
 }
 
@@ -526,7 +526,7 @@ static void _call_f_moveBottom_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveBottom (arg1);
 }
@@ -546,7 +546,7 @@ static void _call_f_moveBottomLeft_1986 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveBottomLeft (arg1);
 }
@@ -566,7 +566,7 @@ static void _call_f_moveBottomRight_1986 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveBottomRight (arg1);
 }
@@ -586,7 +586,7 @@ static void _call_f_moveCenter_1986 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveCenter (arg1);
 }
@@ -606,7 +606,7 @@ static void _call_f_moveLeft_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveLeft (arg1);
 }
@@ -626,7 +626,7 @@ static void _call_f_moveRight_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveRight (arg1);
 }
@@ -648,8 +648,8 @@ static void _call_f_moveTo_2034 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveTo (arg1, arg2);
 }
@@ -669,7 +669,7 @@ static void _call_f_moveTo_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveTo (arg1);
 }
@@ -689,7 +689,7 @@ static void _call_f_moveTop_1071 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveTop (arg1);
 }
@@ -709,7 +709,7 @@ static void _call_f_moveTopLeft_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveTopLeft (arg1);
 }
@@ -729,7 +729,7 @@ static void _call_f_moveTopRight_1986 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->moveTopRight (arg1);
 }
@@ -764,7 +764,7 @@ static void _call_f_operator_amp__c1862 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QRectF *)cls)->operator& (arg1));
 }
 
@@ -783,7 +783,7 @@ static void _call_f_operator_amp__eq__1862 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF & > ((QRectF &)((QRectF *)cls)->operator&= (arg1));
 }
 
@@ -802,7 +802,7 @@ static void _call_f_operator_pipe__c1862 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QRectF *)cls)->operator| (arg1));
 }
 
@@ -821,7 +821,7 @@ static void _call_f_operator_pipe__eq__1862 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF & > ((QRectF &)((QRectF *)cls)->operator|= (arg1));
 }
 
@@ -855,7 +855,7 @@ static void _call_f_setBottom_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setBottom (arg1);
 }
@@ -875,7 +875,7 @@ static void _call_f_setBottomLeft_1986 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setBottomLeft (arg1);
 }
@@ -895,7 +895,7 @@ static void _call_f_setBottomRight_1986 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setBottomRight (arg1);
 }
@@ -921,10 +921,10 @@ static void _call_f_setCoords_3960 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setCoords (arg1, arg2, arg3, arg4);
 }
@@ -944,7 +944,7 @@ static void _call_f_setHeight_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setHeight (arg1);
 }
@@ -964,7 +964,7 @@ static void _call_f_setLeft_1071 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setLeft (arg1);
 }
@@ -990,10 +990,10 @@ static void _call_f_setRect_3960 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setRect (arg1, arg2, arg3, arg4);
 }
@@ -1013,7 +1013,7 @@ static void _call_f_setRight_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setRight (arg1);
 }
@@ -1033,7 +1033,7 @@ static void _call_f_setSize_1875 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setSize (arg1);
 }
@@ -1053,7 +1053,7 @@ static void _call_f_setTop_1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setTop (arg1);
 }
@@ -1073,7 +1073,7 @@ static void _call_f_setTopLeft_1986 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setTopLeft (arg1);
 }
@@ -1093,7 +1093,7 @@ static void _call_f_setTopRight_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setTopRight (arg1);
 }
@@ -1113,7 +1113,7 @@ static void _call_f_setWidth_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setWidth (arg1);
 }
@@ -1133,7 +1133,7 @@ static void _call_f_setX_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setX (arg1);
 }
@@ -1153,7 +1153,7 @@ static void _call_f_setY_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->setY (arg1);
 }
@@ -1265,8 +1265,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->translate (arg1, arg2);
 }
@@ -1286,7 +1286,7 @@ static void _call_f_translate_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRectF *)cls)->translate (arg1);
 }
@@ -1308,8 +1308,8 @@ static void _call_f_translated_c2034 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRectF > ((QRectF)((QRectF *)cls)->translated (arg1, arg2));
 }
 
@@ -1328,7 +1328,7 @@ static void _call_f_translated_c1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QRectF *)cls)->translated (arg1));
 }
 
@@ -1347,7 +1347,7 @@ static void _call_f_unite_c1862 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QRectF *)cls)->unite (arg1));
 }
 
@@ -1366,7 +1366,7 @@ static void _call_f_united_c1862 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QRectF *)cls)->united (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQRegExp.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQRegExp.cc
@@ -69,9 +69,9 @@ static void _call_ctor_QRegExp_6734 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CaseSensitivity>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CaseSensitivity>(heap, Qt::CaseSensitive));
-  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & > (heap) : (const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type &)(qt_gsi::CppToQtReadAdaptor<QRegExp::PatternSyntax>(heap, QRegExp::RegExp));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CaseSensitivity>(heap, Qt::CaseSensitive), heap);
+  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QRegExp::PatternSyntax>(heap, QRegExp::RegExp), heap);
   ret.write<QRegExp *> (new QRegExp (arg1, qt_gsi::QtToCppAdaptor<Qt::CaseSensitivity>(arg2).cref(), qt_gsi::QtToCppAdaptor<QRegExp::PatternSyntax>(arg3).cref()));
 }
 
@@ -90,7 +90,7 @@ static void _call_ctor_QRegExp_1981 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegExp &arg1 = args.read<const QRegExp & > (heap);
+  const QRegExp &arg1 = gsi::arg_reader<const QRegExp & >() (args, heap);
   ret.write<QRegExp *> (new QRegExp (arg1));
 }
 
@@ -109,7 +109,7 @@ static void _call_f_cap_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QString > ((QString)((QRegExp *)cls)->cap (arg1));
 }
 
@@ -128,7 +128,7 @@ static void _call_f_cap_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QString > ((QString)((QRegExp *)cls)->cap (arg1));
 }
 
@@ -237,7 +237,7 @@ static void _call_f_exactMatch_c2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QRegExp *)cls)->exactMatch (arg1));
 }
 
@@ -260,9 +260,9 @@ static void _call_f_indexIn_c4680 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  const qt_gsi::Converter<QRegExp::CaretMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QRegExp::CaretMode>::target_type & > (heap) : (const qt_gsi::Converter<QRegExp::CaretMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QRegExp::CaretMode>(heap, QRegExp::CaretAtZero));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  const qt_gsi::Converter<QRegExp::CaretMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QRegExp::CaretMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QRegExp::CaretMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QRegExp::CaretMode>(heap, QRegExp::CaretAtZero), heap);
   ret.write<int > ((int)((QRegExp *)cls)->indexIn (arg1, arg2, qt_gsi::QtToCppAdaptor<QRegExp::CaretMode>(arg3).cref()));
 }
 
@@ -330,9 +330,9 @@ static void _call_f_lastIndexIn_c4680 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(-1);
-  const qt_gsi::Converter<QRegExp::CaretMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QRegExp::CaretMode>::target_type & > (heap) : (const qt_gsi::Converter<QRegExp::CaretMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QRegExp::CaretMode>(heap, QRegExp::CaretAtZero));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  const qt_gsi::Converter<QRegExp::CaretMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QRegExp::CaretMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QRegExp::CaretMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QRegExp::CaretMode>(heap, QRegExp::CaretAtZero), heap);
   ret.write<int > ((int)((QRegExp *)cls)->lastIndexIn (arg1, arg2, qt_gsi::QtToCppAdaptor<QRegExp::CaretMode>(arg3).cref()));
 }
 
@@ -381,7 +381,7 @@ static void _call_f_operator_excl__eq__c1981 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegExp &arg1 = args.read<const QRegExp & > (heap);
+  const QRegExp &arg1 = gsi::arg_reader<const QRegExp & >() (args, heap);
   ret.write<bool > ((bool)((QRegExp *)cls)->operator!= (arg1));
 }
 
@@ -400,7 +400,7 @@ static void _call_f_operator_eq__1981 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegExp &arg1 = args.read<const QRegExp & > (heap);
+  const QRegExp &arg1 = gsi::arg_reader<const QRegExp & >() (args, heap);
   ret.write<QRegExp & > ((QRegExp &)((QRegExp *)cls)->operator= (arg1));
 }
 
@@ -419,7 +419,7 @@ static void _call_f_operator_eq__eq__c1981 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegExp &arg1 = args.read<const QRegExp & > (heap);
+  const QRegExp &arg1 = gsi::arg_reader<const QRegExp & >() (args, heap);
   ret.write<bool > ((bool)((QRegExp *)cls)->operator== (arg1));
 }
 
@@ -468,7 +468,7 @@ static void _call_f_pos_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<int > ((int)((QRegExp *)cls)->pos (arg1));
 }
 
@@ -487,7 +487,7 @@ static void _call_f_pos_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<int > ((int)((QRegExp *)cls)->pos (arg1));
 }
 
@@ -506,7 +506,7 @@ static void _call_f_setCaseSensitivity_2324 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRegExp *)cls)->setCaseSensitivity (qt_gsi::QtToCppAdaptor<Qt::CaseSensitivity>(arg1).cref());
 }
@@ -526,7 +526,7 @@ static void _call_f_setMinimal_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRegExp *)cls)->setMinimal (arg1);
 }
@@ -546,7 +546,7 @@ static void _call_f_setPattern_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRegExp *)cls)->setPattern (arg1);
 }
@@ -566,7 +566,7 @@ static void _call_f_setPatternSyntax_2601 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg1 = args.read<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & > (heap);
+  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRegExp *)cls)->setPatternSyntax (qt_gsi::QtToCppAdaptor<QRegExp::PatternSyntax>(arg1).cref());
 }
@@ -586,7 +586,7 @@ static void _call_f_escape_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QRegExp::escape (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQResource.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQResource.cc
@@ -53,8 +53,8 @@ static void _call_ctor_QResource_3903 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QLocale &arg2 = args ? args.read<const QLocale & > (heap) : (const QLocale &)(QLocale());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QLocale &arg2 = args ? gsi::arg_reader<const QLocale & >() (args, heap) : gsi::arg_maker<const QLocale & >() (QLocale(), heap);
   ret.write<QResource *> (new QResource (arg1, arg2));
 }
 
@@ -163,7 +163,7 @@ static void _call_f_setFileName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QResource *)cls)->setFileName (arg1);
 }
@@ -183,7 +183,7 @@ static void _call_f_setLocale_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLocale &arg1 = args.read<const QLocale & > (heap);
+  const QLocale &arg1 = gsi::arg_reader<const QLocale & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QResource *)cls)->setLocale (arg1);
 }
@@ -218,7 +218,7 @@ static void _call_f_addSearchPath_2025 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QResource::addSearchPath (arg1);
 }
@@ -240,8 +240,8 @@ static void _call_f_registerResource_3942 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)QResource::registerResource (arg1, arg2));
 }
 
@@ -262,8 +262,8 @@ static void _call_f_registerResource_4653 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const unsigned char *arg1 = args.read<const unsigned char * > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const unsigned char *arg1 = gsi::arg_reader<const unsigned char * >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)QResource::registerResource (arg1, arg2));
 }
 
@@ -299,8 +299,8 @@ static void _call_f_unregisterResource_3942 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)QResource::unregisterResource (arg1, arg2));
 }
 
@@ -321,8 +321,8 @@ static void _call_f_unregisterResource_4653 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const unsigned char *arg1 = args.read<const unsigned char * > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const unsigned char *arg1 = gsi::arg_reader<const unsigned char * >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)QResource::unregisterResource (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQSemaphore.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQSemaphore.cc
@@ -50,7 +50,7 @@ static void _call_ctor_QSemaphore_767 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QSemaphore *> (new QSemaphore (arg1));
 }
 
@@ -69,7 +69,7 @@ static void _call_f_acquire_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSemaphore *)cls)->acquire (arg1);
 }
@@ -104,7 +104,7 @@ static void _call_f_release_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSemaphore *)cls)->release (arg1);
 }
@@ -124,7 +124,7 @@ static void _call_f_tryAcquire_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   ret.write<bool > ((bool)((QSemaphore *)cls)->tryAcquire (arg1));
 }
 
@@ -145,8 +145,8 @@ static void _call_f_tryAcquire_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSemaphore *)cls)->tryAcquire (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQSettings.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQSettings.cc
@@ -98,7 +98,7 @@ static void _call_f_beginGroup_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSettings *)cls)->beginGroup (arg1);
 }
@@ -118,7 +118,7 @@ static void _call_f_beginReadArray_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QSettings *)cls)->beginReadArray (arg1));
 }
 
@@ -139,8 +139,8 @@ static void _call_f_beginWriteArray_2684 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(-1);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSettings *)cls)->beginWriteArray (arg1, arg2);
 }
@@ -206,7 +206,7 @@ static void _call_f_contains_c2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSettings *)cls)->contains (arg1));
 }
 
@@ -347,7 +347,7 @@ static void _call_f_remove_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSettings *)cls)->remove (arg1);
 }
@@ -382,7 +382,7 @@ static void _call_f_setArrayIndex_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSettings *)cls)->setArrayIndex (arg1);
 }
@@ -402,7 +402,7 @@ static void _call_f_setFallbacksEnabled_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSettings *)cls)->setFallbacksEnabled (arg1);
 }
@@ -424,8 +424,8 @@ static void _call_f_setValue_4036 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSettings *)cls)->setValue (arg1, arg2);
 }
@@ -478,8 +478,8 @@ static void _call_f_value_c4036 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QVariant &arg2 = args ? args.read<const QVariant & > (heap) : (const QVariant &)(QVariant());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg2 = args ? gsi::arg_reader<const QVariant & >() (args, heap) : gsi::arg_maker<const QVariant & >() (QVariant(), heap);
   ret.write<QVariant > ((QVariant)((QSettings *)cls)->value (arg1, arg2));
 }
 
@@ -513,7 +513,7 @@ static void _call_f_setDefaultFormat_2099 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSettings::Format>::target_type & arg1 = args.read<const qt_gsi::Converter<QSettings::Format>::target_type & > (heap);
+  const qt_gsi::Converter<QSettings::Format>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSettings::Format>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSettings::setDefaultFormat (qt_gsi::QtToCppAdaptor<QSettings::Format>(arg1).cref());
 }
@@ -537,9 +537,9 @@ static void _call_f_setPath_5896 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSettings::Format>::target_type & arg1 = args.read<const qt_gsi::Converter<QSettings::Format>::target_type & > (heap);
-  const qt_gsi::Converter<QSettings::Scope>::target_type & arg2 = args.read<const qt_gsi::Converter<QSettings::Scope>::target_type & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const qt_gsi::Converter<QSettings::Format>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSettings::Format>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSettings::Scope>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSettings::Scope>::target_type & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSettings::setPath (qt_gsi::QtToCppAdaptor<QSettings::Format>(arg1).cref(), qt_gsi::QtToCppAdaptor<QSettings::Scope>(arg2).cref(), arg3);
 }
@@ -559,7 +559,7 @@ static void _call_f_setSystemIniPath_2025 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSettings::setSystemIniPath (arg1);
 }
@@ -579,7 +579,7 @@ static void _call_f_setUserIniPath_2025 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSettings::setUserIniPath (arg1);
 }
@@ -601,8 +601,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSettings::tr (arg1, arg2));
 }
 
@@ -625,9 +625,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSettings::tr (arg1, arg2, arg3));
 }
 
@@ -648,8 +648,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSettings::trUtf8 (arg1, arg2));
 }
 
@@ -672,9 +672,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSettings::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -951,9 +951,9 @@ static void _call_ctor_QSettings_Adaptor_5136 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  QObject *arg3 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  QObject *arg3 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSettings_Adaptor *> (new QSettings_Adaptor (arg1, arg2, arg3));
 }
 
@@ -977,10 +977,10 @@ static void _call_ctor_QSettings_Adaptor_7016 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSettings::Scope>::target_type & arg1 = args.read<const qt_gsi::Converter<QSettings::Scope>::target_type & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  QObject *arg4 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const qt_gsi::Converter<QSettings::Scope>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSettings::Scope>::target_type & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  QObject *arg4 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSettings_Adaptor *> (new QSettings_Adaptor (qt_gsi::QtToCppAdaptor<QSettings::Scope>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -1006,11 +1006,11 @@ static void _call_ctor_QSettings_Adaptor_9007 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSettings::Format>::target_type & arg1 = args.read<const qt_gsi::Converter<QSettings::Format>::target_type & > (heap);
-  const qt_gsi::Converter<QSettings::Scope>::target_type & arg2 = args.read<const qt_gsi::Converter<QSettings::Scope>::target_type & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  QObject *arg5 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const qt_gsi::Converter<QSettings::Format>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSettings::Format>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSettings::Scope>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSettings::Scope>::target_type & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  QObject *arg5 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSettings_Adaptor *> (new QSettings_Adaptor (qt_gsi::QtToCppAdaptor<QSettings::Format>(arg1).cref(), qt_gsi::QtToCppAdaptor<QSettings::Scope>(arg2).cref(), arg3, arg4, arg5));
 }
 
@@ -1032,9 +1032,9 @@ static void _call_ctor_QSettings_Adaptor_5210 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSettings::Format>::target_type & arg2 = args.read<const qt_gsi::Converter<QSettings::Format>::target_type & > (heap);
-  QObject *arg3 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSettings::Format>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSettings::Format>::target_type & >() (args, heap);
+  QObject *arg3 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSettings_Adaptor *> (new QSettings_Adaptor (arg1, qt_gsi::QtToCppAdaptor<QSettings::Format>(arg2).cref(), arg3));
 }
 
@@ -1052,7 +1052,7 @@ static void _call_ctor_QSettings_Adaptor_1302 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSettings_Adaptor *> (new QSettings_Adaptor (arg1));
 }
 
@@ -1118,7 +1118,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSettings_Adaptor *)cls)->emitter_QSettings_destroyed_1302 (arg1);
 }
 
@@ -1209,7 +1209,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSettings_Adaptor *)cls)->fp_QSettings_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQSignalMapper.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQSignalMapper.cc
@@ -85,7 +85,7 @@ static void _call_f_map_1302 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSignalMapper *)cls)->map (arg1);
 }
@@ -105,7 +105,7 @@ static void _call_f_mapping_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QObject * > ((QObject *)((QSignalMapper *)cls)->mapping (arg1));
 }
 
@@ -124,7 +124,7 @@ static void _call_f_mapping_c2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QObject * > ((QObject *)((QSignalMapper *)cls)->mapping (arg1));
 }
 
@@ -143,7 +143,7 @@ static void _call_f_mapping_c1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QObject * > ((QObject *)((QSignalMapper *)cls)->mapping (arg1));
 }
 
@@ -162,7 +162,7 @@ static void _call_f_mapping_c1302 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QObject * > ((QObject *)((QSignalMapper *)cls)->mapping (arg1));
 }
 
@@ -181,7 +181,7 @@ static void _call_f_removeMappings_1302 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSignalMapper *)cls)->removeMappings (arg1);
 }
@@ -203,8 +203,8 @@ static void _call_f_setMapping_1961 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  int arg2 = args.read<int > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSignalMapper *)cls)->setMapping (arg1, arg2);
 }
@@ -226,8 +226,8 @@ static void _call_f_setMapping_3219 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSignalMapper *)cls)->setMapping (arg1, arg2);
 }
@@ -249,8 +249,8 @@ static void _call_f_setMapping_2509 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSignalMapper *)cls)->setMapping (arg1, arg2);
 }
@@ -272,8 +272,8 @@ static void _call_f_setMapping_2496 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSignalMapper *)cls)->setMapping (arg1, arg2);
 }
@@ -295,8 +295,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSignalMapper::tr (arg1, arg2));
 }
 
@@ -319,9 +319,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSignalMapper::tr (arg1, arg2, arg3));
 }
 
@@ -342,8 +342,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSignalMapper::trUtf8 (arg1, arg2));
 }
 
@@ -366,9 +366,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSignalMapper::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -584,7 +584,7 @@ static void _call_ctor_QSignalMapper_Adaptor_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSignalMapper_Adaptor *> (new QSignalMapper_Adaptor (arg1));
 }
 
@@ -650,7 +650,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSignalMapper_Adaptor *)cls)->emitter_QSignalMapper_destroyed_1302 (arg1);
 }
 
@@ -741,7 +741,7 @@ static void _call_emitter_mapped_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QSignalMapper_Adaptor *)cls)->emitter_QSignalMapper_mapped_767 (arg1);
 }
 
@@ -759,7 +759,7 @@ static void _call_emitter_mapped_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QSignalMapper_Adaptor *)cls)->emitter_QSignalMapper_mapped_2025 (arg1);
 }
 
@@ -777,7 +777,7 @@ static void _call_emitter_mapped_1315 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ((QSignalMapper_Adaptor *)cls)->emitter_QSignalMapper_mapped_1315 (arg1);
 }
 
@@ -795,7 +795,7 @@ static void _call_emitter_mapped_1302 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ((QSignalMapper_Adaptor *)cls)->emitter_QSignalMapper_mapped_1302 (arg1);
 }
 
@@ -813,7 +813,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSignalMapper_Adaptor *)cls)->fp_QSignalMapper_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQSize.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQSize.cc
@@ -67,8 +67,8 @@ static void _call_ctor_QSize_1426 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QSize *> (new QSize (arg1, arg2));
 }
 
@@ -87,7 +87,7 @@ static void _call_f_boundedTo_c1805 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QSize > ((QSize)((QSize *)cls)->boundedTo (arg1));
 }
 
@@ -106,7 +106,7 @@ static void _call_f_expandedTo_c1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QSize > ((QSize)((QSize *)cls)->expandedTo (arg1));
 }
 
@@ -185,7 +185,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QSize & > ((QSize &)((QSize *)cls)->operator*= (arg1));
 }
 
@@ -204,7 +204,7 @@ static void _call_f_operator_plus__eq__1805 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QSize & > ((QSize &)((QSize *)cls)->operator+= (arg1));
 }
 
@@ -223,7 +223,7 @@ static void _call_f_operator_minus__eq__1805 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QSize & > ((QSize &)((QSize *)cls)->operator-= (arg1));
 }
 
@@ -242,7 +242,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QSize & > ((QSize &)((QSize *)cls)->operator/= (arg1));
 }
 
@@ -295,9 +295,9 @@ static void _call_f_scale_3575 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSize *)cls)->scale (arg1, arg2, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg3).cref());
 }
@@ -319,8 +319,8 @@ static void _call_f_scale_3954 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSize *)cls)->scale (arg1, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg2).cref());
 }
@@ -340,7 +340,7 @@ static void _call_f_setHeight_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSize *)cls)->setHeight (arg1);
 }
@@ -360,7 +360,7 @@ static void _call_f_setWidth_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSize *)cls)->setWidth (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQSizeF.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQSizeF.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QSizeF_1805 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QSizeF *> (new QSizeF (arg1));
 }
 
@@ -87,8 +87,8 @@ static void _call_ctor_QSizeF_2034 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QSizeF *> (new QSizeF (arg1, arg2));
 }
 
@@ -107,7 +107,7 @@ static void _call_f_boundedTo_c1875 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   ret.write<QSizeF > ((QSizeF)((QSizeF *)cls)->boundedTo (arg1));
 }
 
@@ -126,7 +126,7 @@ static void _call_f_expandedTo_c1875 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   ret.write<QSizeF > ((QSizeF)((QSizeF *)cls)->expandedTo (arg1));
 }
 
@@ -205,7 +205,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QSizeF & > ((QSizeF &)((QSizeF *)cls)->operator*= (arg1));
 }
 
@@ -224,7 +224,7 @@ static void _call_f_operator_plus__eq__1875 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   ret.write<QSizeF & > ((QSizeF &)((QSizeF *)cls)->operator+= (arg1));
 }
 
@@ -243,7 +243,7 @@ static void _call_f_operator_minus__eq__1875 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   ret.write<QSizeF & > ((QSizeF &)((QSizeF *)cls)->operator-= (arg1));
 }
 
@@ -262,7 +262,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QSizeF & > ((QSizeF &)((QSizeF *)cls)->operator/= (arg1));
 }
 
@@ -315,9 +315,9 @@ static void _call_f_scale_4183 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizeF *)cls)->scale (arg1, arg2, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg3).cref());
 }
@@ -339,8 +339,8 @@ static void _call_f_scale_4024 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizeF *)cls)->scale (arg1, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg2).cref());
 }
@@ -360,7 +360,7 @@ static void _call_f_setHeight_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizeF *)cls)->setHeight (arg1);
 }
@@ -380,7 +380,7 @@ static void _call_f_setWidth_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizeF *)cls)->setWidth (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQSocketNotifier.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQSocketNotifier.cc
@@ -83,7 +83,7 @@ static void _call_f_setEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSocketNotifier *)cls)->setEnabled (arg1);
 }
@@ -135,8 +135,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSocketNotifier::tr (arg1, arg2));
 }
 
@@ -159,9 +159,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSocketNotifier::tr (arg1, arg2, arg3));
 }
 
@@ -182,8 +182,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSocketNotifier::trUtf8 (arg1, arg2));
 }
 
@@ -206,9 +206,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSocketNotifier::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -400,9 +400,9 @@ static void _call_ctor_QSocketNotifier_Adaptor_4353 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QSocketNotifier::Type>::target_type & arg2 = args.read<const qt_gsi::Converter<QSocketNotifier::Type>::target_type & > (heap);
-  QObject *arg3 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QSocketNotifier::Type>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSocketNotifier::Type>::target_type & >() (args, heap);
+  QObject *arg3 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSocketNotifier_Adaptor *> (new QSocketNotifier_Adaptor (arg1, qt_gsi::QtToCppAdaptor<QSocketNotifier::Type>(arg2).cref(), arg3));
 }
 
@@ -420,7 +420,7 @@ static void _call_emitter_activated_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QSocketNotifier_Adaptor *)cls)->emitter_QSocketNotifier_activated_767 (arg1);
 }
 
@@ -486,7 +486,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSocketNotifier_Adaptor *)cls)->emitter_QSocketNotifier_destroyed_1302 (arg1);
 }
 
@@ -577,7 +577,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSocketNotifier_Adaptor *)cls)->fp_QSocketNotifier_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQStringMatcher.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQStringMatcher.cc
@@ -67,8 +67,8 @@ static void _call_ctor_QStringMatcher_4241 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CaseSensitivity>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CaseSensitivity>(heap, Qt::CaseSensitive));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CaseSensitivity>(heap, Qt::CaseSensitive), heap);
   ret.write<QStringMatcher *> (new QStringMatcher (arg1, qt_gsi::QtToCppAdaptor<Qt::CaseSensitivity>(arg2).cref()));
 }
 
@@ -87,7 +87,7 @@ static void _call_ctor_QStringMatcher_2733 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringMatcher &arg1 = args.read<const QStringMatcher & > (heap);
+  const QStringMatcher &arg1 = gsi::arg_reader<const QStringMatcher & >() (args, heap);
   ret.write<QStringMatcher *> (new QStringMatcher (arg1));
 }
 
@@ -123,8 +123,8 @@ static void _call_f_indexIn_c2684 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<int > ((int)((QStringMatcher *)cls)->indexIn (arg1, arg2));
 }
 
@@ -143,7 +143,7 @@ static void _call_f_operator_eq__2733 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringMatcher &arg1 = args.read<const QStringMatcher & > (heap);
+  const QStringMatcher &arg1 = gsi::arg_reader<const QStringMatcher & >() (args, heap);
   ret.write<QStringMatcher & > ((QStringMatcher &)((QStringMatcher *)cls)->operator= (arg1));
 }
 
@@ -177,7 +177,7 @@ static void _call_f_setCaseSensitivity_2324 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringMatcher *)cls)->setCaseSensitivity (qt_gsi::QtToCppAdaptor<Qt::CaseSensitivity>(arg1).cref());
 }
@@ -197,7 +197,7 @@ static void _call_f_setPattern_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringMatcher *)cls)->setPattern (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQSystemLocale.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQSystemLocale.cc
@@ -68,8 +68,8 @@ static void _call_f_query_c3956 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSystemLocale::QueryType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSystemLocale::QueryType>::target_type & > (heap);
-  QVariant arg2 = args.read<QVariant > (heap);
+  const qt_gsi::Converter<QSystemLocale::QueryType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSystemLocale::QueryType>::target_type & >() (args, heap);
+  QVariant arg2 = gsi::arg_reader<QVariant >() (args, heap);
   ret.write<QVariant > ((QVariant)((QSystemLocale *)cls)->query (qt_gsi::QtToCppAdaptor<QSystemLocale::QueryType>(arg1).cref(), arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTemporaryFile.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTemporaryFile.cc
@@ -82,7 +82,7 @@ static void _call_ctor_QTemporaryFile_2025 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QTemporaryFile *> (new QTemporaryFile (arg1));
 }
 
@@ -101,7 +101,7 @@ static void _call_ctor_QTemporaryFile_1302 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QTemporaryFile *> (new QTemporaryFile (arg1));
 }
 
@@ -122,8 +122,8 @@ static void _call_ctor_QTemporaryFile_3219 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QTemporaryFile *> (new QTemporaryFile (arg1, arg2));
 }
 
@@ -202,7 +202,7 @@ static void _call_f_setAutoRemove_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTemporaryFile *)cls)->setAutoRemove (arg1);
 }
@@ -222,7 +222,7 @@ static void _call_f_setFileTemplate_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTemporaryFile *)cls)->setFileTemplate (arg1);
 }
@@ -242,7 +242,7 @@ static void _call_f_createLocalFile_2025 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QTemporaryFile * > ((QTemporaryFile *)QTemporaryFile::createLocalFile (arg1));
 }
 
@@ -261,7 +261,7 @@ static void _call_f_createLocalFile_1083 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFile &arg1 = args.read<QFile & > (heap);
+  QFile &arg1 = gsi::arg_reader<QFile & >() (args, heap);
   ret.write<QTemporaryFile * > ((QTemporaryFile *)QTemporaryFile::createLocalFile (arg1));
 }
 
@@ -282,8 +282,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTemporaryFile::tr (arg1, arg2));
 }
 
@@ -306,9 +306,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTemporaryFile::tr (arg1, arg2, arg3));
 }
 
@@ -329,8 +329,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTemporaryFile::trUtf8 (arg1, arg2));
 }
 
@@ -353,9 +353,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTemporaryFile::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTextCodec.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTextCodec.cc
@@ -67,7 +67,7 @@ static void _call_f_canEncode_c899 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QTextCodec *)cls)->canEncode (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 
@@ -86,7 +86,7 @@ static void _call_f_canEncode_c2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QTextCodec *)cls)->canEncode (arg1));
 }
 
@@ -105,7 +105,7 @@ static void _call_f_fromUnicode_c2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QTextCodec *)cls)->fromUnicode (arg1));
 }
 
@@ -184,7 +184,7 @@ static void _call_f_toUnicode_c1731 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QString > ((QString)((QTextCodec *)cls)->toUnicode (arg1));
 }
 
@@ -207,9 +207,9 @@ static void _call_f_toUnicode_c5465 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  int arg2 = args.read<int > (heap);
-  QTextCodec::ConverterState *arg3 = args ? args.read<QTextCodec::ConverterState * > (heap) : (QTextCodec::ConverterState *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QTextCodec::ConverterState *arg3 = args ? gsi::arg_reader<QTextCodec::ConverterState * >() (args, heap) : gsi::arg_maker<QTextCodec::ConverterState * >() (0, heap);
   ret.write<QString > ((QString)((QTextCodec *)cls)->toUnicode (arg1, arg2, arg3));
 }
 
@@ -273,7 +273,7 @@ static void _call_f_codecForHtml_2309 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QTextCodec * > ((QTextCodec *)QTextCodec::codecForHtml (arg1));
 }
 
@@ -294,8 +294,8 @@ static void _call_f_codecForHtml_3803 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  QTextCodec *arg2 = args.read<QTextCodec * > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  QTextCodec *arg2 = gsi::arg_reader<QTextCodec * >() (args, heap);
   ret.write<QTextCodec * > ((QTextCodec *)QTextCodec::codecForHtml (arg1, arg2));
 }
 
@@ -329,7 +329,7 @@ static void _call_f_codecForMib_767 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextCodec * > ((QTextCodec *)QTextCodec::codecForMib (arg1));
 }
 
@@ -348,7 +348,7 @@ static void _call_f_codecForName_1731 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QTextCodec * > ((QTextCodec *)QTextCodec::codecForName (arg1));
 }
 
@@ -382,7 +382,7 @@ static void _call_f_codecForUtfText_2309 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QTextCodec * > ((QTextCodec *)QTextCodec::codecForUtfText (arg1));
 }
 
@@ -403,8 +403,8 @@ static void _call_f_codecForUtfText_3803 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  QTextCodec *arg2 = args.read<QTextCodec * > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  QTextCodec *arg2 = gsi::arg_reader<QTextCodec * >() (args, heap);
   ret.write<QTextCodec * > ((QTextCodec *)QTextCodec::codecForUtfText (arg1, arg2));
 }
 
@@ -423,7 +423,7 @@ static void _call_f_setCodecForCStrings_1602 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextCodec *arg1 = args.read<QTextCodec * > (heap);
+  QTextCodec *arg1 = gsi::arg_reader<QTextCodec * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QTextCodec::setCodecForCStrings (arg1);
 }
@@ -443,7 +443,7 @@ static void _call_f_setCodecForLocale_1602 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextCodec *arg1 = args.read<QTextCodec * > (heap);
+  QTextCodec *arg1 = gsi::arg_reader<QTextCodec * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QTextCodec::setCodecForLocale (arg1);
 }
@@ -463,7 +463,7 @@ static void _call_f_setCodecForTr_1602 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextCodec *arg1 = args.read<QTextCodec * > (heap);
+  QTextCodec *arg1 = gsi::arg_reader<QTextCodec * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QTextCodec::setCodecForTr (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTextCodec_ConverterState.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTextCodec_ConverterState.cc
@@ -50,7 +50,7 @@ static void _call_ctor_QTextCodec_ConverterState_3668 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QTextCodec::ConversionFlag> arg1 = args ? args.read<QFlags<QTextCodec::ConversionFlag> > (heap) : (QFlags<QTextCodec::ConversionFlag>)(QTextCodec::DefaultConversion);
+  QFlags<QTextCodec::ConversionFlag> arg1 = args ? gsi::arg_reader<QFlags<QTextCodec::ConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<QTextCodec::ConversionFlag> >() (QTextCodec::DefaultConversion, heap);
   ret.write<QTextCodec::ConverterState *> (new QTextCodec::ConverterState (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTextDecoder.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTextDecoder.cc
@@ -51,7 +51,7 @@ static void _call_ctor_QTextDecoder_2297 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCodec *arg1 = args.read<const QTextCodec * > (heap);
+  const QTextCodec *arg1 = gsi::arg_reader<const QTextCodec * >() (args, heap);
   ret.write<QTextDecoder *> (new QTextDecoder (arg1));
 }
 
@@ -87,8 +87,8 @@ static void _call_f_toUnicode_2390 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  int arg2 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTextDecoder *)cls)->toUnicode (arg1, arg2));
 }
 
@@ -107,7 +107,7 @@ static void _call_f_toUnicode_2309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QString > ((QString)((QTextDecoder *)cls)->toUnicode (arg1));
 }
 
@@ -130,9 +130,9 @@ static void _call_f_toUnicode_3616 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString *arg1 = args.read<QString * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  QString *arg1 = gsi::arg_reader<QString * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDecoder *)cls)->toUnicode (arg1, arg2, arg3);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTextEncoder.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTextEncoder.cc
@@ -51,7 +51,7 @@ static void _call_ctor_QTextEncoder_2297 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCodec *arg1 = args.read<const QTextCodec * > (heap);
+  const QTextCodec *arg1 = gsi::arg_reader<const QTextCodec * >() (args, heap);
   ret.write<QTextEncoder *> (new QTextEncoder (arg1));
 }
 
@@ -70,7 +70,7 @@ static void _call_f_fromUnicode_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QTextEncoder *)cls)->fromUnicode (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTextStream.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTextStream.cc
@@ -394,7 +394,7 @@ static void _call_f_read_986 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<QString > ((QString)((QTextStream *)cls)->read (arg1));
 }
 
@@ -428,7 +428,7 @@ static void _call_f_readLine_986 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args ? args.read<qint64 > (heap) : (qint64)(0);
+  qint64 arg1 = args ? gsi::arg_reader<qint64 >() (args, heap) : gsi::arg_maker<qint64 >() (0, heap);
   ret.write<QString > ((QString)((QTextStream *)cls)->readLine (arg1));
 }
 
@@ -509,7 +509,7 @@ static void _call_f_seek_986 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   ret.write<bool > ((bool)((QTextStream *)cls)->seek (arg1));
 }
 
@@ -528,7 +528,7 @@ static void _call_f_setAutoDetectUnicode_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setAutoDetectUnicode (arg1);
 }
@@ -548,7 +548,7 @@ static void _call_f_setCodec_1602 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextCodec *arg1 = args.read<QTextCodec * > (heap);
+  QTextCodec *arg1 = gsi::arg_reader<QTextCodec * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setCodec (arg1);
 }
@@ -568,7 +568,7 @@ static void _call_f_setCodec_1731 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setCodec (arg1);
 }
@@ -588,7 +588,7 @@ static void _call_f_setDevice_1447 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setDevice (arg1);
 }
@@ -608,7 +608,7 @@ static void _call_f_setFieldAlignment_3085 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextStream::FieldAlignment>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextStream::FieldAlignment>::target_type & > (heap);
+  const qt_gsi::Converter<QTextStream::FieldAlignment>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextStream::FieldAlignment>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setFieldAlignment (qt_gsi::QtToCppAdaptor<QTextStream::FieldAlignment>(arg1).cref());
 }
@@ -628,7 +628,7 @@ static void _call_f_setFieldWidth_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setFieldWidth (arg1);
 }
@@ -648,7 +648,7 @@ static void _call_f_setGenerateByteOrderMark_864 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setGenerateByteOrderMark (arg1);
 }
@@ -668,7 +668,7 @@ static void _call_f_setIntegerBase_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setIntegerBase (arg1);
 }
@@ -688,7 +688,7 @@ static void _call_f_setLocale_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLocale &arg1 = args.read<const QLocale & > (heap);
+  const QLocale &arg1 = gsi::arg_reader<const QLocale & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setLocale (arg1);
 }
@@ -708,7 +708,7 @@ static void _call_f_setNumberFlags_3365 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QTextStream::NumberFlag> arg1 = args.read<QFlags<QTextStream::NumberFlag> > (heap);
+  QFlags<QTextStream::NumberFlag> arg1 = gsi::arg_reader<QFlags<QTextStream::NumberFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setNumberFlags (arg1);
 }
@@ -728,7 +728,7 @@ static void _call_f_setPadChar_899 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setPadChar (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref());
 }
@@ -748,7 +748,7 @@ static void _call_f_setRealNumberNotation_3523 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextStream::RealNumberNotation>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextStream::RealNumberNotation>::target_type & > (heap);
+  const qt_gsi::Converter<QTextStream::RealNumberNotation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextStream::RealNumberNotation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setRealNumberNotation (qt_gsi::QtToCppAdaptor<QTextStream::RealNumberNotation>(arg1).cref());
 }
@@ -768,7 +768,7 @@ static void _call_f_setRealNumberPrecision_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setRealNumberPrecision (arg1);
 }
@@ -788,7 +788,7 @@ static void _call_f_setStatus_2318 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextStream::Status>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextStream::Status>::target_type & > (heap);
+  const qt_gsi::Converter<QTextStream::Status>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextStream::Status>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setStatus (qt_gsi::QtToCppAdaptor<QTextStream::Status>(arg1).cref());
 }
@@ -810,8 +810,8 @@ static void _call_f_setString_4468 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString *arg1 = args.read<QString * > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg2 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  QString *arg1 = gsi::arg_reader<QString * >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg2 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextStream *)cls)->setString (arg1, arg2);
 }
@@ -1004,7 +1004,7 @@ static void _call_ctor_QTextStream_Adaptor_1447 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   ret.write<QTextStream_Adaptor *> (new QTextStream_Adaptor (arg1));
 }
 
@@ -1024,8 +1024,8 @@ static void _call_ctor_QTextStream_Adaptor_4468 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString *arg1 = args.read<QString * > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg2 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  QString *arg1 = gsi::arg_reader<QString * >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg2 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   ret.write<QTextStream_Adaptor *> (new QTextStream_Adaptor (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQThread.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQThread.cc
@@ -67,7 +67,7 @@ static void _call_f_exit_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QThread *)cls)->exit (arg1);
 }
@@ -148,7 +148,7 @@ static void _call_f_setPriority_2099 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QThread::Priority>::target_type & arg1 = args.read<const qt_gsi::Converter<QThread::Priority>::target_type & > (heap);
+  const qt_gsi::Converter<QThread::Priority>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QThread::Priority>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QThread *)cls)->setPriority (qt_gsi::QtToCppAdaptor<QThread::Priority>(arg1).cref());
 }
@@ -168,7 +168,7 @@ static void _call_f_setStackSize_1772 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QThread *)cls)->setStackSize (arg1);
 }
@@ -203,7 +203,7 @@ static void _call_f_start_2099 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QThread::Priority>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QThread::Priority>::target_type & > (heap) : (const qt_gsi::Converter<QThread::Priority>::target_type &)(qt_gsi::CppToQtReadAdaptor<QThread::Priority>(heap, QThread::InheritPriority));
+  const qt_gsi::Converter<QThread::Priority>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QThread::Priority>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QThread::Priority>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QThread::Priority>(heap, QThread::InheritPriority), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QThread *)cls)->start (qt_gsi::QtToCppAdaptor<QThread::Priority>(arg1).cref());
 }
@@ -239,7 +239,7 @@ static void _call_f_wait_2348 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned long int arg1 = args ? args.read<unsigned long int > (heap) : (unsigned long int)(ULONG_MAX);
+  unsigned long int arg1 = args ? gsi::arg_reader<unsigned long int >() (args, heap) : gsi::arg_maker<unsigned long int >() (ULONG_MAX, heap);
   ret.write<bool > ((bool)((QThread *)cls)->wait (arg1));
 }
 
@@ -305,8 +305,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QThread::tr (arg1, arg2));
 }
 
@@ -329,9 +329,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QThread::tr (arg1, arg2, arg3));
 }
 
@@ -352,8 +352,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QThread::trUtf8 (arg1, arg2));
 }
 
@@ -376,9 +376,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QThread::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -648,7 +648,7 @@ static void _call_ctor_QThread_Adaptor_1302 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QThread_Adaptor *> (new QThread_Adaptor (arg1));
 }
 
@@ -714,7 +714,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QThread_Adaptor *)cls)->emitter_QThread_destroyed_1302 (arg1);
 }
 
@@ -833,7 +833,7 @@ static void _call_fp_msleep_2348 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned long int arg1 = args.read<unsigned long int > (heap);
+  unsigned long int arg1 = gsi::arg_reader<unsigned long int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QThread_Adaptor::fp_QThread_msleep_2348 (arg1);
 }
@@ -852,7 +852,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QThread_Adaptor *)cls)->fp_QThread_receivers_c1731 (arg1));
 }
 
@@ -904,7 +904,7 @@ static void _call_fp_setTerminationEnabled_864 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QThread_Adaptor::fp_QThread_setTerminationEnabled_864 (arg1);
 }
@@ -923,7 +923,7 @@ static void _call_fp_sleep_2348 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned long int arg1 = args.read<unsigned long int > (heap);
+  unsigned long int arg1 = gsi::arg_reader<unsigned long int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QThread_Adaptor::fp_QThread_sleep_2348 (arg1);
 }
@@ -994,7 +994,7 @@ static void _call_fp_usleep_2348 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned long int arg1 = args.read<unsigned long int > (heap);
+  unsigned long int arg1 = gsi::arg_reader<unsigned long int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QThread_Adaptor::fp_QThread_usleep_2348 (arg1);
 }

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTime.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTime.cc
@@ -71,10 +71,10 @@ static void _call_ctor_QTime_2744 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QTime *> (new QTime (arg1, arg2, arg3, arg4));
 }
 
@@ -93,7 +93,7 @@ static void _call_f_addMSecs_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTime > ((QTime)((QTime *)cls)->addMSecs (arg1));
 }
 
@@ -112,7 +112,7 @@ static void _call_f_addSecs_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTime > ((QTime)((QTime *)cls)->addSecs (arg1));
 }
 
@@ -221,7 +221,7 @@ static void _call_f_msecsTo_c1793 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ret.write<int > ((int)((QTime *)cls)->msecsTo (arg1));
 }
 
@@ -240,7 +240,7 @@ static void _call_f_operator_excl__eq__c1793 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ret.write<bool > ((bool)((QTime *)cls)->operator!= (arg1));
 }
 
@@ -259,7 +259,7 @@ static void _call_f_operator_lt__c1793 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ret.write<bool > ((bool)((QTime *)cls)->operator< (arg1));
 }
 
@@ -278,7 +278,7 @@ static void _call_f_operator_lt__eq__c1793 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ret.write<bool > ((bool)((QTime *)cls)->operator<= (arg1));
 }
 
@@ -297,7 +297,7 @@ static void _call_f_operator_eq__eq__c1793 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ret.write<bool > ((bool)((QTime *)cls)->operator== (arg1));
 }
 
@@ -316,7 +316,7 @@ static void _call_f_operator_gt__c1793 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ret.write<bool > ((bool)((QTime *)cls)->operator> (arg1));
 }
 
@@ -335,7 +335,7 @@ static void _call_f_operator_gt__eq__c1793 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ret.write<bool > ((bool)((QTime *)cls)->operator>= (arg1));
 }
 
@@ -384,7 +384,7 @@ static void _call_f_secsTo_c1793 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ret.write<int > ((int)((QTime *)cls)->secsTo (arg1));
 }
 
@@ -409,10 +409,10 @@ static void _call_f_setHMS_2744 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<bool > ((bool)((QTime *)cls)->setHMS (arg1, arg2, arg3, arg4));
 }
 
@@ -447,7 +447,7 @@ static void _call_f_toString_c1748 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::DateFormat>::target_type & > (heap) : (const qt_gsi::Converter<Qt::DateFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate));
+  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate), heap);
   ret.write<QString > ((QString)((QTime *)cls)->toString (qt_gsi::QtToCppAdaptor<Qt::DateFormat>(arg1).cref()));
 }
 
@@ -466,7 +466,7 @@ static void _call_f_toString_c2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QTime *)cls)->toString (arg1));
 }
 
@@ -502,8 +502,8 @@ static void _call_f_fromString_3665 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::DateFormat>::target_type & > (heap) : (const qt_gsi::Converter<Qt::DateFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<Qt::DateFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::DateFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::DateFormat>(heap, Qt::TextDate), heap);
   ret.write<QTime > ((QTime)QTime::fromString (arg1, qt_gsi::QtToCppAdaptor<Qt::DateFormat>(arg2).cref()));
 }
 
@@ -524,8 +524,8 @@ static void _call_f_fromString_3942 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QTime > ((QTime)QTime::fromString (arg1, arg2));
 }
 
@@ -550,10 +550,10 @@ static void _call_f_isValid_2744 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<bool > ((bool)QTime::isValid (arg1, arg2, arg3, arg4));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTimeLine.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTimeLine.cc
@@ -189,7 +189,7 @@ static void _call_f_frameForTime_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTimeLine *)cls)->frameForTime (arg1));
 }
 
@@ -239,7 +239,7 @@ static void _call_f_setCurrentTime_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setCurrentTime (arg1);
 }
@@ -259,7 +259,7 @@ static void _call_f_setCurveShape_2438 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTimeLine::CurveShape>::target_type & arg1 = args.read<const qt_gsi::Converter<QTimeLine::CurveShape>::target_type & > (heap);
+  const qt_gsi::Converter<QTimeLine::CurveShape>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTimeLine::CurveShape>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setCurveShape (qt_gsi::QtToCppAdaptor<QTimeLine::CurveShape>(arg1).cref());
 }
@@ -279,7 +279,7 @@ static void _call_f_setDirection_2353 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTimeLine::Direction>::target_type & arg1 = args.read<const qt_gsi::Converter<QTimeLine::Direction>::target_type & > (heap);
+  const qt_gsi::Converter<QTimeLine::Direction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTimeLine::Direction>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setDirection (qt_gsi::QtToCppAdaptor<QTimeLine::Direction>(arg1).cref());
 }
@@ -299,7 +299,7 @@ static void _call_f_setDuration_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setDuration (arg1);
 }
@@ -319,7 +319,7 @@ static void _call_f_setEasingCurve_2510 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QEasingCurve &arg1 = args.read<const QEasingCurve & > (heap);
+  const QEasingCurve &arg1 = gsi::arg_reader<const QEasingCurve & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setEasingCurve (arg1);
 }
@@ -339,7 +339,7 @@ static void _call_f_setEndFrame_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setEndFrame (arg1);
 }
@@ -361,8 +361,8 @@ static void _call_f_setFrameRange_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setFrameRange (arg1, arg2);
 }
@@ -382,7 +382,7 @@ static void _call_f_setLoopCount_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setLoopCount (arg1);
 }
@@ -402,7 +402,7 @@ static void _call_f_setPaused_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setPaused (arg1);
 }
@@ -422,7 +422,7 @@ static void _call_f_setStartFrame_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setStartFrame (arg1);
 }
@@ -442,7 +442,7 @@ static void _call_f_setUpdateInterval_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeLine *)cls)->setUpdateInterval (arg1);
 }
@@ -555,7 +555,7 @@ static void _call_f_valueForTime_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QTimeLine *)cls)->valueForTime (arg1));
 }
 
@@ -576,8 +576,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTimeLine::tr (arg1, arg2));
 }
 
@@ -600,9 +600,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTimeLine::tr (arg1, arg2, arg3));
 }
 
@@ -623,8 +623,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTimeLine::trUtf8 (arg1, arg2));
 }
 
@@ -647,9 +647,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTimeLine::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -907,8 +907,8 @@ static void _call_ctor_QTimeLine_Adaptor_1961 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(1000);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1000, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTimeLine_Adaptor *> (new QTimeLine_Adaptor (arg1, arg2));
 }
 
@@ -974,7 +974,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTimeLine_Adaptor *)cls)->emitter_QTimeLine_destroyed_1302 (arg1);
 }
 
@@ -1079,7 +1079,7 @@ static void _call_emitter_frameChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QTimeLine_Adaptor *)cls)->emitter_QTimeLine_frameChanged_767 (arg1);
 }
 
@@ -1097,7 +1097,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTimeLine_Adaptor *)cls)->fp_QTimeLine_receivers_c1731 (arg1));
 }
 
@@ -1129,7 +1129,7 @@ static void _call_emitter_stateChanged_1937 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTimeLine::State>::target_type & arg1 = args.read<const qt_gsi::Converter<QTimeLine::State>::target_type & > (heap);
+  const qt_gsi::Converter<QTimeLine::State>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTimeLine::State>::target_type & >() (args, heap);
   ((QTimeLine_Adaptor *)cls)->emitter_QTimeLine_stateChanged_1937 (arg1);
 }
 
@@ -1171,7 +1171,7 @@ static void _call_emitter_valueChanged_1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ((QTimeLine_Adaptor *)cls)->emitter_QTimeLine_valueChanged_1071 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTimer.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTimer.cc
@@ -113,7 +113,7 @@ static void _call_f_setInterval_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimer *)cls)->setInterval (arg1);
 }
@@ -133,7 +133,7 @@ static void _call_f_setSingleShot_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimer *)cls)->setSingleShot (arg1);
 }
@@ -153,7 +153,7 @@ static void _call_f_start_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimer *)cls)->start (arg1);
 }
@@ -222,8 +222,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTimer::tr (arg1, arg2));
 }
 
@@ -246,9 +246,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTimer::tr (arg1, arg2, arg3));
 }
 
@@ -269,8 +269,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTimer::trUtf8 (arg1, arg2));
 }
 
@@ -293,9 +293,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTimer::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -488,7 +488,7 @@ static void _call_ctor_QTimer_Adaptor_1302 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTimer_Adaptor *> (new QTimer_Adaptor (arg1));
 }
 
@@ -554,7 +554,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTimer_Adaptor *)cls)->emitter_QTimer_destroyed_1302 (arg1);
 }
 
@@ -645,7 +645,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTimer_Adaptor *)cls)->fp_QTimer_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTimerEvent.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTimerEvent.cc
@@ -101,7 +101,7 @@ static void _call_ctor_QTimerEvent_Adaptor_767 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTimerEvent_Adaptor *> (new QTimerEvent_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQTranslator.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQTranslator.cc
@@ -89,10 +89,10 @@ static void _call_f_load_7776 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)((QTranslator *)cls)->load (arg1, arg2, arg3, arg4));
 }
 
@@ -113,8 +113,8 @@ static void _call_f_load_3395 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const unsigned char *arg1 = args.read<const unsigned char * > (heap);
-  int arg2 = args.read<int > (heap);
+  const unsigned char *arg1 = gsi::arg_reader<const unsigned char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTranslator *)cls)->load (arg1, arg2));
 }
 
@@ -137,9 +137,9 @@ static void _call_f_translate_c4977 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  const char *arg3 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg3 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)((QTranslator *)cls)->translate (arg1, arg2, arg3));
 }
 
@@ -164,10 +164,10 @@ static void _call_f_translate_c5636 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  const char *arg3 = args.read<const char * > (heap);
-  int arg4 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTranslator *)cls)->translate (arg1, arg2, arg3, arg4));
 }
 
@@ -188,8 +188,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTranslator::tr (arg1, arg2));
 }
 
@@ -212,9 +212,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTranslator::tr (arg1, arg2, arg3));
 }
 
@@ -235,8 +235,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTranslator::trUtf8 (arg1, arg2));
 }
 
@@ -259,9 +259,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTranslator::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -475,7 +475,7 @@ static void _call_ctor_QTranslator_Adaptor_1302 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTranslator_Adaptor *> (new QTranslator_Adaptor (arg1));
 }
 
@@ -541,7 +541,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTranslator_Adaptor *)cls)->emitter_QTranslator_destroyed_1302 (arg1);
 }
 
@@ -651,7 +651,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTranslator_Adaptor *)cls)->fp_QTranslator_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQUrl.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQUrl.cc
@@ -65,7 +65,7 @@ static void _call_ctor_QUrl_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QUrl *> (new QUrl (arg1));
 }
 
@@ -86,8 +86,8 @@ static void _call_ctor_QUrl_3970 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QUrl::ParsingMode>::target_type & arg2 = args.read<const qt_gsi::Converter<QUrl::ParsingMode>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QUrl::ParsingMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QUrl::ParsingMode>::target_type & >() (args, heap);
   ret.write<QUrl *> (new QUrl (arg1, qt_gsi::QtToCppAdaptor<QUrl::ParsingMode>(arg2).cref()));
 }
 
@@ -106,7 +106,7 @@ static void _call_ctor_QUrl_1701 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QUrl *> (new QUrl (arg1));
 }
 
@@ -127,8 +127,8 @@ static void _call_f_addEncodedQueryItem_4510 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const QByteArray &arg2 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const QByteArray &arg2 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->addEncodedQueryItem (arg1, arg2);
 }
@@ -150,8 +150,8 @@ static void _call_f_addQueryItem_3942 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->addQueryItem (arg1, arg2);
 }
@@ -171,7 +171,7 @@ static void _call_f_allEncodedQueryItemValues_c2309 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QList<QByteArray> > ((QList<QByteArray>)((QUrl *)cls)->allEncodedQueryItemValues (arg1));
 }
 
@@ -190,7 +190,7 @@ static void _call_f_allQueryItemValues_c2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStringList > ((QStringList)((QUrl *)cls)->allQueryItemValues (arg1));
 }
 
@@ -331,7 +331,7 @@ static void _call_f_encodedQueryItemValue_c2309 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QUrl *)cls)->encodedQueryItemValue (arg1));
 }
 
@@ -410,7 +410,7 @@ static void _call_f_hasEncodedQueryItem_c2309 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<bool > ((bool)((QUrl *)cls)->hasEncodedQueryItem (arg1));
 }
 
@@ -459,7 +459,7 @@ static void _call_f_hasQueryItem_c2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QUrl *)cls)->hasQueryItem (arg1));
 }
 
@@ -523,7 +523,7 @@ static void _call_f_isParentOf_c1701 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<bool > ((bool)((QUrl *)cls)->isParentOf (arg1));
 }
 
@@ -572,7 +572,7 @@ static void _call_f_operator_excl__eq__c1701 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<bool > ((bool)((QUrl *)cls)->operator != (arg1));
 }
 
@@ -591,7 +591,7 @@ static void _call_f_operator_lt__c1701 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<bool > ((bool)((QUrl *)cls)->operator < (arg1));
 }
 
@@ -610,7 +610,7 @@ static void _call_f_operator_eq__1701 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QUrl & > ((QUrl &)((QUrl *)cls)->operator = (arg1));
 }
 
@@ -629,7 +629,7 @@ static void _call_f_operator_eq__2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QUrl & > ((QUrl &)((QUrl *)cls)->operator = (arg1));
 }
 
@@ -648,7 +648,7 @@ static void _call_f_operator_eq__eq__c1701 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<bool > ((bool)((QUrl *)cls)->operator == (arg1));
 }
 
@@ -712,7 +712,7 @@ static void _call_f_port_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QUrl *)cls)->port (arg1));
 }
 
@@ -731,7 +731,7 @@ static void _call_f_queryItemValue_c2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QUrl *)cls)->queryItemValue (arg1));
 }
 
@@ -795,7 +795,7 @@ static void _call_f_removeAllEncodedQueryItems_2309 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->removeAllEncodedQueryItems (arg1);
 }
@@ -815,7 +815,7 @@ static void _call_f_removeAllQueryItems_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->removeAllQueryItems (arg1);
 }
@@ -835,7 +835,7 @@ static void _call_f_removeEncodedQueryItem_2309 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->removeEncodedQueryItem (arg1);
 }
@@ -855,7 +855,7 @@ static void _call_f_removeQueryItem_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->removeQueryItem (arg1);
 }
@@ -875,7 +875,7 @@ static void _call_f_resolved_c1701 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QUrl > ((QUrl)((QUrl *)cls)->resolved (arg1));
 }
 
@@ -909,7 +909,7 @@ static void _call_f_setAuthority_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setAuthority (arg1);
 }
@@ -929,7 +929,7 @@ static void _call_f_setEncodedFragment_2309 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setEncodedFragment (arg1);
 }
@@ -949,7 +949,7 @@ static void _call_f_setEncodedHost_2309 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setEncodedHost (arg1);
 }
@@ -969,7 +969,7 @@ static void _call_f_setEncodedPassword_2309 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setEncodedPassword (arg1);
 }
@@ -989,7 +989,7 @@ static void _call_f_setEncodedPath_2309 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setEncodedPath (arg1);
 }
@@ -1009,7 +1009,7 @@ static void _call_f_setEncodedQuery_2309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setEncodedQuery (arg1);
 }
@@ -1029,7 +1029,7 @@ static void _call_f_setEncodedQueryItems_4851 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QPair<QByteArray, QByteArray> > &arg1 = args.read<const QList<QPair<QByteArray, QByteArray> > & > (heap);
+  const QList<QPair<QByteArray, QByteArray> > &arg1 = gsi::arg_reader<const QList<QPair<QByteArray, QByteArray> > & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setEncodedQueryItems (arg1);
 }
@@ -1049,7 +1049,7 @@ static void _call_f_setEncodedUrl_2309 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setEncodedUrl (arg1);
 }
@@ -1071,8 +1071,8 @@ static void _call_f_setEncodedUrl_4254 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const qt_gsi::Converter<QUrl::ParsingMode>::target_type & arg2 = args.read<const qt_gsi::Converter<QUrl::ParsingMode>::target_type & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const qt_gsi::Converter<QUrl::ParsingMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QUrl::ParsingMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setEncodedUrl (arg1, qt_gsi::QtToCppAdaptor<QUrl::ParsingMode>(arg2).cref());
 }
@@ -1092,7 +1092,7 @@ static void _call_f_setEncodedUserName_2309 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setEncodedUserName (arg1);
 }
@@ -1112,7 +1112,7 @@ static void _call_f_setFragment_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setFragment (arg1);
 }
@@ -1132,7 +1132,7 @@ static void _call_f_setHost_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setHost (arg1);
 }
@@ -1152,7 +1152,7 @@ static void _call_f_setPassword_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setPassword (arg1);
 }
@@ -1172,7 +1172,7 @@ static void _call_f_setPath_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setPath (arg1);
 }
@@ -1192,7 +1192,7 @@ static void _call_f_setPort_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setPort (arg1);
 }
@@ -1214,8 +1214,8 @@ static void _call_f_setQueryDelimiters_1592 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  char arg1 = args.read<char > (heap);
-  char arg2 = args.read<char > (heap);
+  char arg1 = gsi::arg_reader<char >() (args, heap);
+  char arg2 = gsi::arg_reader<char >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setQueryDelimiters (arg1, arg2);
 }
@@ -1235,7 +1235,7 @@ static void _call_f_setQueryItems_4283 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QPair<QString, QString> > &arg1 = args.read<const QList<QPair<QString, QString> > & > (heap);
+  const QList<QPair<QString, QString> > &arg1 = gsi::arg_reader<const QList<QPair<QString, QString> > & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setQueryItems (arg1);
 }
@@ -1255,7 +1255,7 @@ static void _call_f_setScheme_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setScheme (arg1);
 }
@@ -1275,7 +1275,7 @@ static void _call_f_setUrl_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setUrl (arg1);
 }
@@ -1297,8 +1297,8 @@ static void _call_f_setUrl_3970 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QUrl::ParsingMode>::target_type & arg2 = args.read<const qt_gsi::Converter<QUrl::ParsingMode>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QUrl::ParsingMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QUrl::ParsingMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setUrl (arg1, qt_gsi::QtToCppAdaptor<QUrl::ParsingMode>(arg2).cref());
 }
@@ -1318,7 +1318,7 @@ static void _call_f_setUserInfo_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setUserInfo (arg1);
 }
@@ -1338,7 +1338,7 @@ static void _call_f_setUserName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrl *)cls)->setUserName (arg1);
 }
@@ -1358,7 +1358,7 @@ static void _call_f_toEncoded_c3320 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QUrl::FormattingOption> arg1 = args ? args.read<QFlags<QUrl::FormattingOption> > (heap) : (QFlags<QUrl::FormattingOption>)(QUrl::None);
+  QFlags<QUrl::FormattingOption> arg1 = args ? gsi::arg_reader<QFlags<QUrl::FormattingOption> >() (args, heap) : gsi::arg_maker<QFlags<QUrl::FormattingOption> >() (QUrl::None, heap);
   ret.write<QByteArray > ((QByteArray)((QUrl *)cls)->toEncoded (arg1));
 }
 
@@ -1392,7 +1392,7 @@ static void _call_f_toString_c3320 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QUrl::FormattingOption> arg1 = args ? args.read<QFlags<QUrl::FormattingOption> > (heap) : (QFlags<QUrl::FormattingOption>)(QUrl::None);
+  QFlags<QUrl::FormattingOption> arg1 = args ? gsi::arg_reader<QFlags<QUrl::FormattingOption> >() (args, heap) : gsi::arg_maker<QFlags<QUrl::FormattingOption> >() (QUrl::None, heap);
   ret.write<QString > ((QString)((QUrl *)cls)->toString (arg1));
 }
 
@@ -1441,7 +1441,7 @@ static void _call_f_fromAce_2309 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QString > ((QString)QUrl::fromAce (arg1));
 }
 
@@ -1460,7 +1460,7 @@ static void _call_f_fromEncoded_2309 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QUrl > ((QUrl)QUrl::fromEncoded (arg1));
 }
 
@@ -1481,8 +1481,8 @@ static void _call_f_fromEncoded_4254 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const qt_gsi::Converter<QUrl::ParsingMode>::target_type & arg2 = args.read<const qt_gsi::Converter<QUrl::ParsingMode>::target_type & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const qt_gsi::Converter<QUrl::ParsingMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QUrl::ParsingMode>::target_type & >() (args, heap);
   ret.write<QUrl > ((QUrl)QUrl::fromEncoded (arg1, qt_gsi::QtToCppAdaptor<QUrl::ParsingMode>(arg2).cref()));
 }
 
@@ -1501,7 +1501,7 @@ static void _call_f_fromLocalFile_2025 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QUrl > ((QUrl)QUrl::fromLocalFile (arg1));
 }
 
@@ -1520,7 +1520,7 @@ static void _call_f_fromPercentEncoding_2309 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QString > ((QString)QUrl::fromPercentEncoding (arg1));
 }
 
@@ -1539,7 +1539,7 @@ static void _call_f_fromPunycode_2309 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QString > ((QString)QUrl::fromPunycode (arg1));
 }
 
@@ -1558,7 +1558,7 @@ static void _call_f_fromUserInput_2025 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QUrl > ((QUrl)QUrl::fromUserInput (arg1));
 }
 
@@ -1592,7 +1592,7 @@ static void _call_f_setIdnWhitelist_2437 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QUrl::setIdnWhitelist (arg1);
 }
@@ -1612,7 +1612,7 @@ static void _call_f_toAce_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)QUrl::toAce (arg1));
 }
 
@@ -1635,9 +1635,9 @@ static void _call_f_toPercentEncoding_6427 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QByteArray &arg2 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
-  const QByteArray &arg3 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QByteArray &arg2 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
+  const QByteArray &arg3 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QByteArray > ((QByteArray)QUrl::toPercentEncoding (arg1, arg2, arg3));
 }
 
@@ -1656,7 +1656,7 @@ static void _call_f_toPunycode_2025 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)QUrl::toPunycode (arg1));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQWaitCondition.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQWaitCondition.cc
@@ -69,8 +69,8 @@ static void _call_f_wait_3474 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMutex *arg1 = args.read<QMutex * > (heap);
-  unsigned long int arg2 = args ? args.read<unsigned long int > (heap) : (unsigned long int)(ULONG_MAX);
+  QMutex *arg1 = gsi::arg_reader<QMutex * >() (args, heap);
+  unsigned long int arg2 = args ? gsi::arg_reader<unsigned long int >() (args, heap) : gsi::arg_maker<unsigned long int >() (ULONG_MAX, heap);
   ret.write<bool > ((bool)((QWaitCondition *)cls)->wait (arg1, arg2));
 }
 
@@ -91,8 +91,8 @@ static void _call_f_wait_4239 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QReadWriteLock *arg1 = args.read<QReadWriteLock * > (heap);
-  unsigned long int arg2 = args ? args.read<unsigned long int > (heap) : (unsigned long int)(ULONG_MAX);
+  QReadWriteLock *arg1 = gsi::arg_reader<QReadWriteLock * >() (args, heap);
+  unsigned long int arg2 = args ? gsi::arg_reader<unsigned long int >() (args, heap) : gsi::arg_maker<unsigned long int >() (ULONG_MAX, heap);
   ret.write<bool > ((bool)((QWaitCondition *)cls)->wait (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtCore/gsiDeclQWriteLocker.cc
+++ b/src/gsiqt/qt4/QtCore/gsiDeclQWriteLocker.cc
@@ -51,7 +51,7 @@ static void _call_ctor_QWriteLocker_1999 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QReadWriteLock *arg1 = args.read<QReadWriteLock * > (heap);
+  QReadWriteLock *arg1 = gsi::arg_reader<QReadWriteLock * >() (args, heap);
   ret.write<QWriteLocker *> (new QWriteLocker (arg1));
 }
 

--- a/src/gsiqt/qt4/QtDesigner/gsiDeclQAbstractFormBuilder.cc
+++ b/src/gsiqt/qt4/QtDesigner/gsiDeclQAbstractFormBuilder.cc
@@ -85,8 +85,8 @@ static void _call_f_load_2654 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QWidget * > ((QWidget *)((QAbstractFormBuilder *)cls)->load (arg1, arg2));
 }
 
@@ -107,8 +107,8 @@ static void _call_f_save_2654 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractFormBuilder *)cls)->save (arg1, arg2);
 }
@@ -128,7 +128,7 @@ static void _call_f_setScriptingEnabled_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractFormBuilder *)cls)->setScriptingEnabled (arg1);
 }
@@ -148,7 +148,7 @@ static void _call_f_setWorkingDirectory_1681 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDir &arg1 = args.read<const QDir & > (heap);
+  const QDir &arg1 = gsi::arg_reader<const QDir & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractFormBuilder *)cls)->setWorkingDirectory (arg1);
 }

--- a/src/gsiqt/qt4/QtDesigner/gsiDeclQFormBuilder.cc
+++ b/src/gsiqt/qt4/QtDesigner/gsiDeclQFormBuilder.cc
@@ -68,7 +68,7 @@ static void _call_f_addPluginPath_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormBuilder *)cls)->addPluginPath (arg1);
 }
@@ -119,7 +119,7 @@ static void _call_f_setPluginPath_2437 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormBuilder *)cls)->setPluginPath (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractButton.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractButton.cc
@@ -112,7 +112,7 @@ static void _call_f_animateClick_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(100);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (100, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->animateClick (arg1);
 }
@@ -298,7 +298,7 @@ static void _call_f_setAutoExclusive_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setAutoExclusive (arg1);
 }
@@ -318,7 +318,7 @@ static void _call_f_setAutoRepeat_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setAutoRepeat (arg1);
 }
@@ -338,7 +338,7 @@ static void _call_f_setAutoRepeatDelay_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setAutoRepeatDelay (arg1);
 }
@@ -358,7 +358,7 @@ static void _call_f_setAutoRepeatInterval_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setAutoRepeatInterval (arg1);
 }
@@ -378,7 +378,7 @@ static void _call_f_setCheckable_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setCheckable (arg1);
 }
@@ -398,7 +398,7 @@ static void _call_f_setChecked_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setChecked (arg1);
 }
@@ -418,7 +418,7 @@ static void _call_f_setDown_864 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setDown (arg1);
 }
@@ -438,7 +438,7 @@ static void _call_f_setIcon_1787 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setIcon (arg1);
 }
@@ -458,7 +458,7 @@ static void _call_f_setIconSize_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setIconSize (arg1);
 }
@@ -478,7 +478,7 @@ static void _call_f_setShortcut_2516 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setShortcut (arg1);
 }
@@ -498,7 +498,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton *)cls)->setText (arg1);
 }
@@ -566,8 +566,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractButton::tr (arg1, arg2));
 }
 
@@ -590,9 +590,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractButton::tr (arg1, arg2, arg3));
 }
 
@@ -613,8 +613,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractButton::trUtf8 (arg1, arg2));
 }
 
@@ -637,9 +637,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractButton::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1596,7 +1596,7 @@ static void _call_ctor_QAbstractButton_Adaptor_1315 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QAbstractButton_Adaptor *> (new QAbstractButton_Adaptor (arg1));
 }
 
@@ -1706,7 +1706,7 @@ static void _call_emitter_clicked_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ((QAbstractButton_Adaptor *)cls)->emitter_QAbstractButton_clicked_864 (arg1);
 }
 
@@ -1776,9 +1776,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton_Adaptor *)cls)->fp_QAbstractButton_create_2208 (arg1, arg2, arg3);
 }
@@ -1797,7 +1797,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QAbstractButton_Adaptor *)cls)->emitter_QAbstractButton_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1841,8 +1841,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractButton_Adaptor *)cls)->fp_QAbstractButton_destroy_1620 (arg1, arg2);
 }
@@ -1861,7 +1861,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractButton_Adaptor *)cls)->emitter_QAbstractButton_destroyed_1302 (arg1);
 }
 
@@ -2691,7 +2691,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractButton_Adaptor *)cls)->fp_QAbstractButton_receivers_c1731 (arg1));
 }
 
@@ -2915,7 +2915,7 @@ static void _call_emitter_toggled_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QAbstractButton_Adaptor *)cls)->emitter_QAbstractButton_toggled_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractGraphicsShapeItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractGraphicsShapeItem.cc
@@ -94,7 +94,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QAbstractGraphicsShapeItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -143,7 +143,7 @@ static void _call_f_setBrush_1910 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractGraphicsShapeItem *)cls)->setBrush (arg1);
 }
@@ -163,7 +163,7 @@ static void _call_f_setPen_1685 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPen &arg1 = args.read<const QPen & > (heap);
+  const QPen &arg1 = gsi::arg_reader<const QPen & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractGraphicsShapeItem *)cls)->setPen (arg1);
 }
@@ -815,8 +815,8 @@ static void _call_ctor_QAbstractGraphicsShapeItem_Adaptor_3825 (const qt_gsi::Ge
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QAbstractGraphicsShapeItem_Adaptor *> (new QAbstractGraphicsShapeItem_Adaptor (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractItemDelegate.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractItemDelegate.cc
@@ -81,9 +81,9 @@ static void _call_f_createEditor_c6860 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QAbstractItemDelegate *)cls)->createEditor (arg1, arg2, arg3));
 }
 
@@ -108,10 +108,10 @@ static void _call_f_editorEvent_9073 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
-  QAbstractItemModel *arg2 = args.read<QAbstractItemModel * > (heap);
-  const QStyleOptionViewItem &arg3 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
+  QAbstractItemModel *arg2 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
+  const QStyleOptionViewItem &arg3 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractItemDelegate *)cls)->editorEvent (arg1, arg2, arg3, arg4));
 }
 
@@ -136,10 +136,10 @@ static void _call_f_helpEvent_9380 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QHelpEvent *arg1 = args.read<QHelpEvent * > (heap);
-  QAbstractItemView *arg2 = args.read<QAbstractItemView * > (heap);
-  const QStyleOptionViewItem &arg3 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
+  QHelpEvent *arg1 = gsi::arg_reader<QHelpEvent * >() (args, heap);
+  QAbstractItemView *arg2 = gsi::arg_reader<QAbstractItemView * >() (args, heap);
+  const QStyleOptionViewItem &arg3 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractItemDelegate *)cls)->helpEvent (arg1, arg2, arg3, arg4));
 }
 
@@ -162,9 +162,9 @@ static void _call_f_paint_c6971 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemDelegate *)cls)->paint (arg1, arg2, arg3);
 }
@@ -186,8 +186,8 @@ static void _call_f_setEditorData_c3602 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemDelegate *)cls)->setEditorData (arg1, arg2);
 }
@@ -211,9 +211,9 @@ static void _call_f_setModelData_c5913 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QAbstractItemModel *arg2 = args.read<QAbstractItemModel * > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QAbstractItemModel *arg2 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemDelegate *)cls)->setModelData (arg1, arg2, arg3);
 }
@@ -235,8 +235,8 @@ static void _call_f_sizeHint_c5653 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QSize > ((QSize)((QAbstractItemDelegate *)cls)->sizeHint (arg1, arg2));
 }
 
@@ -259,9 +259,9 @@ static void _call_f_updateEditorGeometry_c6860 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemDelegate *)cls)->updateEditorGeometry (arg1, arg2, arg3);
 }
@@ -287,10 +287,10 @@ static void _call_f_elidedText_7038 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::TextElideMode>::target_type & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextElideMode>::target_type & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QAbstractItemDelegate::elidedText (arg1, arg2, qt_gsi::QtToCppAdaptor<Qt::TextElideMode>(arg3).cref(), arg4));
 }
 
@@ -311,8 +311,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractItemDelegate::tr (arg1, arg2));
 }
 
@@ -335,9 +335,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractItemDelegate::tr (arg1, arg2, arg3));
 }
 
@@ -358,8 +358,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractItemDelegate::trUtf8 (arg1, arg2));
 }
 
@@ -382,9 +382,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractItemDelegate::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -708,7 +708,7 @@ static void _call_ctor_QAbstractItemDelegate_Adaptor_1302 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QAbstractItemDelegate_Adaptor *> (new QAbstractItemDelegate_Adaptor (arg1));
 }
 
@@ -752,8 +752,8 @@ static void _call_emitter_closeEditor_4926 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemDelegate::EndEditHint>(heap, QAbstractItemDelegate::NoHint));
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemDelegate::EndEditHint>(heap, QAbstractItemDelegate::NoHint), heap);
   ((QAbstractItemDelegate_Adaptor *)cls)->emitter_QAbstractItemDelegate_closeEditor_4926 (arg1, arg2);
 }
 
@@ -771,7 +771,7 @@ static void _call_emitter_commitData_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ((QAbstractItemDelegate_Adaptor *)cls)->emitter_QAbstractItemDelegate_commitData_1315 (arg1);
 }
 
@@ -842,7 +842,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractItemDelegate_Adaptor *)cls)->emitter_QAbstractItemDelegate_destroyed_1302 (arg1);
 }
 
@@ -995,7 +995,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractItemDelegate_Adaptor *)cls)->fp_QAbstractItemDelegate_receivers_c1731 (arg1));
 }
 
@@ -1110,7 +1110,7 @@ static void _call_emitter_sizeHintChanged_2395 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractItemDelegate_Adaptor *)cls)->emitter_QAbstractItemDelegate_sizeHintChanged_2395 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractItemView.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractItemView.cc
@@ -164,7 +164,7 @@ static void _call_f_closePersistentEditor_2395 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->closePersistentEditor (arg1);
 }
@@ -275,7 +275,7 @@ static void _call_f_edit_2395 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->edit (arg1);
 }
@@ -355,7 +355,7 @@ static void _call_f_indexAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractItemView *)cls)->indexAt (arg1));
 }
 
@@ -374,7 +374,7 @@ static void _call_f_indexWidget_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QAbstractItemView *)cls)->indexWidget (arg1));
 }
 
@@ -393,7 +393,7 @@ static void _call_f_inputMethodQuery_c2420 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QAbstractItemView *)cls)->inputMethodQuery (qt_gsi::QtToCppAdaptor<Qt::InputMethodQuery>(arg1).cref()));
 }
 
@@ -427,7 +427,7 @@ static void _call_f_itemDelegate_c2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QAbstractItemDelegate * > ((QAbstractItemDelegate *)((QAbstractItemView *)cls)->itemDelegate (arg1));
 }
 
@@ -446,7 +446,7 @@ static void _call_f_itemDelegateForColumn_c767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QAbstractItemDelegate * > ((QAbstractItemDelegate *)((QAbstractItemView *)cls)->itemDelegateForColumn (arg1));
 }
 
@@ -465,7 +465,7 @@ static void _call_f_itemDelegateForRow_c767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QAbstractItemDelegate * > ((QAbstractItemDelegate *)((QAbstractItemView *)cls)->itemDelegateForRow (arg1));
 }
 
@@ -484,7 +484,7 @@ static void _call_f_keyboardSearch_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->keyboardSearch (arg1);
 }
@@ -519,7 +519,7 @@ static void _call_f_openPersistentEditor_2395 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->openPersistentEditor (arg1);
 }
@@ -572,8 +572,8 @@ static void _call_f_scrollTo_5576 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible));
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->scrollTo (arg1, qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollHint>(arg2).cref());
 }
@@ -686,7 +686,7 @@ static void _call_f_setAlternatingRowColors_864 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setAlternatingRowColors (arg1);
 }
@@ -706,7 +706,7 @@ static void _call_f_setAutoScroll_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setAutoScroll (arg1);
 }
@@ -726,7 +726,7 @@ static void _call_f_setAutoScrollMargin_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setAutoScrollMargin (arg1);
 }
@@ -746,7 +746,7 @@ static void _call_f_setCurrentIndex_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setCurrentIndex (arg1);
 }
@@ -766,7 +766,7 @@ static void _call_f_setDefaultDropAction_1760 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setDefaultDropAction (qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg1).cref());
 }
@@ -786,7 +786,7 @@ static void _call_f_setDragDropMode_3439 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractItemView::DragDropMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractItemView::DragDropMode>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractItemView::DragDropMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::DragDropMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setDragDropMode (qt_gsi::QtToCppAdaptor<QAbstractItemView::DragDropMode>(arg1).cref());
 }
@@ -806,7 +806,7 @@ static void _call_f_setDragDropOverwriteMode_864 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setDragDropOverwriteMode (arg1);
 }
@@ -826,7 +826,7 @@ static void _call_f_setDragEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setDragEnabled (arg1);
 }
@@ -846,7 +846,7 @@ static void _call_f_setDropIndicatorShown_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setDropIndicatorShown (arg1);
 }
@@ -866,7 +866,7 @@ static void _call_f_setEditTriggers_4073 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QAbstractItemView::EditTrigger> arg1 = args.read<QFlags<QAbstractItemView::EditTrigger> > (heap);
+  QFlags<QAbstractItemView::EditTrigger> arg1 = gsi::arg_reader<QFlags<QAbstractItemView::EditTrigger> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setEditTriggers (arg1);
 }
@@ -886,7 +886,7 @@ static void _call_f_setHorizontalScrollMode_3275 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractItemView::ScrollMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractItemView::ScrollMode>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setHorizontalScrollMode (qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollMode>(arg1).cref());
 }
@@ -906,7 +906,7 @@ static void _call_f_setIconSize_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setIconSize (arg1);
 }
@@ -928,8 +928,8 @@ static void _call_f_setIndexWidget_3602 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setIndexWidget (arg1, arg2);
 }
@@ -949,7 +949,7 @@ static void _call_f_setItemDelegate_2717 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemDelegate *arg1 = args.read<QAbstractItemDelegate * > (heap);
+  QAbstractItemDelegate *arg1 = gsi::arg_reader<QAbstractItemDelegate * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setItemDelegate (arg1);
 }
@@ -971,8 +971,8 @@ static void _call_f_setItemDelegateForColumn_3376 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QAbstractItemDelegate *arg2 = args.read<QAbstractItemDelegate * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QAbstractItemDelegate *arg2 = gsi::arg_reader<QAbstractItemDelegate * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setItemDelegateForColumn (arg1, arg2);
 }
@@ -994,8 +994,8 @@ static void _call_f_setItemDelegateForRow_3376 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QAbstractItemDelegate *arg2 = args.read<QAbstractItemDelegate * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QAbstractItemDelegate *arg2 = gsi::arg_reader<QAbstractItemDelegate * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setItemDelegateForRow (arg1, arg2);
 }
@@ -1015,7 +1015,7 @@ static void _call_f_setModel_2419 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setModel (arg1);
 }
@@ -1035,7 +1035,7 @@ static void _call_f_setRootIndex_2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setRootIndex (arg1);
 }
@@ -1055,7 +1055,7 @@ static void _call_f_setSelectionBehavior_4013 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractItemView::SelectionBehavior>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractItemView::SelectionBehavior>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractItemView::SelectionBehavior>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::SelectionBehavior>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setSelectionBehavior (qt_gsi::QtToCppAdaptor<QAbstractItemView::SelectionBehavior>(arg1).cref());
 }
@@ -1075,7 +1075,7 @@ static void _call_f_setSelectionMode_3586 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractItemView::SelectionMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractItemView::SelectionMode>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractItemView::SelectionMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::SelectionMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setSelectionMode (qt_gsi::QtToCppAdaptor<QAbstractItemView::SelectionMode>(arg1).cref());
 }
@@ -1095,7 +1095,7 @@ static void _call_f_setSelectionModel_2533 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QItemSelectionModel *arg1 = args.read<QItemSelectionModel * > (heap);
+  QItemSelectionModel *arg1 = gsi::arg_reader<QItemSelectionModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setSelectionModel (arg1);
 }
@@ -1115,7 +1115,7 @@ static void _call_f_setTabKeyNavigation_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setTabKeyNavigation (arg1);
 }
@@ -1135,7 +1135,7 @@ static void _call_f_setTextElideMode_2042 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TextElideMode>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextElideMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setTextElideMode (qt_gsi::QtToCppAdaptor<Qt::TextElideMode>(arg1).cref());
 }
@@ -1155,7 +1155,7 @@ static void _call_f_setVerticalScrollMode_3275 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractItemView::ScrollMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractItemView::ScrollMode>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->setVerticalScrollMode (qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollMode>(arg1).cref());
 }
@@ -1190,7 +1190,7 @@ static void _call_f_sizeHintForColumn_c767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAbstractItemView *)cls)->sizeHintForColumn (arg1));
 }
 
@@ -1209,7 +1209,7 @@ static void _call_f_sizeHintForIndex_c2395 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QSize > ((QSize)((QAbstractItemView *)cls)->sizeHintForIndex (arg1));
 }
 
@@ -1228,7 +1228,7 @@ static void _call_f_sizeHintForRow_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAbstractItemView *)cls)->sizeHintForRow (arg1));
 }
 
@@ -1277,7 +1277,7 @@ static void _call_f_update_2006 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->update (arg1);
 }
@@ -1297,7 +1297,7 @@ static void _call_f_update_2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView *)cls)->update (arg1);
 }
@@ -1332,7 +1332,7 @@ static void _call_f_visualRect_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QRect > ((QRect)((QAbstractItemView *)cls)->visualRect (arg1));
 }
 
@@ -1353,8 +1353,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractItemView::tr (arg1, arg2));
 }
 
@@ -1377,9 +1377,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractItemView::tr (arg1, arg2, arg3));
 }
 
@@ -1400,8 +1400,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractItemView::trUtf8 (arg1, arg2));
 }
 
@@ -1424,9 +1424,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractItemView::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -3135,7 +3135,7 @@ static void _call_ctor_QAbstractItemView_Adaptor_1315 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QAbstractItemView_Adaptor *> (new QAbstractItemView_Adaptor (arg1));
 }
 
@@ -3177,7 +3177,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractItemView_Adaptor *)cls)->emitter_QAbstractItemView_activated_2395 (arg1);
 }
 
@@ -3243,7 +3243,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractItemView_Adaptor *)cls)->emitter_QAbstractItemView_clicked_2395 (arg1);
 }
 
@@ -3364,9 +3364,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_create_2208 (arg1, arg2, arg3);
 }
@@ -3412,7 +3412,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QAbstractItemView_Adaptor *)cls)->emitter_QAbstractItemView_customContextMenuRequested_1916 (arg1);
 }
 
@@ -3483,8 +3483,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_destroy_1620 (arg1, arg2);
 }
@@ -3503,7 +3503,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractItemView_Adaptor *)cls)->emitter_QAbstractItemView_destroyed_1302 (arg1);
 }
 
@@ -3594,7 +3594,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractItemView_Adaptor *)cls)->emitter_QAbstractItemView_doubleClicked_2395 (arg1);
 }
 
@@ -3684,7 +3684,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_drawFrame_1426 (arg1);
 }
@@ -3842,7 +3842,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractItemView_Adaptor *)cls)->emitter_QAbstractItemView_entered_2395 (arg1);
 }
 
@@ -4639,7 +4639,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractItemView_Adaptor *)cls)->emitter_QAbstractItemView_pressed_2395 (arg1);
 }
 
@@ -4657,7 +4657,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_receivers_c1731 (arg1));
 }
 
@@ -4838,8 +4838,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -4991,7 +4991,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_setDirtyRegion_2006 (arg1);
 }
@@ -5010,7 +5010,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -5128,7 +5128,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_setState_2776 (arg1);
 }
@@ -5147,7 +5147,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_setVerticalStepsPerItem_767 (arg1);
 }
@@ -5172,10 +5172,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -5194,7 +5194,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_setViewportMargins_2115 (arg1);
 }
@@ -5237,7 +5237,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractItemView_Adaptor *)cls)->fp_QAbstractItemView_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractPageSetupDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractPageSetupDialog.cc
@@ -112,7 +112,7 @@ static void _call_f_done_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPageSetupDialog *)cls)->done (arg1);
 }
@@ -164,8 +164,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractPageSetupDialog::tr (arg1, arg2));
 }
 
@@ -188,9 +188,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractPageSetupDialog::tr (arg1, arg2, arg3));
 }
 
@@ -211,8 +211,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractPageSetupDialog::trUtf8 (arg1, arg2));
 }
 
@@ -235,9 +235,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractPageSetupDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1176,8 +1176,8 @@ static void _call_ctor_QAbstractPageSetupDialog_Adaptor_2650 (const qt_gsi::Gene
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QAbstractPageSetupDialog_Adaptor *> (new QAbstractPageSetupDialog_Adaptor (arg1, arg2));
 }
 
@@ -1254,7 +1254,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPageSetupDialog_Adaptor *)cls)->fp_QAbstractPageSetupDialog_adjustPosition_1315 (arg1);
 }
@@ -1373,9 +1373,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPageSetupDialog_Adaptor *)cls)->fp_QAbstractPageSetupDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -1394,7 +1394,7 @@ static void _call_fp_customContextMenuRequested_1916 (const qt_gsi::GenericMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPageSetupDialog_Adaptor *)cls)->fp_QAbstractPageSetupDialog_customContextMenuRequested_1916 (arg1);
 }
@@ -1439,8 +1439,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPageSetupDialog_Adaptor *)cls)->fp_QAbstractPageSetupDialog_destroy_1620 (arg1, arg2);
 }
@@ -1459,7 +1459,7 @@ static void _call_fp_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPageSetupDialog_Adaptor *)cls)->fp_QAbstractPageSetupDialog_destroyed_1302 (arg1);
 }
@@ -1738,7 +1738,7 @@ static void _call_fp_finished_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPageSetupDialog_Adaptor *)cls)->fp_QAbstractPageSetupDialog_finished_767 (arg1);
 }
@@ -2295,7 +2295,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractPageSetupDialog_Adaptor *)cls)->fp_QAbstractPageSetupDialog_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractPrintDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractPrintDialog.cc
@@ -112,7 +112,7 @@ static void _call_f_addEnabledOption_4320 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPrintDialog *)cls)->addEnabledOption (qt_gsi::QtToCppAdaptor<QAbstractPrintDialog::PrintDialogOption>(arg1).cref());
 }
@@ -177,7 +177,7 @@ static void _call_f_isOptionEnabled_c4320 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractPrintDialog *)cls)->isOptionEnabled (qt_gsi::QtToCppAdaptor<QAbstractPrintDialog::PrintDialogOption>(arg1).cref()));
 }
 
@@ -256,7 +256,7 @@ static void _call_f_setEnabledOptions_5016 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QAbstractPrintDialog::PrintDialogOption> arg1 = args.read<QFlags<QAbstractPrintDialog::PrintDialogOption> > (heap);
+  QFlags<QAbstractPrintDialog::PrintDialogOption> arg1 = gsi::arg_reader<QFlags<QAbstractPrintDialog::PrintDialogOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPrintDialog *)cls)->setEnabledOptions (arg1);
 }
@@ -278,8 +278,8 @@ static void _call_f_setFromTo_1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPrintDialog *)cls)->setFromTo (arg1, arg2);
 }
@@ -301,8 +301,8 @@ static void _call_f_setMinMax_1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPrintDialog *)cls)->setMinMax (arg1, arg2);
 }
@@ -322,7 +322,7 @@ static void _call_f_setOptionTabs_2663 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QWidget*> &arg1 = args.read<const QList<QWidget*> & > (heap);
+  const QList<QWidget*> &arg1 = gsi::arg_reader<const QList<QWidget*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPrintDialog *)cls)->setOptionTabs (arg1);
 }
@@ -342,7 +342,7 @@ static void _call_f_setPrintRange_3588 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractPrintDialog::PrintRange>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractPrintDialog::PrintRange>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractPrintDialog::PrintRange>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractPrintDialog::PrintRange>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPrintDialog *)cls)->setPrintRange (qt_gsi::QtToCppAdaptor<QAbstractPrintDialog::PrintRange>(arg1).cref());
 }
@@ -379,8 +379,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractPrintDialog::tr (arg1, arg2));
 }
 
@@ -403,9 +403,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractPrintDialog::tr (arg1, arg2, arg3));
 }
 
@@ -426,8 +426,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractPrintDialog::trUtf8 (arg1, arg2));
 }
 
@@ -450,9 +450,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractPrintDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1413,8 +1413,8 @@ static void _call_ctor_QAbstractPrintDialog_Adaptor_2650 (const qt_gsi::GenericS
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QAbstractPrintDialog_Adaptor *> (new QAbstractPrintDialog_Adaptor (arg1, arg2));
 }
 
@@ -1490,7 +1490,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPrintDialog_Adaptor *)cls)->fp_QAbstractPrintDialog_adjustPosition_1315 (arg1);
 }
@@ -1609,9 +1609,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPrintDialog_Adaptor *)cls)->fp_QAbstractPrintDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -1630,7 +1630,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QAbstractPrintDialog_Adaptor *)cls)->emitter_QAbstractPrintDialog_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1674,8 +1674,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractPrintDialog_Adaptor *)cls)->fp_QAbstractPrintDialog_destroy_1620 (arg1, arg2);
 }
@@ -1694,7 +1694,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractPrintDialog_Adaptor *)cls)->emitter_QAbstractPrintDialog_destroyed_1302 (arg1);
 }
 
@@ -1972,7 +1972,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractPrintDialog_Adaptor *)cls)->emitter_QAbstractPrintDialog_finished_767 (arg1);
 }
 
@@ -2528,7 +2528,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractPrintDialog_Adaptor *)cls)->fp_QAbstractPrintDialog_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractProxyModel.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractProxyModel.cc
@@ -76,8 +76,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QAbstractProxyModel *)cls)->data (arg1, arg2));
 }
 
@@ -96,7 +96,7 @@ static void _call_f_flags_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFlags<Qt::ItemFlag> > ((QFlags<Qt::ItemFlag>)((QAbstractProxyModel *)cls)->flags (arg1));
 }
 
@@ -119,9 +119,9 @@ static void _call_f_headerData_c3231 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QAbstractProxyModel *)cls)->headerData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3));
 }
 
@@ -140,7 +140,7 @@ static void _call_f_itemData_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QMap<int, QVariant> > ((QMap<int, QVariant>)((QAbstractProxyModel *)cls)->itemData (arg1));
 }
 
@@ -159,7 +159,7 @@ static void _call_f_mapFromSource_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractProxyModel *)cls)->mapFromSource (arg1));
 }
 
@@ -178,7 +178,7 @@ static void _call_f_mapSelectionFromSource_c2727 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelection &arg1 = args.read<const QItemSelection & > (heap);
+  const QItemSelection &arg1 = gsi::arg_reader<const QItemSelection & >() (args, heap);
   ret.write<QItemSelection > ((QItemSelection)((QAbstractProxyModel *)cls)->mapSelectionFromSource (arg1));
 }
 
@@ -197,7 +197,7 @@ static void _call_f_mapSelectionToSource_c2727 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelection &arg1 = args.read<const QItemSelection & > (heap);
+  const QItemSelection &arg1 = gsi::arg_reader<const QItemSelection & >() (args, heap);
   ret.write<QItemSelection > ((QItemSelection)((QAbstractProxyModel *)cls)->mapSelectionToSource (arg1));
 }
 
@@ -216,7 +216,7 @@ static void _call_f_mapToSource_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractProxyModel *)cls)->mapToSource (arg1));
 }
 
@@ -255,9 +255,9 @@ static void _call_f_setData_5065 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QAbstractProxyModel *)cls)->setData (arg1, arg2, arg3));
 }
 
@@ -282,10 +282,10 @@ static void _call_f_setHeaderData_5242 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QAbstractProxyModel *)cls)->setHeaderData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3, arg4));
 }
 
@@ -304,7 +304,7 @@ static void _call_f_setSourceModel_2419 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractProxyModel *)cls)->setSourceModel (arg1);
 }
@@ -356,8 +356,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractProxyModel::tr (arg1, arg2));
 }
 
@@ -380,9 +380,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractProxyModel::tr (arg1, arg2, arg3));
 }
 
@@ -403,8 +403,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractProxyModel::trUtf8 (arg1, arg2));
 }
 
@@ -427,9 +427,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractProxyModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1304,7 +1304,7 @@ static void _call_ctor_QAbstractProxyModel_Adaptor_1302 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QAbstractProxyModel_Adaptor *> (new QAbstractProxyModel_Adaptor (arg1));
 }
 
@@ -1326,9 +1326,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -1351,9 +1351,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1380,11 +1380,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1410,11 +1410,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1436,9 +1436,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -1461,9 +1461,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -1545,8 +1545,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -1567,8 +1567,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -1638,9 +1638,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -1662,9 +1662,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -1686,9 +1686,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -1758,8 +1758,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QAbstractProxyModel_Adaptor *)cls)->emitter_QAbstractProxyModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -1783,10 +1783,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -1804,7 +1804,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractProxyModel_Adaptor *)cls)->emitter_QAbstractProxyModel_destroyed_1302 (arg1);
 }
 
@@ -1883,8 +1883,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_encodeData_c4599 (arg1, arg2);
 }
@@ -2160,9 +2160,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractProxyModel_Adaptor *)cls)->emitter_QAbstractProxyModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -2524,7 +2524,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_receivers_c1731 (arg1));
 }
 
@@ -2759,7 +2759,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractProxyModel_Adaptor *)cls)->fp_QAbstractProxyModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractScrollArea.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractScrollArea.cc
@@ -114,8 +114,8 @@ static void _call_f_addScrollBarWidget_3957 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QFlags<Qt::AlignmentFlag> arg2 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg2 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea *)cls)->addScrollBarWidget (arg1, arg2);
 }
@@ -210,7 +210,7 @@ static void _call_f_scrollBarWidgets_2750 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   ret.write<QList<QWidget *> > ((QList<QWidget *>)((QAbstractScrollArea *)cls)->scrollBarWidgets (arg1));
 }
 
@@ -229,7 +229,7 @@ static void _call_f_setCornerWidget_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea *)cls)->setCornerWidget (arg1);
 }
@@ -249,7 +249,7 @@ static void _call_f_setHorizontalScrollBar_1603 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QScrollBar *arg1 = args.read<QScrollBar * > (heap);
+  QScrollBar *arg1 = gsi::arg_reader<QScrollBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea *)cls)->setHorizontalScrollBar (arg1);
 }
@@ -269,7 +269,7 @@ static void _call_f_setHorizontalScrollBarPolicy_2273 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ScrollBarPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ScrollBarPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ScrollBarPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ScrollBarPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea *)cls)->setHorizontalScrollBarPolicy (qt_gsi::QtToCppAdaptor<Qt::ScrollBarPolicy>(arg1).cref());
 }
@@ -289,7 +289,7 @@ static void _call_f_setVerticalScrollBar_1603 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QScrollBar *arg1 = args.read<QScrollBar * > (heap);
+  QScrollBar *arg1 = gsi::arg_reader<QScrollBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea *)cls)->setVerticalScrollBar (arg1);
 }
@@ -309,7 +309,7 @@ static void _call_f_setVerticalScrollBarPolicy_2273 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ScrollBarPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ScrollBarPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ScrollBarPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ScrollBarPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea *)cls)->setVerticalScrollBarPolicy (qt_gsi::QtToCppAdaptor<Qt::ScrollBarPolicy>(arg1).cref());
 }
@@ -329,7 +329,7 @@ static void _call_f_setViewport_1315 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea *)cls)->setViewport (arg1);
 }
@@ -411,8 +411,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractScrollArea::tr (arg1, arg2));
 }
 
@@ -435,9 +435,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractScrollArea::tr (arg1, arg2, arg3));
 }
 
@@ -458,8 +458,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractScrollArea::trUtf8 (arg1, arg2));
 }
 
@@ -482,9 +482,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractScrollArea::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1407,7 +1407,7 @@ static void _call_ctor_QAbstractScrollArea_Adaptor_1315 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QAbstractScrollArea_Adaptor *> (new QAbstractScrollArea_Adaptor (arg1));
 }
 
@@ -1549,9 +1549,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea_Adaptor *)cls)->fp_QAbstractScrollArea_create_2208 (arg1, arg2, arg3);
 }
@@ -1570,7 +1570,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QAbstractScrollArea_Adaptor *)cls)->emitter_QAbstractScrollArea_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1614,8 +1614,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea_Adaptor *)cls)->fp_QAbstractScrollArea_destroy_1620 (arg1, arg2);
 }
@@ -1634,7 +1634,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractScrollArea_Adaptor *)cls)->emitter_QAbstractScrollArea_destroyed_1302 (arg1);
 }
 
@@ -1748,7 +1748,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea_Adaptor *)cls)->fp_QAbstractScrollArea_drawFrame_1426 (arg1);
 }
@@ -2426,7 +2426,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractScrollArea_Adaptor *)cls)->fp_QAbstractScrollArea_receivers_c1731 (arg1));
 }
 
@@ -2530,10 +2530,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea_Adaptor *)cls)->fp_QAbstractScrollArea_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -2552,7 +2552,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea_Adaptor *)cls)->fp_QAbstractScrollArea_setViewportMargins_2115 (arg1);
 }
@@ -2595,7 +2595,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractScrollArea_Adaptor *)cls)->fp_QAbstractScrollArea_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractSlider.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractSlider.cc
@@ -231,7 +231,7 @@ static void _call_f_setInvertedAppearance_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setInvertedAppearance (arg1);
 }
@@ -251,7 +251,7 @@ static void _call_f_setInvertedControls_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setInvertedControls (arg1);
 }
@@ -271,7 +271,7 @@ static void _call_f_setMaximum_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setMaximum (arg1);
 }
@@ -291,7 +291,7 @@ static void _call_f_setMinimum_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setMinimum (arg1);
 }
@@ -311,7 +311,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -331,7 +331,7 @@ static void _call_f_setPageStep_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setPageStep (arg1);
 }
@@ -353,8 +353,8 @@ static void _call_f_setRange_1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setRange (arg1, arg2);
 }
@@ -374,7 +374,7 @@ static void _call_f_setSingleStep_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setSingleStep (arg1);
 }
@@ -394,7 +394,7 @@ static void _call_f_setSliderDown_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setSliderDown (arg1);
 }
@@ -414,7 +414,7 @@ static void _call_f_setSliderPosition_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setSliderPosition (arg1);
 }
@@ -434,7 +434,7 @@ static void _call_f_setTracking_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setTracking (arg1);
 }
@@ -454,7 +454,7 @@ static void _call_f_setValue_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->setValue (arg1);
 }
@@ -504,7 +504,7 @@ static void _call_f_triggerAction_3281 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider *)cls)->triggerAction (qt_gsi::QtToCppAdaptor<QAbstractSlider::SliderAction>(arg1).cref());
 }
@@ -541,8 +541,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractSlider::tr (arg1, arg2));
 }
 
@@ -565,9 +565,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractSlider::tr (arg1, arg2, arg3));
 }
 
@@ -588,8 +588,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractSlider::trUtf8 (arg1, arg2));
 }
 
@@ -612,9 +612,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractSlider::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1560,7 +1560,7 @@ static void _call_ctor_QAbstractSlider_Adaptor_1315 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QAbstractSlider_Adaptor *> (new QAbstractSlider_Adaptor (arg1));
 }
 
@@ -1602,7 +1602,7 @@ static void _call_emitter_actionTriggered_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractSlider_Adaptor *)cls)->emitter_QAbstractSlider_actionTriggered_767 (arg1);
 }
 
@@ -1720,9 +1720,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider_Adaptor *)cls)->fp_QAbstractSlider_create_2208 (arg1, arg2, arg3);
 }
@@ -1741,7 +1741,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QAbstractSlider_Adaptor *)cls)->emitter_QAbstractSlider_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1785,8 +1785,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider_Adaptor *)cls)->fp_QAbstractSlider_destroy_1620 (arg1, arg2);
 }
@@ -1805,7 +1805,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractSlider_Adaptor *)cls)->emitter_QAbstractSlider_destroyed_1302 (arg1);
 }
 
@@ -2580,8 +2580,8 @@ static void _call_emitter_rangeChanged_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractSlider_Adaptor *)cls)->emitter_QAbstractSlider_rangeChanged_1426 (arg1, arg2);
 }
 
@@ -2599,7 +2599,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractSlider_Adaptor *)cls)->fp_QAbstractSlider_receivers_c1731 (arg1));
 }
 
@@ -2688,9 +2688,9 @@ static void _call_fp_setRepeatAction_4599 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(500);
-  int arg3 = args ? args.read<int > (heap) : (int)(50);
+  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (500, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSlider_Adaptor *)cls)->fp_QAbstractSlider_setRepeatAction_4599 (arg1, arg2, arg3);
 }
@@ -2800,7 +2800,7 @@ static void _call_emitter_sliderMoved_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractSlider_Adaptor *)cls)->emitter_QAbstractSlider_sliderMoved_767 (arg1);
 }
 
@@ -2933,7 +2933,7 @@ static void _call_emitter_valueChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractSlider_Adaptor *)cls)->emitter_QAbstractSlider_valueChanged_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractSpinBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractSpinBox.cc
@@ -174,7 +174,7 @@ static void _call_f_event_1217 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QAbstractSpinBox *)cls)->event (arg1));
 }
 
@@ -193,7 +193,7 @@ static void _call_f_fixup_c1330 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->fixup (arg1);
 }
@@ -243,7 +243,7 @@ static void _call_f_inputMethodQuery_c2420 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QAbstractSpinBox *)cls)->inputMethodQuery (qt_gsi::QtToCppAdaptor<Qt::InputMethodQuery>(arg1).cref()));
 }
 
@@ -354,7 +354,7 @@ static void _call_f_setAccelerated_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->setAccelerated (arg1);
 }
@@ -374,7 +374,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->setAlignment (arg1);
 }
@@ -394,7 +394,7 @@ static void _call_f_setButtonSymbols_3541 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSpinBox::ButtonSymbols>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSpinBox::ButtonSymbols>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractSpinBox::ButtonSymbols>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSpinBox::ButtonSymbols>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->setButtonSymbols (qt_gsi::QtToCppAdaptor<QAbstractSpinBox::ButtonSymbols>(arg1).cref());
 }
@@ -414,7 +414,7 @@ static void _call_f_setCorrectionMode_3597 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSpinBox::CorrectionMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSpinBox::CorrectionMode>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractSpinBox::CorrectionMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSpinBox::CorrectionMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->setCorrectionMode (qt_gsi::QtToCppAdaptor<QAbstractSpinBox::CorrectionMode>(arg1).cref());
 }
@@ -434,7 +434,7 @@ static void _call_f_setFrame_864 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->setFrame (arg1);
 }
@@ -454,7 +454,7 @@ static void _call_f_setKeyboardTracking_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->setKeyboardTracking (arg1);
 }
@@ -474,7 +474,7 @@ static void _call_f_setReadOnly_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->setReadOnly (arg1);
 }
@@ -494,7 +494,7 @@ static void _call_f_setSpecialValueText_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->setSpecialValueText (arg1);
 }
@@ -514,7 +514,7 @@ static void _call_f_setWrapping_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->setWrapping (arg1);
 }
@@ -564,7 +564,7 @@ static void _call_f_stepBy_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox *)cls)->stepBy (arg1);
 }
@@ -633,8 +633,8 @@ static void _call_f_validate_c2171 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
-  int &arg2 = args.read<int & > (heap);
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
+  int &arg2 = gsi::arg_reader<int & >() (args, heap);
   ret.write<qt_gsi::Converter<QValidator::State>::target_type > ((qt_gsi::Converter<QValidator::State>::target_type)qt_gsi::CppToQtAdaptor<QValidator::State>(((QAbstractSpinBox *)cls)->validate (arg1, arg2)));
 }
 
@@ -670,8 +670,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractSpinBox::tr (arg1, arg2));
 }
 
@@ -694,9 +694,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractSpinBox::tr (arg1, arg2, arg3));
 }
 
@@ -717,8 +717,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractSpinBox::trUtf8 (arg1, arg2));
 }
 
@@ -741,9 +741,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractSpinBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1731,7 +1731,7 @@ static void _call_ctor_QAbstractSpinBox_Adaptor_1315 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QAbstractSpinBox_Adaptor *> (new QAbstractSpinBox_Adaptor (arg1));
 }
 
@@ -1893,9 +1893,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox_Adaptor *)cls)->fp_QAbstractSpinBox_create_2208 (arg1, arg2, arg3);
 }
@@ -1914,7 +1914,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QAbstractSpinBox_Adaptor *)cls)->emitter_QAbstractSpinBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1958,8 +1958,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox_Adaptor *)cls)->fp_QAbstractSpinBox_destroy_1620 (arg1, arg2);
 }
@@ -1978,7 +1978,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractSpinBox_Adaptor *)cls)->emitter_QAbstractSpinBox_destroyed_1302 (arg1);
 }
 
@@ -2421,7 +2421,7 @@ static void _call_fp_initStyleOption_c2572 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionSpinBox *arg1 = args.read<QStyleOptionSpinBox * > (heap);
+  QStyleOptionSpinBox *arg1 = gsi::arg_reader<QStyleOptionSpinBox * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox_Adaptor *)cls)->fp_QAbstractSpinBox_initStyleOption_c2572 (arg1);
 }
@@ -2822,7 +2822,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractSpinBox_Adaptor *)cls)->fp_QAbstractSpinBox_receivers_c1731 (arg1));
 }
 
@@ -2893,7 +2893,7 @@ static void _call_fp_setLineEdit_1485 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLineEdit *arg1 = args.read<QLineEdit * > (heap);
+  QLineEdit *arg1 = gsi::arg_reader<QLineEdit * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSpinBox_Adaptor *)cls)->fp_QAbstractSpinBox_setLineEdit_1485 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAbstractTextDocumentLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAbstractTextDocumentLayout.cc
@@ -80,7 +80,7 @@ static void _call_f_anchorAt_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QString > ((QString)((QAbstractTextDocumentLayout *)cls)->anchorAt (arg1));
 }
 
@@ -99,7 +99,7 @@ static void _call_f_blockBoundingRect_c2306 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QAbstractTextDocumentLayout *)cls)->blockBoundingRect (arg1));
 }
 
@@ -150,8 +150,8 @@ static void _call_f_draw_6787 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QAbstractTextDocumentLayout::PaintContext &arg2 = args.read<const QAbstractTextDocumentLayout::PaintContext & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QAbstractTextDocumentLayout::PaintContext &arg2 = gsi::arg_reader<const QAbstractTextDocumentLayout::PaintContext & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTextDocumentLayout *)cls)->draw (arg1, arg2);
 }
@@ -171,7 +171,7 @@ static void _call_f_frameBoundingRect_c1615 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextFrame *arg1 = args.read<QTextFrame * > (heap);
+  QTextFrame *arg1 = gsi::arg_reader<QTextFrame * >() (args, heap);
   ret.write<QRectF > ((QRectF)((QAbstractTextDocumentLayout *)cls)->frameBoundingRect (arg1));
 }
 
@@ -190,7 +190,7 @@ static void _call_f_handlerForObject_c767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextObjectInterface * > ((QTextObjectInterface *)((QAbstractTextDocumentLayout *)cls)->handlerForObject (arg1));
 }
 
@@ -211,8 +211,8 @@ static void _call_f_hitTest_c4147 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const qt_gsi::Converter<Qt::HitTestAccuracy>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::HitTestAccuracy>::target_type & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const qt_gsi::Converter<Qt::HitTestAccuracy>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::HitTestAccuracy>::target_type & >() (args, heap);
   ret.write<int > ((int)((QAbstractTextDocumentLayout *)cls)->hitTest (arg1, qt_gsi::QtToCppAdaptor<Qt::HitTestAccuracy>(arg2).cref()));
 }
 
@@ -263,8 +263,8 @@ static void _call_f_registerHandler_1961 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTextDocumentLayout *)cls)->registerHandler (arg1, arg2);
 }
@@ -284,7 +284,7 @@ static void _call_f_setPaintDevice_1803 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPaintDevice *arg1 = args.read<QPaintDevice * > (heap);
+  QPaintDevice *arg1 = gsi::arg_reader<QPaintDevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractTextDocumentLayout *)cls)->setPaintDevice (arg1);
 }
@@ -306,8 +306,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractTextDocumentLayout::tr (arg1, arg2));
 }
 
@@ -330,9 +330,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractTextDocumentLayout::tr (arg1, arg2, arg3));
 }
 
@@ -353,8 +353,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractTextDocumentLayout::trUtf8 (arg1, arg2));
 }
 
@@ -377,9 +377,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractTextDocumentLayout::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -769,7 +769,7 @@ static void _call_ctor_QAbstractTextDocumentLayout_Adaptor_1955 (const qt_gsi::G
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   ret.write<QAbstractTextDocumentLayout_Adaptor *> (new QAbstractTextDocumentLayout_Adaptor (arg1));
 }
 
@@ -858,7 +858,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractTextDocumentLayout_Adaptor *)cls)->emitter_QAbstractTextDocumentLayout_destroyed_1302 (arg1);
 }
 
@@ -949,7 +949,7 @@ static void _call_emitter_documentSizeChanged_1875 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   ((QAbstractTextDocumentLayout_Adaptor *)cls)->emitter_QAbstractTextDocumentLayout_documentSizeChanged_1875 (arg1);
 }
 
@@ -1079,7 +1079,7 @@ static void _call_fp_format_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextCharFormat > ((QTextCharFormat)((QAbstractTextDocumentLayout_Adaptor *)cls)->fp_QAbstractTextDocumentLayout_format_767 (arg1));
 }
 
@@ -1097,7 +1097,7 @@ static void _call_fp_formatIndex_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAbstractTextDocumentLayout_Adaptor *)cls)->fp_QAbstractTextDocumentLayout_formatIndex_767 (arg1));
 }
 
@@ -1183,7 +1183,7 @@ static void _call_emitter_pageCountChanged_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QAbstractTextDocumentLayout_Adaptor *)cls)->emitter_QAbstractTextDocumentLayout_pageCountChanged_767 (arg1);
 }
 
@@ -1231,7 +1231,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractTextDocumentLayout_Adaptor *)cls)->fp_QAbstractTextDocumentLayout_receivers_c1731 (arg1));
 }
 
@@ -1317,7 +1317,7 @@ static void _call_emitter_update_1862 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF(0., 0., 1000000000., 1000000000.));
+  const QRectF &arg1 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(0., 0., 1000000000., 1000000000.), heap);
   ((QAbstractTextDocumentLayout_Adaptor *)cls)->emitter_QAbstractTextDocumentLayout_update_1862 (arg1);
 }
 
@@ -1335,7 +1335,7 @@ static void _call_emitter_updateBlock_2306 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ((QAbstractTextDocumentLayout_Adaptor *)cls)->emitter_QAbstractTextDocumentLayout_updateBlock_2306 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAccessible.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAccessible.cc
@@ -98,7 +98,7 @@ static void _call_f_queryAccessibleInterface_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QAccessibleInterface * > ((QAccessibleInterface *)QAccessible::queryAccessibleInterface (arg1));
 }
 
@@ -117,7 +117,7 @@ static void _call_f_setRootObject_1302 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QAccessible::setRootObject (arg1);
 }
@@ -141,9 +141,9 @@ static void _call_f_updateAccessibility_4006 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<QAccessible::Event>::target_type & arg3 = args.read<const qt_gsi::Converter<QAccessible::Event>::target_type & > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QAccessible::Event>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Event>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QAccessible::updateAccessibility (arg1, arg2, qt_gsi::QtToCppAdaptor<QAccessible::Event>(arg3).cref());
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleApplication.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleApplication.cc
@@ -58,9 +58,9 @@ static void _call_f_actionText_c3378 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QAccessible::Text>::target_type & arg2 = args.read<const qt_gsi::Converter<QAccessible::Text>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QAccessible::Text>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Text>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QAccessibleApplication *)cls)->actionText (arg1, qt_gsi::QtToCppAdaptor<QAccessible::Text>(arg2).cref(), arg3));
 }
 
@@ -81,8 +81,8 @@ static void _call_f_childAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAccessibleApplication *)cls)->childAt (arg1, arg2));
 }
 
@@ -120,9 +120,9 @@ static void _call_f_doAction_4052 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QList<QVariant> &arg3 = args.read<const QList<QVariant> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QList<QVariant> &arg3 = gsi::arg_reader<const QList<QVariant> & >() (args, heap);
   ret.write<bool > ((bool)((QAccessibleApplication *)cls)->doAction (arg1, arg2, arg3));
 }
 
@@ -141,7 +141,7 @@ static void _call_f_indexOfChild_c3317 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QAccessibleInterface *arg1 = args.read<const QAccessibleInterface * > (heap);
+  const QAccessibleInterface *arg1 = gsi::arg_reader<const QAccessibleInterface * >() (args, heap);
   ret.write<int > ((int)((QAccessibleApplication *)cls)->indexOfChild (arg1));
 }
 
@@ -164,9 +164,9 @@ static void _call_f_relationTo_c4635 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QAccessibleInterface *arg2 = args.read<const QAccessibleInterface * > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QAccessibleInterface *arg2 = gsi::arg_reader<const QAccessibleInterface * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFlags<QAccessible::RelationFlag> > ((QFlags<QAccessible::RelationFlag>)((QAccessibleApplication *)cls)->relationTo (arg1, arg2, arg3));
 }
 
@@ -185,7 +185,7 @@ static void _call_f_role_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<qt_gsi::Converter<QAccessible::Role>::target_type > ((qt_gsi::Converter<QAccessible::Role>::target_type)qt_gsi::CppToQtAdaptor<QAccessible::Role>(((QAccessibleApplication *)cls)->role (arg1)));
 }
 
@@ -204,7 +204,7 @@ static void _call_f_state_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFlags<QAccessible::StateFlag> > ((QFlags<QAccessible::StateFlag>)((QAccessibleApplication *)cls)->state (arg1));
 }
 
@@ -225,8 +225,8 @@ static void _call_f_text_c2719 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = args.read<const qt_gsi::Converter<QAccessible::Text>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
+  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Text>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QAccessibleApplication *)cls)->text (qt_gsi::QtToCppAdaptor<QAccessible::Text>(arg1).cref(), arg2));
 }
 
@@ -245,7 +245,7 @@ static void _call_f_userActionCount_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAccessibleApplication *)cls)->userActionCount (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleEvent.cc
@@ -52,8 +52,8 @@ static void _call_ctor_QAccessibleEvent_2224 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QAccessibleEvent *> (new QAccessibleEvent (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2));
 }
 
@@ -87,7 +87,7 @@ static void _call_f_setValue_2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAccessibleEvent *)cls)->setValue (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleInterface.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleInterface.cc
@@ -57,9 +57,9 @@ static void _call_f_actionText_c3378 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QAccessible::Text>::target_type & arg2 = args.read<const qt_gsi::Converter<QAccessible::Text>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QAccessible::Text>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Text>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QAccessibleInterface *)cls)->actionText (arg1, qt_gsi::QtToCppAdaptor<QAccessible::Text>(arg2).cref(), arg3));
 }
 
@@ -95,8 +95,8 @@ static void _call_f_childAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAccessibleInterface *)cls)->childAt (arg1, arg2));
 }
 
@@ -134,9 +134,9 @@ static void _call_f_doAction_4052 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QList<QVariant> &arg3 = args ? args.read<const QList<QVariant> & > (heap) : (const QList<QVariant> &)(QVariantList());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QList<QVariant> &arg3 = args ? gsi::arg_reader<const QList<QVariant> & >() (args, heap) : gsi::arg_maker<const QList<QVariant> & >() (QVariantList(), heap);
   ret.write<bool > ((bool)((QAccessibleInterface *)cls)->doAction (arg1, arg2, arg3));
 }
 
@@ -170,7 +170,7 @@ static void _call_f_indexOfChild_c3317 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QAccessibleInterface *arg1 = args.read<const QAccessibleInterface * > (heap);
+  const QAccessibleInterface *arg1 = gsi::arg_reader<const QAccessibleInterface * >() (args, heap);
   ret.write<int > ((int)((QAccessibleInterface *)cls)->indexOfChild (arg1));
 }
 
@@ -193,9 +193,9 @@ static void _call_f_invokeMethod_5533 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAccessible::Method>::target_type & arg1 = args.read<const qt_gsi::Converter<QAccessible::Method>::target_type & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  const QList<QVariant> &arg3 = args ? args.read<const QList<QVariant> & > (heap) : (const QList<QVariant> &)(QVariantList());
+  const qt_gsi::Converter<QAccessible::Method>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Method>::target_type & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  const QList<QVariant> &arg3 = args ? gsi::arg_reader<const QList<QVariant> & >() (args, heap) : gsi::arg_maker<const QList<QVariant> & >() (QVariantList(), heap);
   ret.write<QVariant > ((QVariant)((QAccessibleInterface *)cls)->invokeMethod (qt_gsi::QtToCppAdaptor<QAccessible::Method>(arg1).cref(), arg2, arg3));
 }
 
@@ -244,7 +244,7 @@ static void _call_f_rect_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRect > ((QRect)((QAccessibleInterface *)cls)->rect (arg1));
 }
 
@@ -267,9 +267,9 @@ static void _call_f_relationTo_c4635 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QAccessibleInterface *arg2 = args.read<const QAccessibleInterface * > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QAccessibleInterface *arg2 = gsi::arg_reader<const QAccessibleInterface * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFlags<QAccessible::RelationFlag> > ((QFlags<QAccessible::RelationFlag>)((QAccessibleInterface *)cls)->relationTo (arg1, arg2, arg3));
 }
 
@@ -288,7 +288,7 @@ static void _call_f_role_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<qt_gsi::Converter<QAccessible::Role>::target_type > ((qt_gsi::Converter<QAccessible::Role>::target_type)qt_gsi::CppToQtAdaptor<QAccessible::Role>(((QAccessibleInterface *)cls)->role (arg1)));
 }
 
@@ -311,9 +311,9 @@ static void _call_f_setText_4636 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = args.read<const qt_gsi::Converter<QAccessible::Text>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Text>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAccessibleInterface *)cls)->setText (qt_gsi::QtToCppAdaptor<QAccessible::Text>(arg1).cref(), arg2, arg3);
 }
@@ -333,7 +333,7 @@ static void _call_f_state_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFlags<QAccessible::StateFlag> > ((QFlags<QAccessible::StateFlag>)((QAccessibleInterface *)cls)->state (arg1));
 }
 
@@ -369,8 +369,8 @@ static void _call_f_text_c2719 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = args.read<const qt_gsi::Converter<QAccessible::Text>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
+  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Text>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QAccessibleInterface *)cls)->text (qt_gsi::QtToCppAdaptor<QAccessible::Text>(arg1).cref(), arg2));
 }
 
@@ -389,7 +389,7 @@ static void _call_f_userActionCount_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAccessibleInterface *)cls)->userActionCount (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleObject.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleObject.cc
@@ -58,9 +58,9 @@ static void _call_f_actionText_c3378 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QAccessible::Text>::target_type & arg2 = args.read<const qt_gsi::Converter<QAccessible::Text>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QAccessible::Text>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Text>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QAccessibleObject *)cls)->actionText (arg1, qt_gsi::QtToCppAdaptor<QAccessible::Text>(arg2).cref(), arg3));
 }
 
@@ -83,9 +83,9 @@ static void _call_f_doAction_4052 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QList<QVariant> &arg3 = args.read<const QList<QVariant> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QList<QVariant> &arg3 = gsi::arg_reader<const QList<QVariant> & >() (args, heap);
   ret.write<bool > ((bool)((QAccessibleObject *)cls)->doAction (arg1, arg2, arg3));
 }
 
@@ -134,7 +134,7 @@ static void _call_f_rect_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRect > ((QRect)((QAccessibleObject *)cls)->rect (arg1));
 }
 
@@ -157,9 +157,9 @@ static void _call_f_setText_4636 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = args.read<const qt_gsi::Converter<QAccessible::Text>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Text>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAccessibleObject *)cls)->setText (qt_gsi::QtToCppAdaptor<QAccessible::Text>(arg1).cref(), arg2, arg3);
 }
@@ -179,7 +179,7 @@ static void _call_f_userActionCount_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAccessibleObject *)cls)->userActionCount (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAccessibleWidget.cc
@@ -59,9 +59,9 @@ static void _call_ctor_QAccessibleWidget_5165 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const qt_gsi::Converter<QAccessible::Role>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAccessible::Role>::target_type & > (heap) : (const qt_gsi::Converter<QAccessible::Role>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAccessible::Role>(heap, QAccessible::Client));
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const qt_gsi::Converter<QAccessible::Role>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAccessible::Role>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAccessible::Role>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAccessible::Role>(heap, QAccessible::Client), heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QAccessibleWidget *> (new QAccessibleWidget (arg1, qt_gsi::QtToCppAdaptor<QAccessible::Role>(arg2).cref(), arg3));
 }
 
@@ -84,9 +84,9 @@ static void _call_f_actionText_c3378 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QAccessible::Text>::target_type & arg2 = args.read<const qt_gsi::Converter<QAccessible::Text>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QAccessible::Text>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Text>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QAccessibleWidget *)cls)->actionText (arg1, qt_gsi::QtToCppAdaptor<QAccessible::Text>(arg2).cref(), arg3));
 }
 
@@ -107,8 +107,8 @@ static void _call_f_childAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAccessibleWidget *)cls)->childAt (arg1, arg2));
 }
 
@@ -146,9 +146,9 @@ static void _call_f_doAction_4052 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QList<QVariant> &arg3 = args.read<const QList<QVariant> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QList<QVariant> &arg3 = gsi::arg_reader<const QList<QVariant> & >() (args, heap);
   ret.write<bool > ((bool)((QAccessibleWidget *)cls)->doAction (arg1, arg2, arg3));
 }
 
@@ -167,7 +167,7 @@ static void _call_f_indexOfChild_c3317 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QAccessibleInterface *arg1 = args.read<const QAccessibleInterface * > (heap);
+  const QAccessibleInterface *arg1 = gsi::arg_reader<const QAccessibleInterface * >() (args, heap);
   ret.write<int > ((int)((QAccessibleWidget *)cls)->indexOfChild (arg1));
 }
 
@@ -186,7 +186,7 @@ static void _call_f_rect_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRect > ((QRect)((QAccessibleWidget *)cls)->rect (arg1));
 }
 
@@ -209,9 +209,9 @@ static void _call_f_relationTo_c4635 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QAccessibleInterface *arg2 = args.read<const QAccessibleInterface * > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QAccessibleInterface *arg2 = gsi::arg_reader<const QAccessibleInterface * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFlags<QAccessible::RelationFlag> > ((QFlags<QAccessible::RelationFlag>)((QAccessibleWidget *)cls)->relationTo (arg1, arg2, arg3));
 }
 
@@ -230,7 +230,7 @@ static void _call_f_role_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<qt_gsi::Converter<QAccessible::Role>::target_type > ((qt_gsi::Converter<QAccessible::Role>::target_type)qt_gsi::CppToQtAdaptor<QAccessible::Role>(((QAccessibleWidget *)cls)->role (arg1)));
 }
 
@@ -249,7 +249,7 @@ static void _call_f_state_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFlags<QAccessible::StateFlag> > ((QFlags<QAccessible::StateFlag>)((QAccessibleWidget *)cls)->state (arg1));
 }
 
@@ -270,8 +270,8 @@ static void _call_f_text_c2719 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = args.read<const qt_gsi::Converter<QAccessible::Text>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
+  const qt_gsi::Converter<QAccessible::Text>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAccessible::Text>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QAccessibleWidget *)cls)->text (qt_gsi::QtToCppAdaptor<QAccessible::Text>(arg1).cref(), arg2));
 }
 
@@ -290,7 +290,7 @@ static void _call_f_userActionCount_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QAccessibleWidget *)cls)->userActionCount (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQAction.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQAction.cc
@@ -80,7 +80,7 @@ static void _call_f_activate_2359 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAction::ActionEvent>::target_type & arg1 = args.read<const qt_gsi::Converter<QAction::ActionEvent>::target_type & > (heap);
+  const qt_gsi::Converter<QAction::ActionEvent>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAction::ActionEvent>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->activate (qt_gsi::QtToCppAdaptor<QAction::ActionEvent>(arg1).cref());
 }
@@ -371,7 +371,7 @@ static void _call_f_setActionGroup_1834 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QActionGroup *arg1 = args.read<QActionGroup * > (heap);
+  QActionGroup *arg1 = gsi::arg_reader<QActionGroup * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setActionGroup (arg1);
 }
@@ -391,7 +391,7 @@ static void _call_f_setAutoRepeat_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setAutoRepeat (arg1);
 }
@@ -411,7 +411,7 @@ static void _call_f_setCheckable_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setCheckable (arg1);
 }
@@ -431,7 +431,7 @@ static void _call_f_setChecked_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setChecked (arg1);
 }
@@ -451,7 +451,7 @@ static void _call_f_setData_2119 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setData (arg1);
 }
@@ -471,7 +471,7 @@ static void _call_f_setDisabled_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setDisabled (arg1);
 }
@@ -491,7 +491,7 @@ static void _call_f_setEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setEnabled (arg1);
 }
@@ -511,7 +511,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setFont (arg1);
 }
@@ -531,7 +531,7 @@ static void _call_f_setIcon_1787 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setIcon (arg1);
 }
@@ -551,7 +551,7 @@ static void _call_f_setIconText_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setIconText (arg1);
 }
@@ -571,7 +571,7 @@ static void _call_f_setIconVisibleInMenu_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setIconVisibleInMenu (arg1);
 }
@@ -591,7 +591,7 @@ static void _call_f_setMenu_1108 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMenu *arg1 = args.read<QMenu * > (heap);
+  QMenu *arg1 = gsi::arg_reader<QMenu * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setMenu (arg1);
 }
@@ -611,7 +611,7 @@ static void _call_f_setMenuRole_2046 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAction::MenuRole>::target_type & arg1 = args.read<const qt_gsi::Converter<QAction::MenuRole>::target_type & > (heap);
+  const qt_gsi::Converter<QAction::MenuRole>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAction::MenuRole>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setMenuRole (qt_gsi::QtToCppAdaptor<QAction::MenuRole>(arg1).cref());
 }
@@ -631,7 +631,7 @@ static void _call_f_setPriority_2105 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAction::Priority>::target_type & arg1 = args.read<const qt_gsi::Converter<QAction::Priority>::target_type & > (heap);
+  const qt_gsi::Converter<QAction::Priority>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAction::Priority>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setPriority (qt_gsi::QtToCppAdaptor<QAction::Priority>(arg1).cref());
 }
@@ -651,7 +651,7 @@ static void _call_f_setSeparator_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setSeparator (arg1);
 }
@@ -671,7 +671,7 @@ static void _call_f_setShortcut_2516 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setShortcut (arg1);
 }
@@ -691,7 +691,7 @@ static void _call_f_setShortcutContext_2350 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setShortcutContext (qt_gsi::QtToCppAdaptor<Qt::ShortcutContext>(arg1).cref());
 }
@@ -711,7 +711,7 @@ static void _call_f_setShortcuts_3131 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QKeySequence> &arg1 = args.read<const QList<QKeySequence> & > (heap);
+  const QList<QKeySequence> &arg1 = gsi::arg_reader<const QList<QKeySequence> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setShortcuts (arg1);
 }
@@ -731,7 +731,7 @@ static void _call_f_setShortcuts_2869 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & arg1 = args.read<const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & > (heap);
+  const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setShortcuts (qt_gsi::QtToCppAdaptor<QKeySequence::StandardKey>(arg1).cref());
 }
@@ -751,7 +751,7 @@ static void _call_f_setSoftKeyRole_2350 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAction::SoftKeyRole>::target_type & arg1 = args.read<const qt_gsi::Converter<QAction::SoftKeyRole>::target_type & > (heap);
+  const qt_gsi::Converter<QAction::SoftKeyRole>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAction::SoftKeyRole>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setSoftKeyRole (qt_gsi::QtToCppAdaptor<QAction::SoftKeyRole>(arg1).cref());
 }
@@ -771,7 +771,7 @@ static void _call_f_setStatusTip_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setStatusTip (arg1);
 }
@@ -791,7 +791,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setText (arg1);
 }
@@ -811,7 +811,7 @@ static void _call_f_setToolTip_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setToolTip (arg1);
 }
@@ -831,7 +831,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setVisible (arg1);
 }
@@ -851,7 +851,7 @@ static void _call_f_setWhatsThis_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAction *)cls)->setWhatsThis (arg1);
 }
@@ -916,7 +916,7 @@ static void _call_f_showStatusText_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<bool > ((bool)((QAction *)cls)->showStatusText (arg1));
 }
 
@@ -1044,8 +1044,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAction::tr (arg1, arg2));
 }
 
@@ -1068,9 +1068,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAction::tr (arg1, arg2, arg3));
 }
 
@@ -1091,8 +1091,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAction::trUtf8 (arg1, arg2));
 }
 
@@ -1115,9 +1115,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAction::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1384,7 +1384,7 @@ static void _call_ctor_QAction_Adaptor_1302 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QAction_Adaptor *> (new QAction_Adaptor (arg1));
 }
 
@@ -1404,8 +1404,8 @@ static void _call_ctor_QAction_Adaptor_3219 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QAction_Adaptor *> (new QAction_Adaptor (arg1, arg2));
 }
 
@@ -1427,9 +1427,9 @@ static void _call_ctor_QAction_Adaptor_4898 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QObject *arg3 = args.read<QObject * > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg3 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QAction_Adaptor *> (new QAction_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1509,7 +1509,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAction_Adaptor *)cls)->emitter_QAction_destroyed_1302 (arg1);
 }
 
@@ -1614,7 +1614,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAction_Adaptor *)cls)->fp_QAction_receivers_c1731 (arg1));
 }
 
@@ -1670,7 +1670,7 @@ static void _call_emitter_toggled_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QAction_Adaptor *)cls)->emitter_QAction_toggled_864 (arg1);
 }
 
@@ -1688,7 +1688,7 @@ static void _call_emitter_triggered_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ((QAction_Adaptor *)cls)->emitter_QAction_triggered_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQActionEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQActionEvent.cc
@@ -128,9 +128,9 @@ static void _call_ctor_QActionEvent_Adaptor_3169 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QAction *arg2 = args.read<QAction * > (heap);
-  QAction *arg3 = args ? args.read<QAction * > (heap) : (QAction *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QAction *arg2 = gsi::arg_reader<QAction * >() (args, heap);
+  QAction *arg3 = args ? gsi::arg_reader<QAction * >() (args, heap) : gsi::arg_maker<QAction * >() (0, heap);
   ret.write<QActionEvent_Adaptor *> (new QActionEvent_Adaptor (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQActionGroup.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQActionGroup.cc
@@ -85,7 +85,7 @@ static void _call_f_addAction_1309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QActionGroup *)cls)->addAction (arg1));
 }
 
@@ -104,7 +104,7 @@ static void _call_f_addAction_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QActionGroup *)cls)->addAction (arg1));
 }
 
@@ -125,8 +125,8 @@ static void _call_f_addAction_3704 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QActionGroup *)cls)->addAction (arg1, arg2));
 }
 
@@ -205,7 +205,7 @@ static void _call_f_removeAction_1309 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QActionGroup *)cls)->removeAction (arg1);
 }
@@ -225,7 +225,7 @@ static void _call_f_setDisabled_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QActionGroup *)cls)->setDisabled (arg1);
 }
@@ -245,7 +245,7 @@ static void _call_f_setEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QActionGroup *)cls)->setEnabled (arg1);
 }
@@ -265,7 +265,7 @@ static void _call_f_setExclusive_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QActionGroup *)cls)->setExclusive (arg1);
 }
@@ -285,7 +285,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QActionGroup *)cls)->setVisible (arg1);
 }
@@ -307,8 +307,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QActionGroup::tr (arg1, arg2));
 }
 
@@ -331,9 +331,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QActionGroup::tr (arg1, arg2, arg3));
 }
 
@@ -354,8 +354,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QActionGroup::trUtf8 (arg1, arg2));
 }
 
@@ -378,9 +378,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QActionGroup::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -585,7 +585,7 @@ static void _call_ctor_QActionGroup_Adaptor_1302 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QActionGroup_Adaptor *> (new QActionGroup_Adaptor (arg1));
 }
 
@@ -651,7 +651,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QActionGroup_Adaptor *)cls)->emitter_QActionGroup_destroyed_1302 (arg1);
 }
 
@@ -742,7 +742,7 @@ static void _call_emitter_hovered_1309 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ((QActionGroup_Adaptor *)cls)->emitter_QActionGroup_hovered_1309 (arg1);
 }
 
@@ -760,7 +760,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QActionGroup_Adaptor *)cls)->fp_QActionGroup_receivers_c1731 (arg1));
 }
 
@@ -778,7 +778,7 @@ static void _call_emitter_selected_1309 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ((QActionGroup_Adaptor *)cls)->emitter_QActionGroup_selected_1309 (arg1);
 }
 
@@ -834,7 +834,7 @@ static void _call_emitter_triggered_1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ((QActionGroup_Adaptor *)cls)->emitter_QActionGroup_triggered_1309 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQApplication.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQApplication.cc
@@ -102,8 +102,8 @@ static void _call_f_notify_2411 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  QEvent *arg2 = args.read<QEvent * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  QEvent *arg2 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QApplication *)cls)->notify (arg1, arg2));
 }
 
@@ -122,7 +122,7 @@ static void _call_f_setAutoSipEnabled_1559 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const bool arg1 = args.read<const bool > (heap);
+  const bool arg1 = gsi::arg_reader<const bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QApplication *)cls)->setAutoSipEnabled (arg1);
 }
@@ -142,7 +142,7 @@ static void _call_f_setInputContext_1972 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QInputContext *arg1 = args.read<QInputContext * > (heap);
+  QInputContext *arg1 = gsi::arg_reader<QInputContext * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QApplication *)cls)->setInputContext (arg1);
 }
@@ -162,7 +162,7 @@ static void _call_f_setStyleSheet_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QApplication *)cls)->setStyleSheet (arg1);
 }
@@ -260,8 +260,8 @@ static void _call_f_alert_1974 (const qt_gsi::GenericStaticMethod * /*decl*/, gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::alert (arg1, arg2);
 }
@@ -312,7 +312,7 @@ static void _call_f_changeOverrideCursor_2032 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QCursor &arg1 = args.read<const QCursor & > (heap);
+  const QCursor &arg1 = gsi::arg_reader<const QCursor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::changeOverrideCursor (arg1);
 }
@@ -483,7 +483,7 @@ static void _call_f_font_2010 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<QFont > ((QFont)QApplication::font (arg1));
 }
 
@@ -502,7 +502,7 @@ static void _call_f_font_1731 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QFont > ((QFont)QApplication::font (arg1));
 }
 
@@ -551,7 +551,7 @@ static void _call_f_isEffectEnabled_1496 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::UIEffect>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::UIEffect>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::UIEffect>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::UIEffect>::target_type & >() (args, heap);
   ret.write<bool > ((bool)QApplication::isEffectEnabled (qt_gsi::QtToCppAdaptor<Qt::UIEffect>(arg1).cref()));
 }
 
@@ -720,7 +720,7 @@ static void _call_f_palette_2010 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<QPalette > ((QPalette)QApplication::palette (arg1));
 }
 
@@ -739,7 +739,7 @@ static void _call_f_palette_1731 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QPalette > ((QPalette)QApplication::palette (arg1));
 }
 
@@ -789,7 +789,7 @@ static void _call_f_setActiveWindow_1315 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setActiveWindow (arg1);
 }
@@ -809,7 +809,7 @@ static void _call_f_setColorSpec_767 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setColorSpec (arg1);
 }
@@ -829,7 +829,7 @@ static void _call_f_setCursorFlashTime_767 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setCursorFlashTime (arg1);
 }
@@ -849,7 +849,7 @@ static void _call_f_setDesktopSettingsAware_864 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setDesktopSettingsAware (arg1);
 }
@@ -869,7 +869,7 @@ static void _call_f_setDoubleClickInterval_767 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setDoubleClickInterval (arg1);
 }
@@ -891,8 +891,8 @@ static void _call_f_setEffectEnabled_2252 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::UIEffect>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::UIEffect>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<Qt::UIEffect>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::UIEffect>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setEffectEnabled (qt_gsi::QtToCppAdaptor<Qt::UIEffect>(arg1).cref(), arg2);
 }
@@ -914,8 +914,8 @@ static void _call_f_setFont_3424 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setFont (arg1, arg2);
 }
@@ -935,7 +935,7 @@ static void _call_f_setGlobalStrut_1805 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setGlobalStrut (arg1);
 }
@@ -955,7 +955,7 @@ static void _call_f_setGraphicsSystem_2025 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setGraphicsSystem (arg1);
 }
@@ -975,7 +975,7 @@ static void _call_f_setKeyboardInputInterval_767 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setKeyboardInputInterval (arg1);
 }
@@ -995,7 +995,7 @@ static void _call_f_setLayoutDirection_2316 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setLayoutDirection (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref());
 }
@@ -1015,7 +1015,7 @@ static void _call_f_setOverrideCursor_2032 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QCursor &arg1 = args.read<const QCursor & > (heap);
+  const QCursor &arg1 = gsi::arg_reader<const QCursor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setOverrideCursor (arg1);
 }
@@ -1037,8 +1037,8 @@ static void _call_f_setPalette_3736 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setPalette (arg1, arg2);
 }
@@ -1058,7 +1058,7 @@ static void _call_f_setQuitOnLastWindowClosed_864 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setQuitOnLastWindowClosed (arg1);
 }
@@ -1078,7 +1078,7 @@ static void _call_f_setStartDragDistance_767 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setStartDragDistance (arg1);
 }
@@ -1098,7 +1098,7 @@ static void _call_f_setStartDragTime_767 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setStartDragTime (arg1);
 }
@@ -1118,7 +1118,7 @@ static void _call_f_setStyle_1232 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyle *arg1 = args.read<QStyle * > (heap);
+  QStyle *arg1 = gsi::arg_reader<QStyle * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setStyle (arg1);
 }
@@ -1138,7 +1138,7 @@ static void _call_f_setStyle_2025 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStyle * > ((QStyle *)QApplication::setStyle (arg1));
 }
 
@@ -1157,7 +1157,7 @@ static void _call_f_setWheelScrollLines_767 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setWheelScrollLines (arg1);
 }
@@ -1177,7 +1177,7 @@ static void _call_f_setWindowIcon_1787 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QApplication::setWindowIcon (arg1);
 }
@@ -1258,7 +1258,7 @@ static void _call_f_topLevelAt_1916 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QWidget * > ((QWidget *)QApplication::topLevelAt (arg1));
 }
 
@@ -1279,8 +1279,8 @@ static void _call_f_topLevelAt_1426 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)QApplication::topLevelAt (arg1, arg2));
 }
 
@@ -1316,8 +1316,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QApplication::tr (arg1, arg2));
 }
 
@@ -1340,9 +1340,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QApplication::tr (arg1, arg2, arg3));
 }
 
@@ -1363,8 +1363,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QApplication::trUtf8 (arg1, arg2));
 }
 
@@ -1387,9 +1387,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QApplication::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1438,7 +1438,7 @@ static void _call_f_widgetAt_1916 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QWidget * > ((QWidget *)QApplication::widgetAt (arg1));
 }
 
@@ -1459,8 +1459,8 @@ static void _call_f_widgetAt_1426 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)QApplication::widgetAt (arg1, arg2));
 }
 
@@ -1850,7 +1850,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QApplication_Adaptor *)cls)->emitter_QApplication_destroyed_1302 (arg1);
 }
 
@@ -1943,8 +1943,8 @@ static void _call_emitter_focusChanged_2522 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   ((QApplication_Adaptor *)cls)->emitter_QApplication_focusChanged_2522 (arg1, arg2);
 }
 
@@ -2016,7 +2016,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QApplication_Adaptor *)cls)->fp_QApplication_receivers_c1731 (arg1));
 }
 
@@ -2072,7 +2072,7 @@ static void _call_emitter_unixSignal_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QApplication_Adaptor *)cls)->emitter_QApplication_unixSignal_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQBitmap.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQBitmap.cc
@@ -78,7 +78,7 @@ static void _call_f_operator_eq__2017 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QBitmap & > ((QBitmap &)((QBitmap *)cls)->operator= (arg1));
 }
 
@@ -97,7 +97,7 @@ static void _call_f_transformed_c2023 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   ret.write<QBitmap > ((QBitmap)((QBitmap *)cls)->transformed (arg1));
 }
 
@@ -116,7 +116,7 @@ static void _call_f_transformed_c2350 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QBitmap > ((QBitmap)((QBitmap *)cls)->transformed (arg1));
 }
 
@@ -139,9 +139,9 @@ static void _call_f_fromData_6058 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const unsigned char *arg2 = args.read<const unsigned char * > (heap);
-  const qt_gsi::Converter<QImage::Format>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QImage::Format>::target_type & > (heap) : (const qt_gsi::Converter<QImage::Format>::target_type &)(qt_gsi::CppToQtReadAdaptor<QImage::Format>(heap, QImage::Format_MonoLSB));
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const unsigned char *arg2 = gsi::arg_reader<const unsigned char * >() (args, heap);
+  const qt_gsi::Converter<QImage::Format>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QImage::Format>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QImage::Format>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QImage::Format>(heap, QImage::Format_MonoLSB), heap);
   ret.write<QBitmap > ((QBitmap)QBitmap::fromData (arg1, arg2, qt_gsi::QtToCppAdaptor<QImage::Format>(arg3).cref()));
 }
 
@@ -162,8 +162,8 @@ static void _call_f_fromImage_5137 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
-  QFlags<Qt::ImageConversionFlag> arg2 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
+  QFlags<Qt::ImageConversionFlag> arg2 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   ret.write<QBitmap > ((QBitmap)QBitmap::fromImage (arg1, arg2));
 }
 
@@ -298,7 +298,7 @@ static void _call_ctor_QBitmap_Adaptor_2017 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QBitmap_Adaptor *> (new QBitmap_Adaptor (arg1));
 }
 
@@ -318,8 +318,8 @@ static void _call_ctor_QBitmap_Adaptor_1426 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QBitmap_Adaptor *> (new QBitmap_Adaptor (arg1, arg2));
 }
 
@@ -337,7 +337,7 @@ static void _call_ctor_QBitmap_Adaptor_1805 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QBitmap_Adaptor *> (new QBitmap_Adaptor (arg1));
 }
 
@@ -357,8 +357,8 @@ static void _call_ctor_QBitmap_Adaptor_3648 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QBitmap_Adaptor *> (new QBitmap_Adaptor (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQBoxLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQBoxLayout.cc
@@ -75,7 +75,7 @@ static void _call_f_addItem_1740 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayoutItem *arg1 = args.read<QLayoutItem * > (heap);
+  QLayoutItem *arg1 = gsi::arg_reader<QLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->addItem (arg1);
 }
@@ -97,9 +97,9 @@ static void _call_f_addLayout_2000 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->addLayout (arg1, arg2);
 }
@@ -119,7 +119,7 @@ static void _call_f_addSpacerItem_1708 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QSpacerItem *arg1 = args.read<QSpacerItem * > (heap);
+  QSpacerItem *arg1 = gsi::arg_reader<QSpacerItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->addSpacerItem (arg1);
 }
@@ -139,7 +139,7 @@ static void _call_f_addSpacing_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->addSpacing (arg1);
 }
@@ -159,7 +159,7 @@ static void _call_f_addStretch_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->addStretch (arg1);
 }
@@ -179,7 +179,7 @@ static void _call_f_addStrut_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->addStrut (arg1);
 }
@@ -203,9 +203,9 @@ static void _call_f_addWidget_4616 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  QFlags<Qt::AlignmentFlag> arg3 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  QFlags<Qt::AlignmentFlag> arg3 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->addWidget (arg1, arg2, arg3);
 }
@@ -285,7 +285,7 @@ static void _call_f_heightForWidth_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QBoxLayout *)cls)->heightForWidth (arg1));
 }
 
@@ -308,9 +308,9 @@ static void _call_f_insertLayout_2659 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QLayout *arg2 = args.read<QLayout * > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QLayout *arg2 = gsi::arg_reader<QLayout * >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->insertLayout (arg1, arg2, arg3);
 }
@@ -332,8 +332,8 @@ static void _call_f_insertSpacerItem_2367 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QSpacerItem *arg2 = args.read<QSpacerItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QSpacerItem *arg2 = gsi::arg_reader<QSpacerItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->insertSpacerItem (arg1, arg2);
 }
@@ -355,8 +355,8 @@ static void _call_f_insertSpacing_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->insertSpacing (arg1, arg2);
 }
@@ -378,8 +378,8 @@ static void _call_f_insertStretch_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->insertStretch (arg1, arg2);
 }
@@ -405,10 +405,10 @@ static void _call_f_insertWidget_5275 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
-  QFlags<Qt::AlignmentFlag> arg4 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  QFlags<Qt::AlignmentFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->insertWidget (arg1, arg2, arg3, arg4);
 }
@@ -444,7 +444,7 @@ static void _call_f_itemAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QBoxLayout *)cls)->itemAt (arg1));
 }
 
@@ -478,7 +478,7 @@ static void _call_f_minimumHeightForWidth_c767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QBoxLayout *)cls)->minimumHeightForWidth (arg1));
 }
 
@@ -512,7 +512,7 @@ static void _call_f_setDirection_2497 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QBoxLayout::Direction>::target_type & arg1 = args.read<const qt_gsi::Converter<QBoxLayout::Direction>::target_type & > (heap);
+  const qt_gsi::Converter<QBoxLayout::Direction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QBoxLayout::Direction>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->setDirection (qt_gsi::QtToCppAdaptor<QBoxLayout::Direction>(arg1).cref());
 }
@@ -532,7 +532,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->setGeometry (arg1);
 }
@@ -552,7 +552,7 @@ static void _call_f_setSpacing_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->setSpacing (arg1);
 }
@@ -574,8 +574,8 @@ static void _call_f_setStretch_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout *)cls)->setStretch (arg1, arg2);
 }
@@ -597,8 +597,8 @@ static void _call_f_setStretchFactor_1974 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args.read<int > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QBoxLayout *)cls)->setStretchFactor (arg1, arg2));
 }
 
@@ -619,8 +619,8 @@ static void _call_f_setStretchFactor_2000 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
-  int arg2 = args.read<int > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QBoxLayout *)cls)->setStretchFactor (arg1, arg2));
 }
 
@@ -669,7 +669,7 @@ static void _call_f_stretch_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QBoxLayout *)cls)->stretch (arg1));
 }
 
@@ -688,7 +688,7 @@ static void _call_f_takeAt_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QBoxLayout *)cls)->takeAt (arg1));
 }
 
@@ -709,8 +709,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QBoxLayout::tr (arg1, arg2));
 }
 
@@ -733,9 +733,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QBoxLayout::tr (arg1, arg2, arg3));
 }
 
@@ -756,8 +756,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QBoxLayout::trUtf8 (arg1, arg2));
 }
 
@@ -780,9 +780,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QBoxLayout::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1322,8 +1322,8 @@ static void _call_ctor_QBoxLayout_Adaptor_3704 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QBoxLayout::Direction>::target_type & arg1 = args.read<const qt_gsi::Converter<QBoxLayout::Direction>::target_type & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const qt_gsi::Converter<QBoxLayout::Direction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QBoxLayout::Direction>::target_type & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QBoxLayout_Adaptor *> (new QBoxLayout_Adaptor (qt_gsi::QtToCppAdaptor<QBoxLayout::Direction>(arg1).cref(), arg2));
 }
 
@@ -1341,7 +1341,7 @@ static void _call_fp_addChildLayout_1341 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout_Adaptor *)cls)->fp_QBoxLayout_addChildLayout_1341 (arg1);
@@ -1361,7 +1361,7 @@ static void _call_fp_addChildWidget_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout_Adaptor *)cls)->fp_QBoxLayout_addChildWidget_1315 (arg1);
 }
@@ -1404,7 +1404,7 @@ static void _call_fp_alignmentRect_c1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QBoxLayout_Adaptor *)cls)->fp_QBoxLayout_alignmentRect_c1792 (arg1));
 }
 
@@ -1489,7 +1489,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QBoxLayout_Adaptor *)cls)->emitter_QBoxLayout_destroyed_1302 (arg1);
 }
 
@@ -1685,8 +1685,8 @@ static void _call_fp_insertItem_2399 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QLayoutItem *arg2 = args.read<QLayoutItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QLayoutItem *arg2 = gsi::arg_reader<QLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout_Adaptor *)cls)->fp_QBoxLayout_insertItem_2399 (arg1, arg2);
 }
@@ -1847,7 +1847,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QBoxLayout_Adaptor *)cls)->fp_QBoxLayout_receivers_c1731 (arg1));
 }
 
@@ -2007,7 +2007,7 @@ static void _call_fp_widgetEvent_1217 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBoxLayout_Adaptor *)cls)->fp_QBoxLayout_widgetEvent_1217 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQBrush.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQBrush.cc
@@ -71,7 +71,7 @@ static void _call_ctor_QBrush_1794 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::BrushStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (args, heap);
   ret.write<QBrush *> (new QBrush (qt_gsi::QtToCppAdaptor<Qt::BrushStyle>(arg1).cref()));
 }
 
@@ -92,8 +92,8 @@ static void _call_ctor_QBrush_3591 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
-  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::BrushStyle>::target_type & > (heap) : (const qt_gsi::Converter<Qt::BrushStyle>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::BrushStyle>(heap, Qt::SolidPattern));
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
+  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::BrushStyle>(heap, Qt::SolidPattern), heap);
   ret.write<QBrush *> (new QBrush (arg1, qt_gsi::QtToCppAdaptor<Qt::BrushStyle>(arg2).cref()));
 }
 
@@ -114,8 +114,8 @@ static void _call_ctor_QBrush_3539 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GlobalColor>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::BrushStyle>::target_type & > (heap) : (const qt_gsi::Converter<Qt::BrushStyle>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::BrushStyle>(heap, Qt::SolidPattern));
+  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GlobalColor>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::BrushStyle>(heap, Qt::SolidPattern), heap);
   ret.write<QBrush *> (new QBrush (qt_gsi::QtToCppAdaptor<Qt::GlobalColor>(arg1).cref(), qt_gsi::QtToCppAdaptor<Qt::BrushStyle>(arg2).cref()));
 }
 
@@ -136,8 +136,8 @@ static void _call_ctor_QBrush_3814 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QBrush *> (new QBrush (arg1, arg2));
 }
 
@@ -158,8 +158,8 @@ static void _call_ctor_QBrush_3762 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GlobalColor>::target_type & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
+  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GlobalColor>::target_type & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QBrush *> (new QBrush (qt_gsi::QtToCppAdaptor<Qt::GlobalColor>(arg1).cref(), arg2));
 }
 
@@ -178,7 +178,7 @@ static void _call_ctor_QBrush_2017 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QBrush *> (new QBrush (arg1));
 }
 
@@ -197,7 +197,7 @@ static void _call_ctor_QBrush_1877 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
   ret.write<QBrush *> (new QBrush (arg1));
 }
 
@@ -216,7 +216,7 @@ static void _call_ctor_QBrush_1910 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   ret.write<QBrush *> (new QBrush (arg1));
 }
 
@@ -235,7 +235,7 @@ static void _call_ctor_QBrush_2208 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGradient &arg1 = args.read<const QGradient & > (heap);
+  const QGradient &arg1 = gsi::arg_reader<const QGradient & >() (args, heap);
   ret.write<QBrush *> (new QBrush (arg1));
 }
 
@@ -329,7 +329,7 @@ static void _call_f_operator_excl__eq__c1910 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   ret.write<bool > ((bool)((QBrush *)cls)->operator!= (arg1));
 }
 
@@ -348,7 +348,7 @@ static void _call_f_operator_eq__1910 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   ret.write<QBrush & > ((QBrush &)((QBrush *)cls)->operator= (arg1));
 }
 
@@ -367,7 +367,7 @@ static void _call_f_operator_eq__eq__c1910 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   ret.write<bool > ((bool)((QBrush *)cls)->operator== (arg1));
 }
 
@@ -386,7 +386,7 @@ static void _call_f_setColor_1905 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBrush *)cls)->setColor (arg1);
 }
@@ -406,7 +406,7 @@ static void _call_f_setColor_1853 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GlobalColor>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GlobalColor>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBrush *)cls)->setColor (qt_gsi::QtToCppAdaptor<Qt::GlobalColor>(arg1).cref());
 }
@@ -426,7 +426,7 @@ static void _call_f_setMatrix_2023 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBrush *)cls)->setMatrix (arg1);
 }
@@ -446,7 +446,7 @@ static void _call_f_setStyle_1794 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::BrushStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBrush *)cls)->setStyle (qt_gsi::QtToCppAdaptor<Qt::BrushStyle>(arg1).cref());
 }
@@ -466,7 +466,7 @@ static void _call_f_setTexture_2017 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBrush *)cls)->setTexture (arg1);
 }
@@ -486,7 +486,7 @@ static void _call_f_setTextureImage_1877 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBrush *)cls)->setTextureImage (arg1);
 }
@@ -506,7 +506,7 @@ static void _call_f_setTransform_2350 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QBrush *)cls)->setTransform (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQButtonGroup.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQButtonGroup.cc
@@ -69,7 +69,7 @@ static void _call_f_addButton_2159 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QButtonGroup *)cls)->addButton (arg1);
 }
@@ -91,8 +91,8 @@ static void _call_f_addButton_2818 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
-  int arg2 = args.read<int > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QButtonGroup *)cls)->addButton (arg1, arg2);
 }
@@ -112,7 +112,7 @@ static void _call_f_button_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QAbstractButton * > ((QAbstractButton *)((QButtonGroup *)cls)->button (arg1));
 }
 
@@ -191,7 +191,7 @@ static void _call_f_id_c2159 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ret.write<int > ((int)((QButtonGroup *)cls)->id (arg1));
 }
 
@@ -210,7 +210,7 @@ static void _call_f_removeButton_2159 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QButtonGroup *)cls)->removeButton (arg1);
 }
@@ -230,7 +230,7 @@ static void _call_f_setExclusive_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QButtonGroup *)cls)->setExclusive (arg1);
 }
@@ -252,8 +252,8 @@ static void _call_f_setId_2818 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
-  int arg2 = args.read<int > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QButtonGroup *)cls)->setId (arg1, arg2);
 }
@@ -275,8 +275,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QButtonGroup::tr (arg1, arg2));
 }
 
@@ -299,9 +299,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QButtonGroup::tr (arg1, arg2, arg3));
 }
 
@@ -322,8 +322,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QButtonGroup::trUtf8 (arg1, arg2));
 }
 
@@ -346,9 +346,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QButtonGroup::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -578,7 +578,7 @@ static void _call_ctor_QButtonGroup_Adaptor_1302 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QButtonGroup_Adaptor *> (new QButtonGroup_Adaptor (arg1));
 }
 
@@ -596,7 +596,7 @@ static void _call_emitter_buttonClicked_2159 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ((QButtonGroup_Adaptor *)cls)->emitter_QButtonGroup_buttonClicked_2159 (arg1);
 }
 
@@ -614,7 +614,7 @@ static void _call_emitter_buttonClicked_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QButtonGroup_Adaptor *)cls)->emitter_QButtonGroup_buttonClicked_767 (arg1);
 }
 
@@ -632,7 +632,7 @@ static void _call_emitter_buttonPressed_2159 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ((QButtonGroup_Adaptor *)cls)->emitter_QButtonGroup_buttonPressed_2159 (arg1);
 }
 
@@ -650,7 +650,7 @@ static void _call_emitter_buttonPressed_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QButtonGroup_Adaptor *)cls)->emitter_QButtonGroup_buttonPressed_767 (arg1);
 }
 
@@ -668,7 +668,7 @@ static void _call_emitter_buttonReleased_2159 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ((QButtonGroup_Adaptor *)cls)->emitter_QButtonGroup_buttonReleased_2159 (arg1);
 }
 
@@ -686,7 +686,7 @@ static void _call_emitter_buttonReleased_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QButtonGroup_Adaptor *)cls)->emitter_QButtonGroup_buttonReleased_767 (arg1);
 }
 
@@ -752,7 +752,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QButtonGroup_Adaptor *)cls)->emitter_QButtonGroup_destroyed_1302 (arg1);
 }
 
@@ -843,7 +843,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QButtonGroup_Adaptor *)cls)->fp_QButtonGroup_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQCDEStyle.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQCDEStyle.cc
@@ -88,10 +88,10 @@ static void _call_f_drawControl_c8285 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ControlElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ControlElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCDEStyle *)cls)->drawControl (qt_gsi::QtToCppAdaptor<QStyle::ControlElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -117,10 +117,10 @@ static void _call_f_drawPrimitive_c8501 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCDEStyle *)cls)->drawPrimitive (qt_gsi::QtToCppAdaptor<QStyle::PrimitiveElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -144,9 +144,9 @@ static void _call_f_pixelMetric_c6642 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QCDEStyle *)cls)->pixelMetric (qt_gsi::QtToCppAdaptor<QStyle::PixelMetric>(arg1).cref(), arg2, arg3));
 }
 
@@ -182,8 +182,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCDEStyle::tr (arg1, arg2));
 }
 
@@ -206,9 +206,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCDEStyle::tr (arg1, arg2, arg3));
 }
 
@@ -229,8 +229,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCDEStyle::trUtf8 (arg1, arg2));
 }
 
@@ -253,9 +253,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCDEStyle::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -782,7 +782,7 @@ static void _call_ctor_QCDEStyle_Adaptor_864 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<QCDEStyle_Adaptor *> (new QCDEStyle_Adaptor (arg1));
 }
 
@@ -848,7 +848,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QCDEStyle_Adaptor *)cls)->emitter_QCDEStyle_destroyed_1302 (arg1);
 }
 
@@ -1246,11 +1246,11 @@ static void _call_fp_layoutSpacingImplementation_c11697 (const qt_gsi::GenericMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QStyleOption *arg4 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg5 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QStyleOption *arg4 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg5 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QCDEStyle_Adaptor *)cls)->fp_QCDEStyle_layoutSpacingImplementation_c11697 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1369,7 +1369,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QCDEStyle_Adaptor *)cls)->fp_QCDEStyle_receivers_c1731 (arg1));
 }
 
@@ -1437,9 +1437,9 @@ static void _call_fp_standardIconImplementation_c6956 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QIcon > ((QIcon)((QCDEStyle_Adaptor *)cls)->fp_QCDEStyle_standardIconImplementation_c6956 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQCalendarWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQCalendarWidget.cc
@@ -143,7 +143,7 @@ static void _call_f_dateTextFormat_c1776 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ret.write<QTextCharFormat > ((QTextCharFormat)((QCalendarWidget *)cls)->dateTextFormat (arg1));
 }
 
@@ -359,8 +359,8 @@ static void _call_f_setCurrentPage_1426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setCurrentPage (arg1, arg2);
 }
@@ -380,7 +380,7 @@ static void _call_f_setDateEditAcceptDelay_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setDateEditAcceptDelay (arg1);
 }
@@ -400,7 +400,7 @@ static void _call_f_setDateEditEnabled_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setDateEditEnabled (arg1);
 }
@@ -422,8 +422,8 @@ static void _call_f_setDateRange_3444 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
-  const QDate &arg2 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
+  const QDate &arg2 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setDateRange (arg1, arg2);
 }
@@ -445,8 +445,8 @@ static void _call_f_setDateTextFormat_4482 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
-  const QTextCharFormat &arg2 = args.read<const QTextCharFormat & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
+  const QTextCharFormat &arg2 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setDateTextFormat (arg1, arg2);
 }
@@ -466,7 +466,7 @@ static void _call_f_setFirstDayOfWeek_1612 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DayOfWeek>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DayOfWeek>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DayOfWeek>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DayOfWeek>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setFirstDayOfWeek (qt_gsi::QtToCppAdaptor<Qt::DayOfWeek>(arg1).cref());
 }
@@ -486,7 +486,7 @@ static void _call_f_setGridVisible_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setGridVisible (arg1);
 }
@@ -506,7 +506,7 @@ static void _call_f_setHeaderTextFormat_2814 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setHeaderTextFormat (arg1);
 }
@@ -526,7 +526,7 @@ static void _call_f_setHeaderVisible_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setHeaderVisible (arg1);
 }
@@ -546,7 +546,7 @@ static void _call_f_setHorizontalHeaderFormat_4307 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QCalendarWidget::HorizontalHeaderFormat>::target_type & arg1 = args.read<const qt_gsi::Converter<QCalendarWidget::HorizontalHeaderFormat>::target_type & > (heap);
+  const qt_gsi::Converter<QCalendarWidget::HorizontalHeaderFormat>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QCalendarWidget::HorizontalHeaderFormat>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setHorizontalHeaderFormat (qt_gsi::QtToCppAdaptor<QCalendarWidget::HorizontalHeaderFormat>(arg1).cref());
 }
@@ -566,7 +566,7 @@ static void _call_f_setMaximumDate_1776 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setMaximumDate (arg1);
 }
@@ -586,7 +586,7 @@ static void _call_f_setMinimumDate_1776 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setMinimumDate (arg1);
 }
@@ -606,7 +606,7 @@ static void _call_f_setNavigationBarVisible_864 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setNavigationBarVisible (arg1);
 }
@@ -626,7 +626,7 @@ static void _call_f_setSelectedDate_1776 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setSelectedDate (arg1);
 }
@@ -646,7 +646,7 @@ static void _call_f_setSelectionMode_3362 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QCalendarWidget::SelectionMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QCalendarWidget::SelectionMode>::target_type & > (heap);
+  const qt_gsi::Converter<QCalendarWidget::SelectionMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QCalendarWidget::SelectionMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setSelectionMode (qt_gsi::QtToCppAdaptor<QCalendarWidget::SelectionMode>(arg1).cref());
 }
@@ -666,7 +666,7 @@ static void _call_f_setVerticalHeaderFormat_4067 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QCalendarWidget::VerticalHeaderFormat>::target_type & arg1 = args.read<const qt_gsi::Converter<QCalendarWidget::VerticalHeaderFormat>::target_type & > (heap);
+  const qt_gsi::Converter<QCalendarWidget::VerticalHeaderFormat>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QCalendarWidget::VerticalHeaderFormat>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setVerticalHeaderFormat (qt_gsi::QtToCppAdaptor<QCalendarWidget::VerticalHeaderFormat>(arg1).cref());
 }
@@ -688,8 +688,8 @@ static void _call_f_setWeekdayTextFormat_4318 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DayOfWeek>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DayOfWeek>::target_type & > (heap);
-  const QTextCharFormat &arg2 = args.read<const QTextCharFormat & > (heap);
+  const qt_gsi::Converter<Qt::DayOfWeek>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DayOfWeek>::target_type & >() (args, heap);
+  const QTextCharFormat &arg2 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget *)cls)->setWeekdayTextFormat (qt_gsi::QtToCppAdaptor<Qt::DayOfWeek>(arg1).cref(), arg2);
 }
@@ -835,7 +835,7 @@ static void _call_f_weekdayTextFormat_c1612 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DayOfWeek>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DayOfWeek>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DayOfWeek>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DayOfWeek>::target_type & >() (args, heap);
   ret.write<QTextCharFormat > ((QTextCharFormat)((QCalendarWidget *)cls)->weekdayTextFormat (qt_gsi::QtToCppAdaptor<Qt::DayOfWeek>(arg1).cref()));
 }
 
@@ -871,8 +871,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCalendarWidget::tr (arg1, arg2));
 }
 
@@ -895,9 +895,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCalendarWidget::tr (arg1, arg2, arg3));
 }
 
@@ -918,8 +918,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCalendarWidget::trUtf8 (arg1, arg2));
 }
 
@@ -942,9 +942,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCalendarWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1895,7 +1895,7 @@ static void _call_ctor_QCalendarWidget_Adaptor_1315 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QCalendarWidget_Adaptor *> (new QCalendarWidget_Adaptor (arg1));
 }
 
@@ -1937,7 +1937,7 @@ static void _call_emitter_activated_1776 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ((QCalendarWidget_Adaptor *)cls)->emitter_QCalendarWidget_activated_1776 (arg1);
 }
 
@@ -2003,7 +2003,7 @@ static void _call_emitter_clicked_1776 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ((QCalendarWidget_Adaptor *)cls)->emitter_QCalendarWidget_clicked_1776 (arg1);
 }
 
@@ -2073,9 +2073,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget_Adaptor *)cls)->fp_QCalendarWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -2096,8 +2096,8 @@ static void _call_emitter_currentPageChanged_1426 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QCalendarWidget_Adaptor *)cls)->emitter_QCalendarWidget_currentPageChanged_1426 (arg1, arg2);
 }
 
@@ -2115,7 +2115,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QCalendarWidget_Adaptor *)cls)->emitter_QCalendarWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2159,8 +2159,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget_Adaptor *)cls)->fp_QCalendarWidget_destroy_1620 (arg1, arg2);
 }
@@ -2179,7 +2179,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QCalendarWidget_Adaptor *)cls)->emitter_QCalendarWidget_destroyed_1302 (arg1);
 }
 
@@ -2982,7 +2982,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QCalendarWidget_Adaptor *)cls)->fp_QCalendarWidget_receivers_c1731 (arg1));
 }
 
@@ -3206,7 +3206,7 @@ static void _call_fp_updateCell_1776 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCalendarWidget_Adaptor *)cls)->fp_QCalendarWidget_updateCell_1776 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQCheckBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQCheckBox.cc
@@ -143,7 +143,7 @@ static void _call_f_setCheckState_1740 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CheckState>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CheckState>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CheckState>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CheckState>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCheckBox *)cls)->setCheckState (qt_gsi::QtToCppAdaptor<Qt::CheckState>(arg1).cref());
 }
@@ -163,7 +163,7 @@ static void _call_f_setTristate_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCheckBox *)cls)->setTristate (arg1);
 }
@@ -200,8 +200,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCheckBox::tr (arg1, arg2));
 }
 
@@ -224,9 +224,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCheckBox::tr (arg1, arg2, arg3));
 }
 
@@ -247,8 +247,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCheckBox::trUtf8 (arg1, arg2));
 }
 
@@ -271,9 +271,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCheckBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1232,7 +1232,7 @@ static void _call_ctor_QCheckBox_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QCheckBox_Adaptor *> (new QCheckBox_Adaptor (arg1));
 }
 
@@ -1252,8 +1252,8 @@ static void _call_ctor_QCheckBox_Adaptor_3232 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QCheckBox_Adaptor *> (new QCheckBox_Adaptor (arg1, arg2));
 }
 
@@ -1363,7 +1363,7 @@ static void _call_emitter_clicked_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ((QCheckBox_Adaptor *)cls)->emitter_QCheckBox_clicked_864 (arg1);
 }
 
@@ -1433,9 +1433,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCheckBox_Adaptor *)cls)->fp_QCheckBox_create_2208 (arg1, arg2, arg3);
 }
@@ -1454,7 +1454,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QCheckBox_Adaptor *)cls)->emitter_QCheckBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1498,8 +1498,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCheckBox_Adaptor *)cls)->fp_QCheckBox_destroy_1620 (arg1, arg2);
 }
@@ -1518,7 +1518,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QCheckBox_Adaptor *)cls)->emitter_QCheckBox_destroyed_1302 (arg1);
 }
 
@@ -1946,7 +1946,7 @@ static void _call_fp_initStyleOption_c2501 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionButton *arg1 = args.read<QStyleOptionButton * > (heap);
+  QStyleOptionButton *arg1 = gsi::arg_reader<QStyleOptionButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCheckBox_Adaptor *)cls)->fp_QCheckBox_initStyleOption_c2501 (arg1);
 }
@@ -2367,7 +2367,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QCheckBox_Adaptor *)cls)->fp_QCheckBox_receivers_c1731 (arg1));
 }
 
@@ -2519,7 +2519,7 @@ static void _call_emitter_stateChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QCheckBox_Adaptor *)cls)->emitter_QCheckBox_stateChanged_767 (arg1);
 }
 
@@ -2609,7 +2609,7 @@ static void _call_emitter_toggled_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QCheckBox_Adaptor *)cls)->emitter_QCheckBox_toggled_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQCleanlooksStyle.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQCleanlooksStyle.cc
@@ -88,10 +88,10 @@ static void _call_f_drawComplexControl_c9027 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args.read<const QWidget * > (heap);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = gsi::arg_reader<const QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->drawComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -117,10 +117,10 @@ static void _call_f_drawControl_c8285 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ControlElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args.read<const QWidget * > (heap);
+  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ControlElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = gsi::arg_reader<const QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->drawControl (qt_gsi::QtToCppAdaptor<QStyle::ControlElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -146,10 +146,10 @@ static void _call_f_drawItemPixmap_c5678 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  int arg3 = args.read<int > (heap);
-  const QPixmap &arg4 = args.read<const QPixmap & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg4 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->drawItemPixmap (arg1, arg2, arg3, arg4);
 }
@@ -181,13 +181,13 @@ static void _call_f_drawItemText_c10604 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  int arg3 = args.read<int > (heap);
-  const QPalette &arg4 = args.read<const QPalette & > (heap);
-  bool arg5 = args.read<bool > (heap);
-  const QString &arg6 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg7 = args ? args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap) : (const qt_gsi::Converter<QPalette::ColorRole>::target_type &)(qt_gsi::CppToQtReadAdaptor<QPalette::ColorRole>(heap, QPalette::NoRole));
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QPalette &arg4 = gsi::arg_reader<const QPalette & >() (args, heap);
+  bool arg5 = gsi::arg_reader<bool >() (args, heap);
+  const QString &arg6 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg7 = args ? gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QPalette::ColorRole>(heap, QPalette::NoRole), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->drawItemText (arg1, arg2, arg3, arg4, arg5, arg6, qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg7).cref());
 }
@@ -213,10 +213,10 @@ static void _call_f_drawPrimitive_c8501 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->drawPrimitive (qt_gsi::QtToCppAdaptor<QStyle::PrimitiveElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -240,9 +240,9 @@ static void _call_f_generatedIconPixmap_c5776 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QStyleOption *arg3 = args.read<const QStyleOption * > (heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QStyleOption *arg3 = gsi::arg_reader<const QStyleOption * >() (args, heap);
   ret.write<QPixmap > ((QPixmap)((QCleanlooksStyle *)cls)->generatedIconPixmap (qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg1).cref(), arg2, arg3));
 }
 
@@ -267,10 +267,10 @@ static void _call_f_hitTestComplexControl_c9517 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<qt_gsi::Converter<QStyle::SubControl>::target_type > ((qt_gsi::Converter<QStyle::SubControl>::target_type)qt_gsi::CppToQtAdaptor<QStyle::SubControl>(((QCleanlooksStyle *)cls)->hitTestComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4)));
 }
 
@@ -293,9 +293,9 @@ static void _call_f_itemPixmapRect_c4360 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QPixmap &arg3 = args.read<const QPixmap & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg3 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QRect > ((QRect)((QCleanlooksStyle *)cls)->itemPixmapRect (arg1, arg2, arg3));
 }
 
@@ -318,9 +318,9 @@ static void _call_f_pixelMetric_c6642 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QCleanlooksStyle *)cls)->pixelMetric (qt_gsi::QtToCppAdaptor<QStyle::PixelMetric>(arg1).cref(), arg2, arg3));
 }
 
@@ -339,7 +339,7 @@ static void _call_f_polish_1315 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->polish (arg1);
 }
@@ -359,7 +359,7 @@ static void _call_f_polish_1843 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->polish (arg1);
 }
@@ -379,7 +379,7 @@ static void _call_f_polish_1418 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPalette &arg1 = args.read<QPalette & > (heap);
+  QPalette &arg1 = gsi::arg_reader<QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->polish (arg1);
 }
@@ -405,10 +405,10 @@ static void _call_f_sizeFromContents_c8477 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ContentsType>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QSize &arg3 = args.read<const QSize & > (heap);
-  const QWidget *arg4 = args.read<const QWidget * > (heap);
+  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ContentsType>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QSize &arg3 = gsi::arg_reader<const QSize & >() (args, heap);
+  const QWidget *arg4 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<QSize > ((QSize)((QCleanlooksStyle *)cls)->sizeFromContents (qt_gsi::QtToCppAdaptor<QStyle::ContentsType>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -446,9 +446,9 @@ static void _call_f_standardPixmap_c6956 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QPixmap > ((QPixmap)((QCleanlooksStyle *)cls)->standardPixmap (qt_gsi::QtToCppAdaptor<QStyle::StandardPixmap>(arg1).cref(), arg2, arg3));
 }
 
@@ -473,10 +473,10 @@ static void _call_f_styleHint_c8615 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StyleHint>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
-  QStyleHintReturn *arg4 = args ? args.read<QStyleHintReturn * > (heap) : (QStyleHintReturn *)(0);
+  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StyleHint>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
+  QStyleHintReturn *arg4 = args ? gsi::arg_reader<QStyleHintReturn * >() (args, heap) : gsi::arg_maker<QStyleHintReturn * >() (0, heap);
   ret.write<int > ((int)((QCleanlooksStyle *)cls)->styleHint (qt_gsi::QtToCppAdaptor<QStyle::StyleHint>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -501,10 +501,10 @@ static void _call_f_subControlRect_c9798 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = args.read<const qt_gsi::Converter<QStyle::SubControl>::target_type & > (heap);
-  const QWidget *arg4 = args.read<const QWidget * > (heap);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubControl>::target_type & >() (args, heap);
+  const QWidget *arg4 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<QRect > ((QRect)((QCleanlooksStyle *)cls)->subControlRect (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, qt_gsi::QtToCppAdaptor<QStyle::SubControl>(arg3).cref(), arg4));
 }
 
@@ -527,9 +527,9 @@ static void _call_f_subElementRect_c6528 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::SubElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QRect > ((QRect)((QCleanlooksStyle *)cls)->subElementRect (qt_gsi::QtToCppAdaptor<QStyle::SubElement>(arg1).cref(), arg2, arg3));
 }
 
@@ -548,7 +548,7 @@ static void _call_f_unpolish_1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->unpolish (arg1);
 }
@@ -568,7 +568,7 @@ static void _call_f_unpolish_1843 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCleanlooksStyle *)cls)->unpolish (arg1);
 }
@@ -590,8 +590,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCleanlooksStyle::tr (arg1, arg2));
 }
 
@@ -614,9 +614,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCleanlooksStyle::tr (arg1, arg2, arg3));
 }
 
@@ -637,8 +637,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCleanlooksStyle::trUtf8 (arg1, arg2));
 }
 
@@ -661,9 +661,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCleanlooksStyle::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1262,7 +1262,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QCleanlooksStyle_Adaptor *)cls)->emitter_QCleanlooksStyle_destroyed_1302 (arg1);
 }
 
@@ -1660,11 +1660,11 @@ static void _call_fp_layoutSpacingImplementation_c11697 (const qt_gsi::GenericMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QStyleOption *arg4 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg5 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QStyleOption *arg4 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg5 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QCleanlooksStyle_Adaptor *)cls)->fp_QCleanlooksStyle_layoutSpacingImplementation_c11697 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1783,7 +1783,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QCleanlooksStyle_Adaptor *)cls)->fp_QCleanlooksStyle_receivers_c1731 (arg1));
 }
 
@@ -1851,9 +1851,9 @@ static void _call_fp_standardIconImplementation_c6956 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QIcon > ((QIcon)((QCleanlooksStyle_Adaptor *)cls)->fp_QCleanlooksStyle_standardIconImplementation_c6956 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQClipboard.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQClipboard.cc
@@ -69,7 +69,7 @@ static void _call_f_clear_1934 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QClipboard *)cls)->clear (qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg1).cref());
 }
@@ -89,7 +89,7 @@ static void _call_f_image_c1934 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   ret.write<QImage > ((QImage)((QClipboard *)cls)->image (qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg1).cref()));
 }
 
@@ -108,7 +108,7 @@ static void _call_f_mimeData_c1934 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   ret.write<const QMimeData * > ((const QMimeData *)((QClipboard *)cls)->mimeData (qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg1).cref()));
 }
 
@@ -172,7 +172,7 @@ static void _call_f_pixmap_c1934 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   ret.write<QPixmap > ((QPixmap)((QClipboard *)cls)->pixmap (qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg1).cref()));
 }
 
@@ -193,8 +193,8 @@ static void _call_f_setImage_3703 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QClipboard *)cls)->setImage (arg1, qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg2).cref());
 }
@@ -216,8 +216,8 @@ static void _call_f_setMimeData_3299 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMimeData *arg1 = args.read<QMimeData * > (heap);
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  QMimeData *arg1 = gsi::arg_reader<QMimeData * >() (args, heap);
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QClipboard *)cls)->setMimeData (arg1, qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg2).cref());
 }
@@ -239,8 +239,8 @@ static void _call_f_setPixmap_3843 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QClipboard *)cls)->setPixmap (arg1, qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg2).cref());
 }
@@ -262,8 +262,8 @@ static void _call_f_setText_3851 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QClipboard *)cls)->setText (arg1, qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg2).cref());
 }
@@ -313,7 +313,7 @@ static void _call_f_text_c1934 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   ret.write<QString > ((QString)((QClipboard *)cls)->text (qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg1).cref()));
 }
 
@@ -334,8 +334,8 @@ static void _call_f_text_c3156 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
-  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QClipboard::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QClipboard::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard));
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
+  const qt_gsi::Converter<QClipboard::Mode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QClipboard::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QClipboard::Mode>(heap, QClipboard::Clipboard), heap);
   ret.write<QString > ((QString)((QClipboard *)cls)->text (arg1, qt_gsi::QtToCppAdaptor<QClipboard::Mode>(arg2).cref()));
 }
 
@@ -356,8 +356,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QClipboard::tr (arg1, arg2));
 }
 
@@ -380,9 +380,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QClipboard::tr (arg1, arg2, arg3));
 }
 
@@ -403,8 +403,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QClipboard::trUtf8 (arg1, arg2));
 }
 
@@ -427,9 +427,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QClipboard::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQColor.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQColor.cc
@@ -65,7 +65,7 @@ static void _call_ctor_QColor_1853 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GlobalColor>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GlobalColor>::target_type & >() (args, heap);
   ret.write<QColor *> (new QColor (qt_gsi::QtToCppAdaptor<Qt::GlobalColor>(arg1).cref()));
 }
 
@@ -90,10 +90,10 @@ static void _call_ctor_QColor_2744 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(255);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (255, heap);
   ret.write<QColor *> (new QColor (arg1, arg2, arg3, arg4));
 }
 
@@ -112,7 +112,7 @@ static void _call_ctor_QColor_1772 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   ret.write<QColor *> (new QColor (arg1));
 }
 
@@ -131,7 +131,7 @@ static void _call_ctor_QColor_1731 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QColor *> (new QColor (arg1));
 }
 
@@ -150,7 +150,7 @@ static void _call_ctor_QColor_1905 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<QColor *> (new QColor (arg1));
 }
 
@@ -169,7 +169,7 @@ static void _call_ctor_QColor_1539 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QColor::Spec>::target_type & arg1 = args.read<const qt_gsi::Converter<QColor::Spec>::target_type & > (heap);
+  const qt_gsi::Converter<QColor::Spec>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QColor::Spec>::target_type & >() (args, heap);
   ret.write<QColor *> (new QColor (qt_gsi::QtToCppAdaptor<QColor::Spec>(arg1).cref()));
 }
 
@@ -278,7 +278,7 @@ static void _call_f_convertTo_c1539 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QColor::Spec>::target_type & arg1 = args.read<const qt_gsi::Converter<QColor::Spec>::target_type & > (heap);
+  const qt_gsi::Converter<QColor::Spec>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QColor::Spec>::target_type & >() (args, heap);
   ret.write<QColor > ((QColor)((QColor *)cls)->convertTo (qt_gsi::QtToCppAdaptor<QColor::Spec>(arg1).cref()));
 }
 
@@ -327,7 +327,7 @@ static void _call_f_dark_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(200);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (200, heap);
   ret.write<QColor > ((QColor)((QColor *)cls)->dark (arg1));
 }
 
@@ -346,7 +346,7 @@ static void _call_f_darker_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(200);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (200, heap);
   ret.write<QColor > ((QColor)((QColor *)cls)->darker (arg1));
 }
 
@@ -373,11 +373,11 @@ static void _call_f_getCmyk_4333 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
-  int *arg5 = args ? args.read<int * > (heap) : (int *)(0);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
+  int *arg5 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->getCmyk (arg1, arg2, arg3, arg4, arg5);
 }
@@ -405,11 +405,11 @@ static void _call_f_getCmykF_5853 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
-  double *arg5 = args ? args.read<double * > (heap) : (double *)(0);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
+  double *arg5 = args ? gsi::arg_reader<double * >() (args, heap) : gsi::arg_maker<double * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->getCmykF (arg1, arg2, arg3, arg4, arg5);
 }
@@ -435,10 +435,10 @@ static void _call_f_getHsl_c3488 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->getHsl (arg1, arg2, arg3, arg4);
 }
@@ -464,10 +464,10 @@ static void _call_f_getHslF_c4704 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args ? args.read<double * > (heap) : (double *)(0);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = args ? gsi::arg_reader<double * >() (args, heap) : gsi::arg_maker<double * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->getHslF (arg1, arg2, arg3, arg4);
 }
@@ -493,10 +493,10 @@ static void _call_f_getHsv_c3488 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->getHsv (arg1, arg2, arg3, arg4);
 }
@@ -522,10 +522,10 @@ static void _call_f_getHsvF_c4704 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args ? args.read<double * > (heap) : (double *)(0);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = args ? gsi::arg_reader<double * >() (args, heap) : gsi::arg_maker<double * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->getHsvF (arg1, arg2, arg3, arg4);
 }
@@ -551,10 +551,10 @@ static void _call_f_getRgb_c3488 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->getRgb (arg1, arg2, arg3, arg4);
 }
@@ -580,10 +580,10 @@ static void _call_f_getRgbF_c4704 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args ? args.read<double * > (heap) : (double *)(0);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = args ? gsi::arg_reader<double * >() (args, heap) : gsi::arg_maker<double * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->getRgbF (arg1, arg2, arg3, arg4);
 }
@@ -798,7 +798,7 @@ static void _call_f_light_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(150);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (150, heap);
   ret.write<QColor > ((QColor)((QColor *)cls)->light (arg1));
 }
 
@@ -817,7 +817,7 @@ static void _call_f_lighter_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(150);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (150, heap);
   ret.write<QColor > ((QColor)((QColor *)cls)->lighter (arg1));
 }
 
@@ -911,7 +911,7 @@ static void _call_f_operator_excl__eq__c1905 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<bool > ((bool)((QColor *)cls)->operator!= (arg1));
 }
 
@@ -930,7 +930,7 @@ static void _call_f_operator_eq__1905 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<QColor & > ((QColor &)((QColor *)cls)->operator= (arg1));
 }
 
@@ -949,7 +949,7 @@ static void _call_f_operator_eq__1853 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GlobalColor>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GlobalColor>::target_type & >() (args, heap);
   ret.write<QColor & > ((QColor &)((QColor *)cls)->operator= (qt_gsi::QtToCppAdaptor<Qt::GlobalColor>(arg1).cref()));
 }
 
@@ -968,7 +968,7 @@ static void _call_f_operator_eq__eq__c1905 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<bool > ((bool)((QColor *)cls)->operator== (arg1));
 }
 
@@ -1077,7 +1077,7 @@ static void _call_f_setAlpha_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setAlpha (arg1);
 }
@@ -1097,7 +1097,7 @@ static void _call_f_setAlphaF_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setAlphaF (arg1);
 }
@@ -1117,7 +1117,7 @@ static void _call_f_setBlue_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setBlue (arg1);
 }
@@ -1137,7 +1137,7 @@ static void _call_f_setBlueF_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setBlueF (arg1);
 }
@@ -1165,11 +1165,11 @@ static void _call_f_setCmyk_3403 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args ? args.read<int > (heap) : (int)(255);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (255, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setCmyk (arg1, arg2, arg3, arg4, arg5);
 }
@@ -1197,11 +1197,11 @@ static void _call_f_setCmykF_4923 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args ? args.read<double > (heap) : (double)(1.0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setCmykF (arg1, arg2, arg3, arg4, arg5);
 }
@@ -1221,7 +1221,7 @@ static void _call_f_setGreen_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setGreen (arg1);
 }
@@ -1241,7 +1241,7 @@ static void _call_f_setGreenF_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setGreenF (arg1);
 }
@@ -1267,10 +1267,10 @@ static void _call_f_setHsl_2744 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(255);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (255, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setHsl (arg1, arg2, arg3, arg4);
 }
@@ -1296,10 +1296,10 @@ static void _call_f_setHslF_3960 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args ? args.read<double > (heap) : (double)(1.0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setHslF (arg1, arg2, arg3, arg4);
 }
@@ -1325,10 +1325,10 @@ static void _call_f_setHsv_2744 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(255);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (255, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setHsv (arg1, arg2, arg3, arg4);
 }
@@ -1354,10 +1354,10 @@ static void _call_f_setHsvF_3960 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args ? args.read<double > (heap) : (double)(1.0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setHsvF (arg1, arg2, arg3, arg4);
 }
@@ -1377,7 +1377,7 @@ static void _call_f_setNamedColor_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setNamedColor (arg1);
 }
@@ -1397,7 +1397,7 @@ static void _call_f_setRed_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setRed (arg1);
 }
@@ -1417,7 +1417,7 @@ static void _call_f_setRedF_1071 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setRedF (arg1);
 }
@@ -1443,10 +1443,10 @@ static void _call_f_setRgb_2744 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(255);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (255, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setRgb (arg1, arg2, arg3, arg4);
 }
@@ -1466,7 +1466,7 @@ static void _call_f_setRgb_1772 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setRgb (arg1);
 }
@@ -1492,10 +1492,10 @@ static void _call_f_setRgbF_3960 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args ? args.read<double > (heap) : (double)(1.0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setRgbF (arg1, arg2, arg3, arg4);
 }
@@ -1515,7 +1515,7 @@ static void _call_f_setRgba_1772 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColor *)cls)->setRgba (arg1);
 }
@@ -1693,11 +1693,11 @@ static void _call_f_fromCmyk_3403 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args ? args.read<int > (heap) : (int)(255);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (255, heap);
   ret.write<QColor > ((QColor)QColor::fromCmyk (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1724,11 +1724,11 @@ static void _call_f_fromCmykF_4923 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args ? args.read<double > (heap) : (double)(1.0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.0, heap);
   ret.write<QColor > ((QColor)QColor::fromCmykF (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1753,10 +1753,10 @@ static void _call_f_fromHsl_2744 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(255);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (255, heap);
   ret.write<QColor > ((QColor)QColor::fromHsl (arg1, arg2, arg3, arg4));
 }
 
@@ -1781,10 +1781,10 @@ static void _call_f_fromHslF_3960 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args ? args.read<double > (heap) : (double)(1.0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.0, heap);
   ret.write<QColor > ((QColor)QColor::fromHslF (arg1, arg2, arg3, arg4));
 }
 
@@ -1809,10 +1809,10 @@ static void _call_f_fromHsv_2744 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(255);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (255, heap);
   ret.write<QColor > ((QColor)QColor::fromHsv (arg1, arg2, arg3, arg4));
 }
 
@@ -1837,10 +1837,10 @@ static void _call_f_fromHsvF_3960 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args ? args.read<double > (heap) : (double)(1.0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.0, heap);
   ret.write<QColor > ((QColor)QColor::fromHsvF (arg1, arg2, arg3, arg4));
 }
 
@@ -1859,7 +1859,7 @@ static void _call_f_fromRgb_1772 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   ret.write<QColor > ((QColor)QColor::fromRgb (arg1));
 }
 
@@ -1884,10 +1884,10 @@ static void _call_f_fromRgb_2744 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(255);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (255, heap);
   ret.write<QColor > ((QColor)QColor::fromRgb (arg1, arg2, arg3, arg4));
 }
 
@@ -1912,10 +1912,10 @@ static void _call_f_fromRgbF_3960 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args ? args.read<double > (heap) : (double)(1.0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.0, heap);
   ret.write<QColor > ((QColor)QColor::fromRgbF (arg1, arg2, arg3, arg4));
 }
 
@@ -1934,7 +1934,7 @@ static void _call_f_fromRgba_1772 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   ret.write<QColor > ((QColor)QColor::fromRgba (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQColorDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQColorDialog.cc
@@ -145,8 +145,8 @@ static void _call_f_open_2925 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColorDialog *)cls)->open (arg1, arg2);
 }
@@ -196,7 +196,7 @@ static void _call_f_setCurrentColor_1905 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColorDialog *)cls)->setCurrentColor (arg1);
 }
@@ -218,8 +218,8 @@ static void _call_f_setOption_4228 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QColorDialog::ColorDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QColorDialog::ColorDialogOption>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QColorDialog::ColorDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QColorDialog::ColorDialogOption>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColorDialog *)cls)->setOption (qt_gsi::QtToCppAdaptor<QColorDialog::ColorDialogOption>(arg1).cref(), arg2);
 }
@@ -239,7 +239,7 @@ static void _call_f_setOptions_4168 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QColorDialog::ColorDialogOption> arg1 = args.read<QFlags<QColorDialog::ColorDialogOption> > (heap);
+  QFlags<QColorDialog::ColorDialogOption> arg1 = gsi::arg_reader<QFlags<QColorDialog::ColorDialogOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColorDialog *)cls)->setOptions (arg1);
 }
@@ -259,7 +259,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColorDialog *)cls)->setVisible (arg1);
 }
@@ -279,7 +279,7 @@ static void _call_f_testOption_c3472 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QColorDialog::ColorDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QColorDialog::ColorDialogOption>::target_type & > (heap);
+  const qt_gsi::Converter<QColorDialog::ColorDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QColorDialog::ColorDialogOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QColorDialog *)cls)->testOption (qt_gsi::QtToCppAdaptor<QColorDialog::ColorDialogOption>(arg1).cref()));
 }
 
@@ -298,7 +298,7 @@ static void _call_f_customColor_767 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<unsigned int > ((unsigned int)QColorDialog::customColor (arg1));
 }
 
@@ -338,10 +338,10 @@ static void _call_f_getColor_9089 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  QFlags<QColorDialog::ColorDialogOption> arg4 = args ? args.read<QFlags<QColorDialog::ColorDialogOption> > (heap) : (QFlags<QColorDialog::ColorDialogOption>)(0);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QColorDialog::ColorDialogOption> arg4 = args ? gsi::arg_reader<QFlags<QColorDialog::ColorDialogOption> >() (args, heap) : gsi::arg_maker<QFlags<QColorDialog::ColorDialogOption> >() (0, heap);
   ret.write<QColor > ((QColor)QColorDialog::getColor (arg1, arg2, arg3, arg4));
 }
 
@@ -362,8 +362,8 @@ static void _call_f_getColor_3112 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args ? args.read<const QColor & > (heap) : (const QColor &)(Qt::white);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QColor &arg1 = args ? gsi::arg_reader<const QColor & >() (args, heap) : gsi::arg_maker<const QColor & >() (Qt::white, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QColor > ((QColor)QColorDialog::getColor (arg1, arg2));
 }
 
@@ -386,9 +386,9 @@ static void _call_f_getRgba_3921 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args ? args.read<unsigned int > (heap) : (unsigned int)(0xffffffff);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  unsigned int arg1 = args ? gsi::arg_reader<unsigned int >() (args, heap) : gsi::arg_maker<unsigned int >() (0xffffffff, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<unsigned int > ((unsigned int)QColorDialog::getRgba (arg1, arg2, arg3));
 }
 
@@ -409,8 +409,8 @@ static void _call_f_setCustomColor_2431 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  unsigned int arg2 = args.read<unsigned int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  unsigned int arg2 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QColorDialog::setCustomColor (arg1, arg2);
 }
@@ -432,8 +432,8 @@ static void _call_f_setStandardColor_2431 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  unsigned int arg2 = args.read<unsigned int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  unsigned int arg2 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QColorDialog::setStandardColor (arg1, arg2);
 }
@@ -455,8 +455,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QColorDialog::tr (arg1, arg2));
 }
 
@@ -479,9 +479,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QColorDialog::tr (arg1, arg2, arg3));
 }
 
@@ -502,8 +502,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QColorDialog::trUtf8 (arg1, arg2));
 }
 
@@ -526,9 +526,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QColorDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1499,7 +1499,7 @@ static void _call_ctor_QColorDialog_Adaptor_1315 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QColorDialog_Adaptor *> (new QColorDialog_Adaptor (arg1));
 }
 
@@ -1519,8 +1519,8 @@ static void _call_ctor_QColorDialog_Adaptor_3112 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QColorDialog_Adaptor *> (new QColorDialog_Adaptor (arg1, arg2));
 }
 
@@ -1596,7 +1596,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColorDialog_Adaptor *)cls)->fp_QColorDialog_adjustPosition_1315 (arg1);
 }
@@ -1687,7 +1687,7 @@ static void _call_emitter_colorSelected_1905 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ((QColorDialog_Adaptor *)cls)->emitter_QColorDialog_colorSelected_1905 (arg1);
 }
 
@@ -1733,9 +1733,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColorDialog_Adaptor *)cls)->fp_QColorDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -1754,7 +1754,7 @@ static void _call_emitter_currentColorChanged_1905 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ((QColorDialog_Adaptor *)cls)->emitter_QColorDialog_currentColorChanged_1905 (arg1);
 }
 
@@ -1772,7 +1772,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QColorDialog_Adaptor *)cls)->emitter_QColorDialog_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1816,8 +1816,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColorDialog_Adaptor *)cls)->fp_QColorDialog_destroy_1620 (arg1, arg2);
 }
@@ -1836,7 +1836,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QColorDialog_Adaptor *)cls)->emitter_QColorDialog_destroyed_1302 (arg1);
 }
 
@@ -2095,7 +2095,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QColorDialog_Adaptor *)cls)->emitter_QColorDialog_finished_767 (arg1);
 }
 
@@ -2651,7 +2651,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QColorDialog_Adaptor *)cls)->fp_QColorDialog_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQColormap.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQColormap.cc
@@ -51,7 +51,7 @@ static void _call_ctor_QColormap_2223 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColormap &arg1 = args.read<const QColormap & > (heap);
+  const QColormap &arg1 = gsi::arg_reader<const QColormap & >() (args, heap);
   ret.write<QColormap *> (new QColormap (arg1));
 }
 
@@ -70,7 +70,7 @@ static void _call_f_colorAt_c1772 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   ret.write<const QColor > ((const QColor)((QColormap *)cls)->colorAt (arg1));
 }
 
@@ -134,7 +134,7 @@ static void _call_f_operator_eq__2223 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColormap &arg1 = args.read<const QColormap & > (heap);
+  const QColormap &arg1 = gsi::arg_reader<const QColormap & >() (args, heap);
   ret.write<QColormap & > ((QColormap &)((QColormap *)cls)->operator= (arg1));
 }
 
@@ -153,7 +153,7 @@ static void _call_f_pixel_c1905 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<unsigned int > ((unsigned int)((QColormap *)cls)->pixel (arg1));
 }
 
@@ -203,7 +203,7 @@ static void _call_f_instance_767 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(-1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QColormap > ((QColormap)QColormap::instance (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQColumnView.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQColumnView.cc
@@ -134,7 +134,7 @@ static void _call_f_indexAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QColumnView *)cls)->indexAt (arg1));
 }
 
@@ -185,8 +185,8 @@ static void _call_f_scrollTo_5576 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible));
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView *)cls)->scrollTo (arg1, qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollHint>(arg2).cref());
 }
@@ -222,7 +222,7 @@ static void _call_f_setColumnWidths_2259 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<int> &arg1 = args.read<const QList<int> & > (heap);
+  const QList<int> &arg1 = gsi::arg_reader<const QList<int> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView *)cls)->setColumnWidths (arg1);
 }
@@ -242,7 +242,7 @@ static void _call_f_setModel_2419 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView *)cls)->setModel (arg1);
 }
@@ -262,7 +262,7 @@ static void _call_f_setPreviewWidget_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView *)cls)->setPreviewWidget (arg1);
 }
@@ -282,7 +282,7 @@ static void _call_f_setResizeGripsVisible_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView *)cls)->setResizeGripsVisible (arg1);
 }
@@ -302,7 +302,7 @@ static void _call_f_setRootIndex_2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView *)cls)->setRootIndex (arg1);
 }
@@ -322,7 +322,7 @@ static void _call_f_setSelectionModel_2533 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QItemSelectionModel *arg1 = args.read<QItemSelectionModel * > (heap);
+  QItemSelectionModel *arg1 = gsi::arg_reader<QItemSelectionModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView *)cls)->setSelectionModel (arg1);
 }
@@ -357,7 +357,7 @@ static void _call_f_visualRect_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QRect > ((QRect)((QColumnView *)cls)->visualRect (arg1));
 }
 
@@ -378,8 +378,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QColumnView::tr (arg1, arg2));
 }
 
@@ -402,9 +402,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QColumnView::tr (arg1, arg2, arg3));
 }
 
@@ -425,8 +425,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QColumnView::trUtf8 (arg1, arg2));
 }
 
@@ -449,9 +449,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QColumnView::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2124,7 +2124,7 @@ static void _call_ctor_QColumnView_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QColumnView_Adaptor *> (new QColumnView_Adaptor (arg1));
 }
 
@@ -2166,7 +2166,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QColumnView_Adaptor *)cls)->emitter_QColumnView_activated_2395 (arg1);
 }
 
@@ -2232,7 +2232,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QColumnView_Adaptor *)cls)->emitter_QColumnView_clicked_2395 (arg1);
 }
 
@@ -2353,9 +2353,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_create_2208 (arg1, arg2, arg3);
 }
@@ -2424,7 +2424,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QColumnView_Adaptor *)cls)->emitter_QColumnView_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2495,8 +2495,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_destroy_1620 (arg1, arg2);
 }
@@ -2515,7 +2515,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QColumnView_Adaptor *)cls)->emitter_QColumnView_destroyed_1302 (arg1);
 }
 
@@ -2606,7 +2606,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QColumnView_Adaptor *)cls)->emitter_QColumnView_doubleClicked_2395 (arg1);
 }
 
@@ -2696,7 +2696,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_drawFrame_1426 (arg1);
 }
@@ -2854,7 +2854,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QColumnView_Adaptor *)cls)->emitter_QColumnView_entered_2395 (arg1);
 }
 
@@ -3210,7 +3210,7 @@ static void _call_fp_initializeColumn_c2333 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemView *arg1 = args.read<QAbstractItemView * > (heap);
+  QAbstractItemView *arg1 = gsi::arg_reader<QAbstractItemView * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_initializeColumn_c2333 (arg1);
 }
@@ -3670,7 +3670,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QColumnView_Adaptor *)cls)->emitter_QColumnView_pressed_2395 (arg1);
 }
 
@@ -3688,7 +3688,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QColumnView_Adaptor *)cls)->fp_QColumnView_receivers_c1731 (arg1));
 }
 
@@ -3869,8 +3869,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -4022,7 +4022,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_setDirtyRegion_2006 (arg1);
 }
@@ -4041,7 +4041,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -4159,7 +4159,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_setState_2776 (arg1);
 }
@@ -4178,7 +4178,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_setVerticalStepsPerItem_767 (arg1);
 }
@@ -4203,10 +4203,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -4225,7 +4225,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_setViewportMargins_2115 (arg1);
 }
@@ -4268,7 +4268,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QColumnView_Adaptor *)cls)->fp_QColumnView_setupViewport_1315 (arg1);
 }
@@ -4591,7 +4591,7 @@ static void _call_emitter_updatePreviewWidget_2395 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QColumnView_Adaptor *)cls)->emitter_QColumnView_updatePreviewWidget_2395 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQComboBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQComboBox.cc
@@ -121,8 +121,8 @@ static void _call_f_addItem_4036 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QVariant &arg2 = args ? args.read<const QVariant & > (heap) : (const QVariant &)(QVariant());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg2 = args ? gsi::arg_reader<const QVariant & >() (args, heap) : gsi::arg_maker<const QVariant & >() (QVariant(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->addItem (arg1, arg2);
 }
@@ -146,9 +146,9 @@ static void _call_f_addItem_5715 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QVariant &arg3 = args ? args.read<const QVariant & > (heap) : (const QVariant &)(QVariant());
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg3 = args ? gsi::arg_reader<const QVariant & >() (args, heap) : gsi::arg_maker<const QVariant & >() (QVariant(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->addItem (arg1, arg2, arg3);
 }
@@ -168,7 +168,7 @@ static void _call_f_addItems_2437 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->addItems (arg1);
 }
@@ -325,7 +325,7 @@ static void _call_f_event_1217 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QComboBox *)cls)->event (arg1));
 }
 
@@ -348,9 +348,9 @@ static void _call_f_findData_c4986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::UserRole);
-  QFlags<Qt::MatchFlag> arg3 = args ? args.read<QFlags<Qt::MatchFlag> > (heap) : (QFlags<Qt::MatchFlag>)(Qt::MatchExactly|Qt::MatchCaseSensitive);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::UserRole, heap);
+  QFlags<Qt::MatchFlag> arg3 = args ? gsi::arg_reader<QFlags<Qt::MatchFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::MatchFlag> >() (Qt::MatchExactly|Qt::MatchCaseSensitive, heap);
   ret.write<int > ((int)((QComboBox *)cls)->findData (arg1, arg2, arg3));
 }
 
@@ -371,8 +371,8 @@ static void _call_f_findText_c4233 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<Qt::MatchFlag> arg2 = args ? args.read<QFlags<Qt::MatchFlag> > (heap) : (QFlags<Qt::MatchFlag>)(Qt::MatchExactly|Qt::MatchCaseSensitive);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<Qt::MatchFlag> arg2 = args ? gsi::arg_reader<QFlags<Qt::MatchFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::MatchFlag> >() (Qt::MatchExactly|Qt::MatchCaseSensitive, heap);
   ret.write<int > ((int)((QComboBox *)cls)->findText (arg1, arg2));
 }
 
@@ -441,9 +441,9 @@ static void _call_f_insertItem_4695 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QVariant &arg3 = args ? args.read<const QVariant & > (heap) : (const QVariant &)(QVariant());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg3 = args ? gsi::arg_reader<const QVariant & >() (args, heap) : gsi::arg_maker<const QVariant & >() (QVariant(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->insertItem (arg1, arg2, arg3);
 }
@@ -469,10 +469,10 @@ static void _call_f_insertItem_6374 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QIcon &arg2 = args.read<const QIcon & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QVariant &arg4 = args ? args.read<const QVariant & > (heap) : (const QVariant &)(QVariant());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QIcon &arg2 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg4 = args ? gsi::arg_reader<const QVariant & >() (args, heap) : gsi::arg_maker<const QVariant & >() (QVariant(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->insertItem (arg1, arg2, arg3, arg4);
 }
@@ -494,8 +494,8 @@ static void _call_f_insertItems_3096 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->insertItems (arg1, arg2);
 }
@@ -530,7 +530,7 @@ static void _call_f_insertSeparator_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->insertSeparator (arg1);
 }
@@ -567,8 +567,8 @@ static void _call_f_itemData_c1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::UserRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::UserRole, heap);
   ret.write<QVariant > ((QVariant)((QComboBox *)cls)->itemData (arg1, arg2));
 }
 
@@ -602,7 +602,7 @@ static void _call_f_itemIcon_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QIcon > ((QIcon)((QComboBox *)cls)->itemIcon (arg1));
 }
 
@@ -621,7 +621,7 @@ static void _call_f_itemText_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QComboBox *)cls)->itemText (arg1));
 }
 
@@ -745,7 +745,7 @@ static void _call_f_removeItem_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->removeItem (arg1);
 }
@@ -780,7 +780,7 @@ static void _call_f_setAutoCompletion_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setAutoCompletion (arg1);
 }
@@ -800,7 +800,7 @@ static void _call_f_setAutoCompletionCaseSensitivity_2324 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setAutoCompletionCaseSensitivity (qt_gsi::QtToCppAdaptor<Qt::CaseSensitivity>(arg1).cref());
 }
@@ -820,7 +820,7 @@ static void _call_f_setCompleter_1642 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QCompleter *arg1 = args.read<QCompleter * > (heap);
+  QCompleter *arg1 = gsi::arg_reader<QCompleter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setCompleter (arg1);
 }
@@ -840,7 +840,7 @@ static void _call_f_setCurrentIndex_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setCurrentIndex (arg1);
 }
@@ -860,7 +860,7 @@ static void _call_f_setDuplicatesEnabled_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setDuplicatesEnabled (arg1);
 }
@@ -880,7 +880,7 @@ static void _call_f_setEditText_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setEditText (arg1);
 }
@@ -900,7 +900,7 @@ static void _call_f_setEditable_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setEditable (arg1);
 }
@@ -920,7 +920,7 @@ static void _call_f_setFrame_864 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setFrame (arg1);
 }
@@ -940,7 +940,7 @@ static void _call_f_setIconSize_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setIconSize (arg1);
 }
@@ -960,7 +960,7 @@ static void _call_f_setInsertPolicy_2679 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QComboBox::InsertPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QComboBox::InsertPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QComboBox::InsertPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QComboBox::InsertPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setInsertPolicy (qt_gsi::QtToCppAdaptor<QComboBox::InsertPolicy>(arg1).cref());
 }
@@ -984,9 +984,9 @@ static void _call_f_setItemData_3437 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::UserRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::UserRole, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setItemData (arg1, arg2, arg3);
 }
@@ -1006,7 +1006,7 @@ static void _call_f_setItemDelegate_2717 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemDelegate *arg1 = args.read<QAbstractItemDelegate * > (heap);
+  QAbstractItemDelegate *arg1 = gsi::arg_reader<QAbstractItemDelegate * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setItemDelegate (arg1);
 }
@@ -1028,8 +1028,8 @@ static void _call_f_setItemIcon_2446 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QIcon &arg2 = args.read<const QIcon & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QIcon &arg2 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setItemIcon (arg1, arg2);
 }
@@ -1051,8 +1051,8 @@ static void _call_f_setItemText_2684 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setItemText (arg1, arg2);
 }
@@ -1072,7 +1072,7 @@ static void _call_f_setLineEdit_1485 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLineEdit *arg1 = args.read<QLineEdit * > (heap);
+  QLineEdit *arg1 = gsi::arg_reader<QLineEdit * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setLineEdit (arg1);
 }
@@ -1092,7 +1092,7 @@ static void _call_f_setMaxCount_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setMaxCount (arg1);
 }
@@ -1112,7 +1112,7 @@ static void _call_f_setMaxVisibleItems_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setMaxVisibleItems (arg1);
 }
@@ -1132,7 +1132,7 @@ static void _call_f_setMinimumContentsLength_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setMinimumContentsLength (arg1);
 }
@@ -1152,7 +1152,7 @@ static void _call_f_setModel_2419 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setModel (arg1);
 }
@@ -1172,7 +1172,7 @@ static void _call_f_setModelColumn_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setModelColumn (arg1);
 }
@@ -1192,7 +1192,7 @@ static void _call_f_setRootModelIndex_2395 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setRootModelIndex (arg1);
 }
@@ -1212,7 +1212,7 @@ static void _call_f_setSizeAdjustPolicy_3080 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QComboBox::SizeAdjustPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QComboBox::SizeAdjustPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QComboBox::SizeAdjustPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QComboBox::SizeAdjustPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setSizeAdjustPolicy (qt_gsi::QtToCppAdaptor<QComboBox::SizeAdjustPolicy>(arg1).cref());
 }
@@ -1232,7 +1232,7 @@ static void _call_f_setValidator_2332 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QValidator *arg1 = args.read<const QValidator * > (heap);
+  const QValidator *arg1 = gsi::arg_reader<const QValidator * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setValidator (arg1);
 }
@@ -1252,7 +1252,7 @@ static void _call_f_setView_2333 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemView *arg1 = args.read<QAbstractItemView * > (heap);
+  QAbstractItemView *arg1 = gsi::arg_reader<QAbstractItemView * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox *)cls)->setView (arg1);
 }
@@ -1350,8 +1350,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QComboBox::tr (arg1, arg2));
 }
 
@@ -1374,9 +1374,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QComboBox::tr (arg1, arg2, arg3));
 }
 
@@ -1397,8 +1397,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QComboBox::trUtf8 (arg1, arg2));
 }
 
@@ -1421,9 +1421,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QComboBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2429,7 +2429,7 @@ static void _call_ctor_QComboBox_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QComboBox_Adaptor *> (new QComboBox_Adaptor (arg1));
 }
 
@@ -2471,7 +2471,7 @@ static void _call_emitter_activated_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QComboBox_Adaptor *)cls)->emitter_QComboBox_activated_767 (arg1);
 }
 
@@ -2489,7 +2489,7 @@ static void _call_emitter_activated_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QComboBox_Adaptor *)cls)->emitter_QComboBox_activated_2025 (arg1);
 }
 
@@ -2607,9 +2607,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox_Adaptor *)cls)->fp_QComboBox_create_2208 (arg1, arg2, arg3);
 }
@@ -2628,7 +2628,7 @@ static void _call_emitter_currentIndexChanged_767 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QComboBox_Adaptor *)cls)->emitter_QComboBox_currentIndexChanged_767 (arg1);
 }
 
@@ -2646,7 +2646,7 @@ static void _call_emitter_currentIndexChanged_2025 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QComboBox_Adaptor *)cls)->emitter_QComboBox_currentIndexChanged_2025 (arg1);
 }
 
@@ -2664,7 +2664,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QComboBox_Adaptor *)cls)->emitter_QComboBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2708,8 +2708,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox_Adaptor *)cls)->fp_QComboBox_destroy_1620 (arg1, arg2);
 }
@@ -2728,7 +2728,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QComboBox_Adaptor *)cls)->emitter_QComboBox_destroyed_1302 (arg1);
 }
 
@@ -2866,7 +2866,7 @@ static void _call_emitter_editTextChanged_2025 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QComboBox_Adaptor *)cls)->emitter_QComboBox_editTextChanged_2025 (arg1);
 }
 
@@ -3171,7 +3171,7 @@ static void _call_emitter_highlighted_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QComboBox_Adaptor *)cls)->emitter_QComboBox_highlighted_767 (arg1);
 }
 
@@ -3189,7 +3189,7 @@ static void _call_emitter_highlighted_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QComboBox_Adaptor *)cls)->emitter_QComboBox_highlighted_2025 (arg1);
 }
 
@@ -3207,7 +3207,7 @@ static void _call_fp_initStyleOption_c2658 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionComboBox *arg1 = args.read<QStyleOptionComboBox * > (heap);
+  QStyleOptionComboBox *arg1 = gsi::arg_reader<QStyleOptionComboBox * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QComboBox_Adaptor *)cls)->fp_QComboBox_initStyleOption_c2658 (arg1);
 }
@@ -3594,7 +3594,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QComboBox_Adaptor *)cls)->fp_QComboBox_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQCommandLinkButton.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQCommandLinkButton.cc
@@ -129,7 +129,7 @@ static void _call_f_setDescription_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommandLinkButton *)cls)->setDescription (arg1);
 }
@@ -151,8 +151,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCommandLinkButton::tr (arg1, arg2));
 }
 
@@ -175,9 +175,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCommandLinkButton::tr (arg1, arg2, arg3));
 }
 
@@ -198,8 +198,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCommandLinkButton::trUtf8 (arg1, arg2));
 }
 
@@ -222,9 +222,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCommandLinkButton::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1185,7 +1185,7 @@ static void _call_ctor_QCommandLinkButton_Adaptor_1315 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QCommandLinkButton_Adaptor *> (new QCommandLinkButton_Adaptor (arg1));
 }
 
@@ -1205,8 +1205,8 @@ static void _call_ctor_QCommandLinkButton_Adaptor_3232 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QCommandLinkButton_Adaptor *> (new QCommandLinkButton_Adaptor (arg1, arg2));
 }
 
@@ -1228,9 +1228,9 @@ static void _call_ctor_QCommandLinkButton_Adaptor_5149 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QCommandLinkButton_Adaptor *> (new QCommandLinkButton_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1340,7 +1340,7 @@ static void _call_emitter_clicked_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ((QCommandLinkButton_Adaptor *)cls)->emitter_QCommandLinkButton_clicked_864 (arg1);
 }
 
@@ -1410,9 +1410,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommandLinkButton_Adaptor *)cls)->fp_QCommandLinkButton_create_2208 (arg1, arg2, arg3);
 }
@@ -1431,7 +1431,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QCommandLinkButton_Adaptor *)cls)->emitter_QCommandLinkButton_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1475,8 +1475,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommandLinkButton_Adaptor *)cls)->fp_QCommandLinkButton_destroy_1620 (arg1, arg2);
 }
@@ -1495,7 +1495,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QCommandLinkButton_Adaptor *)cls)->emitter_QCommandLinkButton_destroyed_1302 (arg1);
 }
 
@@ -1923,7 +1923,7 @@ static void _call_fp_initStyleOption_c2501 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionButton *arg1 = args.read<QStyleOptionButton * > (heap);
+  QStyleOptionButton *arg1 = gsi::arg_reader<QStyleOptionButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommandLinkButton_Adaptor *)cls)->fp_QCommandLinkButton_initStyleOption_c2501 (arg1);
 }
@@ -2344,7 +2344,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QCommandLinkButton_Adaptor *)cls)->fp_QCommandLinkButton_receivers_c1731 (arg1));
 }
 
@@ -2568,7 +2568,7 @@ static void _call_emitter_toggled_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QCommandLinkButton_Adaptor *)cls)->emitter_QCommandLinkButton_toggled_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQCommonStyle.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQCommonStyle.cc
@@ -88,10 +88,10 @@ static void _call_f_drawComplexControl_c9027 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommonStyle *)cls)->drawComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -117,10 +117,10 @@ static void _call_f_drawControl_c8285 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ControlElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ControlElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommonStyle *)cls)->drawControl (qt_gsi::QtToCppAdaptor<QStyle::ControlElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -146,10 +146,10 @@ static void _call_f_drawPrimitive_c8501 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommonStyle *)cls)->drawPrimitive (qt_gsi::QtToCppAdaptor<QStyle::PrimitiveElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -173,9 +173,9 @@ static void _call_f_generatedIconPixmap_c5776 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QStyleOption *arg3 = args.read<const QStyleOption * > (heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QStyleOption *arg3 = gsi::arg_reader<const QStyleOption * >() (args, heap);
   ret.write<QPixmap > ((QPixmap)((QCommonStyle *)cls)->generatedIconPixmap (qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg1).cref(), arg2, arg3));
 }
 
@@ -200,10 +200,10 @@ static void _call_f_hitTestComplexControl_c9517 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<qt_gsi::Converter<QStyle::SubControl>::target_type > ((qt_gsi::Converter<QStyle::SubControl>::target_type)qt_gsi::CppToQtAdaptor<QStyle::SubControl>(((QCommonStyle *)cls)->hitTestComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4)));
 }
 
@@ -226,9 +226,9 @@ static void _call_f_pixelMetric_c6642 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QCommonStyle *)cls)->pixelMetric (qt_gsi::QtToCppAdaptor<QStyle::PixelMetric>(arg1).cref(), arg2, arg3));
 }
 
@@ -247,7 +247,7 @@ static void _call_f_polish_1418 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPalette &arg1 = args.read<QPalette & > (heap);
+  QPalette &arg1 = gsi::arg_reader<QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommonStyle *)cls)->polish (arg1);
 }
@@ -267,7 +267,7 @@ static void _call_f_polish_1843 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommonStyle *)cls)->polish (arg1);
 }
@@ -287,7 +287,7 @@ static void _call_f_polish_1315 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommonStyle *)cls)->polish (arg1);
 }
@@ -313,10 +313,10 @@ static void _call_f_sizeFromContents_c8477 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ContentsType>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QSize &arg3 = args.read<const QSize & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ContentsType>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QSize &arg3 = gsi::arg_reader<const QSize & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QSize > ((QSize)((QCommonStyle *)cls)->sizeFromContents (qt_gsi::QtToCppAdaptor<QStyle::ContentsType>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -339,9 +339,9 @@ static void _call_f_standardPixmap_c6956 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QPixmap > ((QPixmap)((QCommonStyle *)cls)->standardPixmap (qt_gsi::QtToCppAdaptor<QStyle::StandardPixmap>(arg1).cref(), arg2, arg3));
 }
 
@@ -366,10 +366,10 @@ static void _call_f_styleHint_c8615 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StyleHint>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
-  QStyleHintReturn *arg4 = args ? args.read<QStyleHintReturn * > (heap) : (QStyleHintReturn *)(0);
+  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StyleHint>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
+  QStyleHintReturn *arg4 = args ? gsi::arg_reader<QStyleHintReturn * >() (args, heap) : gsi::arg_maker<QStyleHintReturn * >() (0, heap);
   ret.write<int > ((int)((QCommonStyle *)cls)->styleHint (qt_gsi::QtToCppAdaptor<QStyle::StyleHint>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -394,10 +394,10 @@ static void _call_f_subControlRect_c9798 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = args.read<const qt_gsi::Converter<QStyle::SubControl>::target_type & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubControl>::target_type & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QRect > ((QRect)((QCommonStyle *)cls)->subControlRect (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, qt_gsi::QtToCppAdaptor<QStyle::SubControl>(arg3).cref(), arg4));
 }
 
@@ -420,9 +420,9 @@ static void _call_f_subElementRect_c6528 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::SubElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QRect > ((QRect)((QCommonStyle *)cls)->subElementRect (qt_gsi::QtToCppAdaptor<QStyle::SubElement>(arg1).cref(), arg2, arg3));
 }
 
@@ -441,7 +441,7 @@ static void _call_f_unpolish_1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommonStyle *)cls)->unpolish (arg1);
 }
@@ -461,7 +461,7 @@ static void _call_f_unpolish_1843 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCommonStyle *)cls)->unpolish (arg1);
 }
@@ -483,8 +483,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCommonStyle::tr (arg1, arg2));
 }
 
@@ -507,9 +507,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCommonStyle::tr (arg1, arg2, arg3));
 }
 
@@ -530,8 +530,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCommonStyle::trUtf8 (arg1, arg2));
 }
 
@@ -554,9 +554,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCommonStyle::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1151,7 +1151,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QCommonStyle_Adaptor *)cls)->emitter_QCommonStyle_destroyed_1302 (arg1);
 }
 
@@ -1549,11 +1549,11 @@ static void _call_fp_layoutSpacingImplementation_c11697 (const qt_gsi::GenericMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QStyleOption *arg4 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg5 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QStyleOption *arg4 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg5 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QCommonStyle_Adaptor *)cls)->fp_QCommonStyle_layoutSpacingImplementation_c11697 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1672,7 +1672,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QCommonStyle_Adaptor *)cls)->fp_QCommonStyle_receivers_c1731 (arg1));
 }
 
@@ -1740,9 +1740,9 @@ static void _call_fp_standardIconImplementation_c6956 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QIcon > ((QIcon)((QCommonStyle_Adaptor *)cls)->fp_QCommonStyle_standardIconImplementation_c6956 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQCompleter.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQCompleter.cc
@@ -88,7 +88,7 @@ static void _call_f_complete_1792 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args ? args.read<const QRect & > (heap) : (const QRect &)(QRect());
+  const QRect &arg1 = args ? gsi::arg_reader<const QRect & >() (args, heap) : gsi::arg_maker<const QRect & >() (QRect(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->complete (arg1);
 }
@@ -288,7 +288,7 @@ static void _call_f_pathFromIndex_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QString > ((QString)((QCompleter *)cls)->pathFromIndex (arg1));
 }
 
@@ -322,7 +322,7 @@ static void _call_f_setCaseSensitivity_2324 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setCaseSensitivity (qt_gsi::QtToCppAdaptor<Qt::CaseSensitivity>(arg1).cref());
 }
@@ -342,7 +342,7 @@ static void _call_f_setCompletionColumn_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setCompletionColumn (arg1);
 }
@@ -362,7 +362,7 @@ static void _call_f_setCompletionMode_3011 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QCompleter::CompletionMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QCompleter::CompletionMode>::target_type & > (heap);
+  const qt_gsi::Converter<QCompleter::CompletionMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QCompleter::CompletionMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setCompletionMode (qt_gsi::QtToCppAdaptor<QCompleter::CompletionMode>(arg1).cref());
 }
@@ -382,7 +382,7 @@ static void _call_f_setCompletionPrefix_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setCompletionPrefix (arg1);
 }
@@ -402,7 +402,7 @@ static void _call_f_setCompletionRole_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setCompletionRole (arg1);
 }
@@ -422,7 +422,7 @@ static void _call_f_setCurrentRow_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QCompleter *)cls)->setCurrentRow (arg1));
 }
 
@@ -441,7 +441,7 @@ static void _call_f_setMaxVisibleItems_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setMaxVisibleItems (arg1);
 }
@@ -461,7 +461,7 @@ static void _call_f_setModel_2419 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setModel (arg1);
 }
@@ -481,7 +481,7 @@ static void _call_f_setModelSorting_2811 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QCompleter::ModelSorting>::target_type & arg1 = args.read<const qt_gsi::Converter<QCompleter::ModelSorting>::target_type & > (heap);
+  const qt_gsi::Converter<QCompleter::ModelSorting>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QCompleter::ModelSorting>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setModelSorting (qt_gsi::QtToCppAdaptor<QCompleter::ModelSorting>(arg1).cref());
 }
@@ -501,7 +501,7 @@ static void _call_f_setPopup_2333 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemView *arg1 = args.read<QAbstractItemView * > (heap);
+  QAbstractItemView *arg1 = gsi::arg_reader<QAbstractItemView * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setPopup (arg1);
 }
@@ -521,7 +521,7 @@ static void _call_f_setWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setWidget (arg1);
 }
@@ -541,7 +541,7 @@ static void _call_f_setWrapAround_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCompleter *)cls)->setWrapAround (arg1);
 }
@@ -561,7 +561,7 @@ static void _call_f_splitPath_c2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStringList > ((QStringList)((QCompleter *)cls)->splitPath (arg1));
 }
 
@@ -612,8 +612,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCompleter::tr (arg1, arg2));
 }
 
@@ -636,9 +636,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCompleter::tr (arg1, arg2, arg3));
 }
 
@@ -659,8 +659,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QCompleter::trUtf8 (arg1, arg2));
 }
 
@@ -683,9 +683,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QCompleter::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -977,7 +977,7 @@ static void _call_ctor_QCompleter_Adaptor_1302 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QCompleter_Adaptor *> (new QCompleter_Adaptor (arg1));
 }
 
@@ -997,8 +997,8 @@ static void _call_ctor_QCompleter_Adaptor_3613 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QCompleter_Adaptor *> (new QCompleter_Adaptor (arg1, arg2));
 }
 
@@ -1018,8 +1018,8 @@ static void _call_ctor_QCompleter_Adaptor_3631 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QCompleter_Adaptor *> (new QCompleter_Adaptor (arg1, arg2));
 }
 
@@ -1037,7 +1037,7 @@ static void _call_emitter_activated_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QCompleter_Adaptor *)cls)->emitter_QCompleter_activated_2025 (arg1);
 }
 
@@ -1055,7 +1055,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QCompleter_Adaptor *)cls)->emitter_QCompleter_activated_2395 (arg1);
 }
 
@@ -1121,7 +1121,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QCompleter_Adaptor *)cls)->emitter_QCompleter_destroyed_1302 (arg1);
 }
 
@@ -1212,7 +1212,7 @@ static void _call_emitter_highlighted_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QCompleter_Adaptor *)cls)->emitter_QCompleter_highlighted_2025 (arg1);
 }
 
@@ -1230,7 +1230,7 @@ static void _call_emitter_highlighted_2395 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QCompleter_Adaptor *)cls)->emitter_QCompleter_highlighted_2395 (arg1);
 }
 
@@ -1271,7 +1271,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QCompleter_Adaptor *)cls)->fp_QCompleter_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQConicalGradient.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQConicalGradient.cc
@@ -70,8 +70,8 @@ static void _call_ctor_QConicalGradient_2949 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  double arg2 = args.read<double > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QConicalGradient *> (new QConicalGradient (arg1, arg2));
 }
 
@@ -94,9 +94,9 @@ static void _call_ctor_QConicalGradient_2997 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   ret.write<QConicalGradient *> (new QConicalGradient (arg1, arg2, arg3));
 }
 
@@ -145,7 +145,7 @@ static void _call_f_setAngle_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QConicalGradient *)cls)->setAngle (arg1);
 }
@@ -165,7 +165,7 @@ static void _call_f_setCenter_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QConicalGradient *)cls)->setCenter (arg1);
 }
@@ -187,8 +187,8 @@ static void _call_f_setCenter_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QConicalGradient *)cls)->setCenter (arg1, arg2);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQContextMenuEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQContextMenuEvent.cc
@@ -216,10 +216,10 @@ static void _call_ctor_QContextMenuEvent_Adaptor_9494 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & arg1 = args.read<const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
-  QFlags<Qt::KeyboardModifier> arg4 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg4 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   ret.write<QContextMenuEvent_Adaptor *> (new QContextMenuEvent_Adaptor (qt_gsi::QtToCppAdaptor<QContextMenuEvent::Reason>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -241,9 +241,9 @@ static void _call_ctor_QContextMenuEvent_Adaptor_6525 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & arg1 = args.read<const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
+  const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QContextMenuEvent_Adaptor *> (new QContextMenuEvent_Adaptor (qt_gsi::QtToCppAdaptor<QContextMenuEvent::Reason>(arg1).cref(), arg2, arg3));
 }
 
@@ -263,8 +263,8 @@ static void _call_ctor_QContextMenuEvent_Adaptor_4717 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & arg1 = args.read<const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QContextMenuEvent::Reason>::target_type & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QContextMenuEvent_Adaptor *> (new QContextMenuEvent_Adaptor (qt_gsi::QtToCppAdaptor<QContextMenuEvent::Reason>(arg1).cref(), arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQCursor.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQCursor.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QCursor_1884 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CursorShape>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CursorShape>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CursorShape>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CursorShape>::target_type & >() (args, heap);
   ret.write<QCursor *> (new QCursor (qt_gsi::QtToCppAdaptor<Qt::CursorShape>(arg1).cref()));
 }
 
@@ -92,10 +92,10 @@ static void _call_ctor_QCursor_5208 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBitmap &arg1 = args.read<const QBitmap & > (heap);
-  const QBitmap &arg2 = args.read<const QBitmap & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(-1);
-  int arg4 = args ? args.read<int > (heap) : (int)(-1);
+  const QBitmap &arg1 = gsi::arg_reader<const QBitmap & >() (args, heap);
+  const QBitmap &arg2 = gsi::arg_reader<const QBitmap & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QCursor *> (new QCursor (arg1, arg2, arg3, arg4));
 }
 
@@ -118,9 +118,9 @@ static void _call_ctor_QCursor_3335 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(-1);
-  int arg3 = args ? args.read<int > (heap) : (int)(-1);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QCursor *> (new QCursor (arg1, arg2, arg3));
 }
 
@@ -139,7 +139,7 @@ static void _call_ctor_QCursor_2032 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QCursor &arg1 = args.read<const QCursor & > (heap);
+  const QCursor &arg1 = gsi::arg_reader<const QCursor & >() (args, heap);
   ret.write<QCursor *> (new QCursor (arg1));
 }
 
@@ -218,7 +218,7 @@ static void _call_f_operator_eq__2032 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QCursor &arg1 = args.read<const QCursor & > (heap);
+  const QCursor &arg1 = gsi::arg_reader<const QCursor & >() (args, heap);
   ret.write<QCursor & > ((QCursor &)((QCursor *)cls)->operator= (arg1));
 }
 
@@ -252,7 +252,7 @@ static void _call_f_setShape_1884 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CursorShape>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CursorShape>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CursorShape>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CursorShape>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QCursor *)cls)->setShape (qt_gsi::QtToCppAdaptor<Qt::CursorShape>(arg1).cref());
 }
@@ -304,8 +304,8 @@ static void _call_f_setPos_1426 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCursor::setPos (arg1, arg2);
 }
@@ -325,7 +325,7 @@ static void _call_f_setPos_1916 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QCursor::setPos (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDataWidgetMapper.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDataWidgetMapper.cc
@@ -74,8 +74,8 @@ static void _call_f_addMapping_1974 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args.read<int > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->addMapping (arg1, arg2);
 }
@@ -99,9 +99,9 @@ static void _call_f_addMapping_4175 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args.read<int > (heap);
-  const QByteArray &arg3 = args.read<const QByteArray & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QByteArray &arg3 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->addMapping (arg1, arg2, arg3);
 }
@@ -167,7 +167,7 @@ static void _call_f_mappedPropertyName_c1315 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QDataWidgetMapper *)cls)->mappedPropertyName (arg1));
 }
 
@@ -186,7 +186,7 @@ static void _call_f_mappedSection_c1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QDataWidgetMapper *)cls)->mappedSection (arg1));
 }
 
@@ -205,7 +205,7 @@ static void _call_f_mappedWidgetAt_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QDataWidgetMapper *)cls)->mappedWidgetAt (arg1));
 }
 
@@ -254,7 +254,7 @@ static void _call_f_removeMapping_1315 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->removeMapping (arg1);
 }
@@ -305,7 +305,7 @@ static void _call_f_setCurrentIndex_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->setCurrentIndex (arg1);
 }
@@ -325,7 +325,7 @@ static void _call_f_setCurrentModelIndex_2395 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->setCurrentModelIndex (arg1);
 }
@@ -345,7 +345,7 @@ static void _call_f_setItemDelegate_2717 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemDelegate *arg1 = args.read<QAbstractItemDelegate * > (heap);
+  QAbstractItemDelegate *arg1 = gsi::arg_reader<QAbstractItemDelegate * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->setItemDelegate (arg1);
 }
@@ -365,7 +365,7 @@ static void _call_f_setModel_2419 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->setModel (arg1);
 }
@@ -385,7 +385,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -405,7 +405,7 @@ static void _call_f_setRootIndex_2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->setRootIndex (arg1);
 }
@@ -425,7 +425,7 @@ static void _call_f_setSubmitPolicy_3488 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDataWidgetMapper::SubmitPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QDataWidgetMapper::SubmitPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QDataWidgetMapper::SubmitPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDataWidgetMapper::SubmitPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDataWidgetMapper *)cls)->setSubmitPolicy (qt_gsi::QtToCppAdaptor<QDataWidgetMapper::SubmitPolicy>(arg1).cref());
 }
@@ -541,8 +541,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDataWidgetMapper::tr (arg1, arg2));
 }
 
@@ -565,9 +565,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDataWidgetMapper::tr (arg1, arg2, arg3));
 }
 
@@ -588,8 +588,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDataWidgetMapper::trUtf8 (arg1, arg2));
 }
 
@@ -612,9 +612,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDataWidgetMapper::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -840,7 +840,7 @@ static void _call_ctor_QDataWidgetMapper_Adaptor_1302 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QDataWidgetMapper_Adaptor *> (new QDataWidgetMapper_Adaptor (arg1));
 }
 
@@ -882,7 +882,7 @@ static void _call_emitter_currentIndexChanged_767 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QDataWidgetMapper_Adaptor *)cls)->emitter_QDataWidgetMapper_currentIndexChanged_767 (arg1);
 }
 
@@ -924,7 +924,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDataWidgetMapper_Adaptor *)cls)->emitter_QDataWidgetMapper_destroyed_1302 (arg1);
 }
 
@@ -1015,7 +1015,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDataWidgetMapper_Adaptor *)cls)->fp_QDataWidgetMapper_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDateEdit.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDateEdit.cc
@@ -119,8 +119,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDateEdit::tr (arg1, arg2));
 }
 
@@ -143,9 +143,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDateEdit::tr (arg1, arg2, arg3));
 }
 
@@ -166,8 +166,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDateEdit::trUtf8 (arg1, arg2));
 }
 
@@ -190,9 +190,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDateEdit::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1213,7 +1213,7 @@ static void _call_ctor_QDateEdit_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDateEdit_Adaptor *> (new QDateEdit_Adaptor (arg1));
 }
 
@@ -1233,8 +1233,8 @@ static void _call_ctor_QDateEdit_Adaptor_2983 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDateEdit_Adaptor *> (new QDateEdit_Adaptor (arg1, arg2));
 }
 
@@ -1396,9 +1396,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateEdit_Adaptor *)cls)->fp_QDateEdit_create_2208 (arg1, arg2, arg3);
 }
@@ -1417,7 +1417,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QDateEdit_Adaptor *)cls)->emitter_QDateEdit_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1459,7 +1459,7 @@ static void _call_emitter_dateChanged_1776 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ((QDateEdit_Adaptor *)cls)->emitter_QDateEdit_dateChanged_1776 (arg1);
 }
 
@@ -1477,7 +1477,7 @@ static void _call_emitter_dateTimeChanged_2175 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ((QDateEdit_Adaptor *)cls)->emitter_QDateEdit_dateTimeChanged_2175 (arg1);
 }
 
@@ -1520,8 +1520,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateEdit_Adaptor *)cls)->fp_QDateEdit_destroy_1620 (arg1, arg2);
 }
@@ -1540,7 +1540,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDateEdit_Adaptor *)cls)->emitter_QDateEdit_destroyed_1302 (arg1);
 }
 
@@ -1983,7 +1983,7 @@ static void _call_fp_initStyleOption_c2572 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionSpinBox *arg1 = args.read<QStyleOptionSpinBox * > (heap);
+  QStyleOptionSpinBox *arg1 = gsi::arg_reader<QStyleOptionSpinBox * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateEdit_Adaptor *)cls)->fp_QDateEdit_initStyleOption_c2572 (arg1);
 }
@@ -2384,7 +2384,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDateEdit_Adaptor *)cls)->fp_QDateEdit_receivers_c1731 (arg1));
 }
 
@@ -2455,7 +2455,7 @@ static void _call_fp_setLineEdit_1485 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLineEdit *arg1 = args.read<QLineEdit * > (heap);
+  QLineEdit *arg1 = gsi::arg_reader<QLineEdit * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateEdit_Adaptor *)cls)->fp_QDateEdit_setLineEdit_1485 (arg1);
 }
@@ -2655,7 +2655,7 @@ static void _call_emitter_timeChanged_1793 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ((QDateEdit_Adaptor *)cls)->emitter_QDateEdit_timeChanged_1793 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDateTimeEdit.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDateTimeEdit.cc
@@ -349,7 +349,7 @@ static void _call_f_event_1217 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QDateTimeEdit *)cls)->event (arg1));
 }
 
@@ -458,7 +458,7 @@ static void _call_f_sectionAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<qt_gsi::Converter<QDateTimeEdit::Section>::target_type > ((qt_gsi::Converter<QDateTimeEdit::Section>::target_type)qt_gsi::CppToQtAdaptor<QDateTimeEdit::Section>(((QDateTimeEdit *)cls)->sectionAt (arg1)));
 }
 
@@ -492,7 +492,7 @@ static void _call_f_sectionText_c2529 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & arg1 = args.read<const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & > (heap);
+  const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QDateTimeEdit *)cls)->sectionText (qt_gsi::QtToCppAdaptor<QDateTimeEdit::Section>(arg1).cref()));
 }
 
@@ -511,7 +511,7 @@ static void _call_f_setCalendarPopup_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setCalendarPopup (arg1);
 }
@@ -531,7 +531,7 @@ static void _call_f_setCalendarWidget_2109 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QCalendarWidget *arg1 = args.read<QCalendarWidget * > (heap);
+  QCalendarWidget *arg1 = gsi::arg_reader<QCalendarWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setCalendarWidget (arg1);
 }
@@ -551,7 +551,7 @@ static void _call_f_setCurrentSection_2529 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & arg1 = args.read<const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & > (heap);
+  const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setCurrentSection (qt_gsi::QtToCppAdaptor<QDateTimeEdit::Section>(arg1).cref());
 }
@@ -571,7 +571,7 @@ static void _call_f_setCurrentSectionIndex_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setCurrentSectionIndex (arg1);
 }
@@ -591,7 +591,7 @@ static void _call_f_setDate_1776 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setDate (arg1);
 }
@@ -613,8 +613,8 @@ static void _call_f_setDateRange_3444 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
-  const QDate &arg2 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
+  const QDate &arg2 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setDateRange (arg1, arg2);
 }
@@ -634,7 +634,7 @@ static void _call_f_setDateTime_2175 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setDateTime (arg1);
 }
@@ -656,8 +656,8 @@ static void _call_f_setDateTimeRange_4242 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
-  const QDateTime &arg2 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
+  const QDateTime &arg2 = gsi::arg_reader<const QDateTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setDateTimeRange (arg1, arg2);
 }
@@ -677,7 +677,7 @@ static void _call_f_setDisplayFormat_2025 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setDisplayFormat (arg1);
 }
@@ -697,7 +697,7 @@ static void _call_f_setMaximumDate_1776 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setMaximumDate (arg1);
 }
@@ -717,7 +717,7 @@ static void _call_f_setMaximumDateTime_2175 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setMaximumDateTime (arg1);
 }
@@ -737,7 +737,7 @@ static void _call_f_setMaximumTime_1793 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setMaximumTime (arg1);
 }
@@ -757,7 +757,7 @@ static void _call_f_setMinimumDate_1776 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setMinimumDate (arg1);
 }
@@ -777,7 +777,7 @@ static void _call_f_setMinimumDateTime_2175 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setMinimumDateTime (arg1);
 }
@@ -797,7 +797,7 @@ static void _call_f_setMinimumTime_1793 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setMinimumTime (arg1);
 }
@@ -817,7 +817,7 @@ static void _call_f_setSelectedSection_2529 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & arg1 = args.read<const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & > (heap);
+  const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDateTimeEdit::Section>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setSelectedSection (qt_gsi::QtToCppAdaptor<QDateTimeEdit::Section>(arg1).cref());
 }
@@ -837,7 +837,7 @@ static void _call_f_setTime_1793 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setTime (arg1);
 }
@@ -859,8 +859,8 @@ static void _call_f_setTimeRange_3478 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
-  const QTime &arg2 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
+  const QTime &arg2 = gsi::arg_reader<const QTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setTimeRange (arg1, arg2);
 }
@@ -880,7 +880,7 @@ static void _call_f_setTimeSpec_1543 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TimeSpec>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TimeSpec>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TimeSpec>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TimeSpec>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->setTimeSpec (qt_gsi::QtToCppAdaptor<Qt::TimeSpec>(arg1).cref());
 }
@@ -915,7 +915,7 @@ static void _call_f_stepBy_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit *)cls)->stepBy (arg1);
 }
@@ -967,8 +967,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDateTimeEdit::tr (arg1, arg2));
 }
 
@@ -991,9 +991,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDateTimeEdit::tr (arg1, arg2, arg3));
 }
 
@@ -1014,8 +1014,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDateTimeEdit::trUtf8 (arg1, arg2));
 }
 
@@ -1038,9 +1038,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDateTimeEdit::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2133,7 +2133,7 @@ static void _call_ctor_QDateTimeEdit_Adaptor_1315 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDateTimeEdit_Adaptor *> (new QDateTimeEdit_Adaptor (arg1));
 }
 
@@ -2153,8 +2153,8 @@ static void _call_ctor_QDateTimeEdit_Adaptor_3382 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDateTimeEdit_Adaptor *> (new QDateTimeEdit_Adaptor (arg1, arg2));
 }
 
@@ -2174,8 +2174,8 @@ static void _call_ctor_QDateTimeEdit_Adaptor_2983 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDateTimeEdit_Adaptor *> (new QDateTimeEdit_Adaptor (arg1, arg2));
 }
 
@@ -2195,8 +2195,8 @@ static void _call_ctor_QDateTimeEdit_Adaptor_3000 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDateTimeEdit_Adaptor *> (new QDateTimeEdit_Adaptor (arg1, arg2));
 }
 
@@ -2358,9 +2358,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit_Adaptor *)cls)->fp_QDateTimeEdit_create_2208 (arg1, arg2, arg3);
 }
@@ -2379,7 +2379,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QDateTimeEdit_Adaptor *)cls)->emitter_QDateTimeEdit_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2421,7 +2421,7 @@ static void _call_emitter_dateChanged_1776 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ((QDateTimeEdit_Adaptor *)cls)->emitter_QDateTimeEdit_dateChanged_1776 (arg1);
 }
 
@@ -2439,7 +2439,7 @@ static void _call_emitter_dateTimeChanged_2175 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ((QDateTimeEdit_Adaptor *)cls)->emitter_QDateTimeEdit_dateTimeChanged_2175 (arg1);
 }
 
@@ -2482,8 +2482,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit_Adaptor *)cls)->fp_QDateTimeEdit_destroy_1620 (arg1, arg2);
 }
@@ -2502,7 +2502,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDateTimeEdit_Adaptor *)cls)->emitter_QDateTimeEdit_destroyed_1302 (arg1);
 }
 
@@ -2945,7 +2945,7 @@ static void _call_fp_initStyleOption_c2572 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionSpinBox *arg1 = args.read<QStyleOptionSpinBox * > (heap);
+  QStyleOptionSpinBox *arg1 = gsi::arg_reader<QStyleOptionSpinBox * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit_Adaptor *)cls)->fp_QDateTimeEdit_initStyleOption_c2572 (arg1);
 }
@@ -3346,7 +3346,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDateTimeEdit_Adaptor *)cls)->fp_QDateTimeEdit_receivers_c1731 (arg1));
 }
 
@@ -3417,7 +3417,7 @@ static void _call_fp_setLineEdit_1485 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLineEdit *arg1 = args.read<QLineEdit * > (heap);
+  QLineEdit *arg1 = gsi::arg_reader<QLineEdit * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDateTimeEdit_Adaptor *)cls)->fp_QDateTimeEdit_setLineEdit_1485 (arg1);
 }
@@ -3617,7 +3617,7 @@ static void _call_emitter_timeChanged_1793 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ((QDateTimeEdit_Adaptor *)cls)->emitter_QDateTimeEdit_timeChanged_1793 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDesktopServices.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDesktopServices.cc
@@ -67,7 +67,7 @@ static void _call_f_displayName_3841 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDesktopServices::StandardLocation>::target_type & arg1 = args.read<const qt_gsi::Converter<QDesktopServices::StandardLocation>::target_type & > (heap);
+  const qt_gsi::Converter<QDesktopServices::StandardLocation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDesktopServices::StandardLocation>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QDesktopServices::displayName (qt_gsi::QtToCppAdaptor<QDesktopServices::StandardLocation>(arg1).cref()));
 }
 
@@ -86,7 +86,7 @@ static void _call_f_openUrl_1701 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<bool > ((bool)QDesktopServices::openUrl (arg1));
 }
 
@@ -109,9 +109,9 @@ static void _call_f_setUrlHandler_4842 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
-  const char *arg3 = args.read<const char * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QDesktopServices::setUrlHandler (arg1, arg2, arg3);
 }
@@ -131,7 +131,7 @@ static void _call_f_storageLocation_3841 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDesktopServices::StandardLocation>::target_type & arg1 = args.read<const qt_gsi::Converter<QDesktopServices::StandardLocation>::target_type & > (heap);
+  const qt_gsi::Converter<QDesktopServices::StandardLocation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDesktopServices::StandardLocation>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QDesktopServices::storageLocation (qt_gsi::QtToCppAdaptor<QDesktopServices::StandardLocation>(arg1).cref()));
 }
 
@@ -150,7 +150,7 @@ static void _call_f_unsetUrlHandler_2025 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QDesktopServices::unsetUrlHandler (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDesktopWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDesktopWidget.cc
@@ -111,7 +111,7 @@ static void _call_f_availableGeometry_c767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(-1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<const QRect > ((const QRect)((QDesktopWidget *)cls)->availableGeometry (arg1));
 }
 
@@ -130,7 +130,7 @@ static void _call_f_availableGeometry_c2010 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<const QRect > ((const QRect)((QDesktopWidget *)cls)->availableGeometry (arg1));
 }
 
@@ -149,7 +149,7 @@ static void _call_f_availableGeometry_c1916 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<const QRect > ((const QRect)((QDesktopWidget *)cls)->availableGeometry (arg1));
 }
 
@@ -213,7 +213,7 @@ static void _call_f_screen_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(-1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QWidget * > ((QWidget *)((QDesktopWidget *)cls)->screen (arg1));
 }
 
@@ -247,7 +247,7 @@ static void _call_f_screenGeometry_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(-1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<const QRect > ((const QRect)((QDesktopWidget *)cls)->screenGeometry (arg1));
 }
 
@@ -266,7 +266,7 @@ static void _call_f_screenGeometry_c2010 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<const QRect > ((const QRect)((QDesktopWidget *)cls)->screenGeometry (arg1));
 }
 
@@ -285,7 +285,7 @@ static void _call_f_screenGeometry_c1916 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<const QRect > ((const QRect)((QDesktopWidget *)cls)->screenGeometry (arg1));
 }
 
@@ -304,7 +304,7 @@ static void _call_f_screenNumber_c2010 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const QWidget *arg1 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QDesktopWidget *)cls)->screenNumber (arg1));
 }
 
@@ -323,7 +323,7 @@ static void _call_f_screenNumber_c1916 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<int > ((int)((QDesktopWidget *)cls)->screenNumber (arg1));
 }
 
@@ -344,8 +344,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDesktopWidget::tr (arg1, arg2));
 }
 
@@ -368,9 +368,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDesktopWidget::tr (arg1, arg2, arg3));
 }
 
@@ -391,8 +391,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDesktopWidget::trUtf8 (arg1, arg2));
 }
 
@@ -415,9 +415,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDesktopWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1437,9 +1437,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDesktopWidget_Adaptor *)cls)->fp_QDesktopWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -1458,7 +1458,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QDesktopWidget_Adaptor *)cls)->emitter_QDesktopWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1502,8 +1502,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDesktopWidget_Adaptor *)cls)->fp_QDesktopWidget_destroy_1620 (arg1, arg2);
 }
@@ -1522,7 +1522,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDesktopWidget_Adaptor *)cls)->emitter_QDesktopWidget_destroyed_1302 (arg1);
 }
 
@@ -2295,7 +2295,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDesktopWidget_Adaptor *)cls)->fp_QDesktopWidget_receivers_c1731 (arg1));
 }
 
@@ -2352,7 +2352,7 @@ static void _call_emitter_resized_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QDesktopWidget_Adaptor *)cls)->emitter_QDesktopWidget_resized_767 (arg1);
 }
 
@@ -2370,7 +2370,7 @@ static void _call_emitter_screenCountChanged_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QDesktopWidget_Adaptor *)cls)->emitter_QDesktopWidget_screenCountChanged_767 (arg1);
 }
 
@@ -2604,7 +2604,7 @@ static void _call_emitter_workAreaResized_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QDesktopWidget_Adaptor *)cls)->emitter_QDesktopWidget_workAreaResized_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDial.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDial.cc
@@ -172,7 +172,7 @@ static void _call_f_setNotchTarget_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDial *)cls)->setNotchTarget (arg1);
 }
@@ -192,7 +192,7 @@ static void _call_f_setNotchesVisible_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDial *)cls)->setNotchesVisible (arg1);
 }
@@ -212,7 +212,7 @@ static void _call_f_setWrapping_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDial *)cls)->setWrapping (arg1);
 }
@@ -264,8 +264,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDial::tr (arg1, arg2));
 }
 
@@ -288,9 +288,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDial::tr (arg1, arg2, arg3));
 }
 
@@ -311,8 +311,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDial::trUtf8 (arg1, arg2));
 }
 
@@ -335,9 +335,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDial::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1273,7 +1273,7 @@ static void _call_ctor_QDial_Adaptor_1315 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDial_Adaptor *> (new QDial_Adaptor (arg1));
 }
 
@@ -1315,7 +1315,7 @@ static void _call_emitter_actionTriggered_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QDial_Adaptor *)cls)->emitter_QDial_actionTriggered_767 (arg1);
 }
 
@@ -1433,9 +1433,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDial_Adaptor *)cls)->fp_QDial_create_2208 (arg1, arg2, arg3);
 }
@@ -1454,7 +1454,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QDial_Adaptor *)cls)->emitter_QDial_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1498,8 +1498,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDial_Adaptor *)cls)->fp_QDial_destroy_1620 (arg1, arg2);
 }
@@ -1518,7 +1518,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDial_Adaptor *)cls)->emitter_QDial_destroyed_1302 (arg1);
 }
 
@@ -1923,7 +1923,7 @@ static void _call_fp_initStyleOption_c2476 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionSlider *arg1 = args.read<QStyleOptionSlider * > (heap);
+  QStyleOptionSlider *arg1 = gsi::arg_reader<QStyleOptionSlider * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDial_Adaptor *)cls)->fp_QDial_initStyleOption_c2476 (arg1);
 }
@@ -2312,8 +2312,8 @@ static void _call_emitter_rangeChanged_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QDial_Adaptor *)cls)->emitter_QDial_rangeChanged_1426 (arg1, arg2);
 }
 
@@ -2331,7 +2331,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDial_Adaptor *)cls)->fp_QDial_receivers_c1731 (arg1));
 }
 
@@ -2420,9 +2420,9 @@ static void _call_fp_setRepeatAction_4599 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(500);
-  int arg3 = args ? args.read<int > (heap) : (int)(50);
+  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (500, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDial_Adaptor *)cls)->fp_QDial_setRepeatAction_4599 (arg1, arg2, arg3);
 }
@@ -2532,7 +2532,7 @@ static void _call_emitter_sliderMoved_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QDial_Adaptor *)cls)->emitter_QDial_sliderMoved_767 (arg1);
 }
 
@@ -2665,7 +2665,7 @@ static void _call_emitter_valueChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QDial_Adaptor *)cls)->emitter_QDial_valueChanged_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDialog.cc
@@ -127,7 +127,7 @@ static void _call_f_done_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog *)cls)->done (arg1);
 }
@@ -269,7 +269,7 @@ static void _call_f_setExtension_1315 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog *)cls)->setExtension (arg1);
 }
@@ -289,7 +289,7 @@ static void _call_f_setModal_864 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog *)cls)->setModal (arg1);
 }
@@ -309,7 +309,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -329,7 +329,7 @@ static void _call_f_setResult_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog *)cls)->setResult (arg1);
 }
@@ -349,7 +349,7 @@ static void _call_f_setSizeGripEnabled_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog *)cls)->setSizeGripEnabled (arg1);
 }
@@ -369,7 +369,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog *)cls)->setVisible (arg1);
 }
@@ -389,7 +389,7 @@ static void _call_f_showExtension_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog *)cls)->showExtension (arg1);
 }
@@ -426,8 +426,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDialog::tr (arg1, arg2));
 }
 
@@ -450,9 +450,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDialog::tr (arg1, arg2, arg3));
 }
 
@@ -473,8 +473,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDialog::trUtf8 (arg1, arg2));
 }
 
@@ -497,9 +497,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1453,8 +1453,8 @@ static void _call_ctor_QDialog_Adaptor_3702 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QDialog_Adaptor *> (new QDialog_Adaptor (arg1, arg2));
 }
 
@@ -1530,7 +1530,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog_Adaptor *)cls)->fp_QDialog_adjustPosition_1315 (arg1);
 }
@@ -1649,9 +1649,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog_Adaptor *)cls)->fp_QDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -1670,7 +1670,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QDialog_Adaptor *)cls)->emitter_QDialog_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1714,8 +1714,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialog_Adaptor *)cls)->fp_QDialog_destroy_1620 (arg1, arg2);
 }
@@ -1734,7 +1734,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDialog_Adaptor *)cls)->emitter_QDialog_destroyed_1302 (arg1);
 }
 
@@ -1993,7 +1993,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QDialog_Adaptor *)cls)->emitter_QDialog_finished_767 (arg1);
 }
 
@@ -2549,7 +2549,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDialog_Adaptor *)cls)->fp_QDialog_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDialogButtonBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDialogButtonBox.cc
@@ -115,8 +115,8 @@ static void _call_f_addButton_5247 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
-  const qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type & > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
+  const qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialogButtonBox *)cls)->addButton (arg1, qt_gsi::QtToCppAdaptor<QDialogButtonBox::ButtonRole>(arg2).cref());
 }
@@ -138,8 +138,8 @@ static void _call_f_addButton_5113 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type & >() (args, heap);
   ret.write<QPushButton * > ((QPushButton *)((QDialogButtonBox *)cls)->addButton (arg1, qt_gsi::QtToCppAdaptor<QDialogButtonBox::ButtonRole>(arg2).cref()));
 }
 
@@ -158,7 +158,7 @@ static void _call_f_addButton_3611 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type & > (heap);
+  const qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type & >() (args, heap);
   ret.write<QPushButton * > ((QPushButton *)((QDialogButtonBox *)cls)->addButton (qt_gsi::QtToCppAdaptor<QDialogButtonBox::StandardButton>(arg1).cref()));
 }
 
@@ -177,7 +177,7 @@ static void _call_f_button_c3611 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type & > (heap);
+  const qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type & >() (args, heap);
   ret.write<QPushButton * > ((QPushButton *)((QDialogButtonBox *)cls)->button (qt_gsi::QtToCppAdaptor<QDialogButtonBox::StandardButton>(arg1).cref()));
 }
 
@@ -196,7 +196,7 @@ static void _call_f_buttonRole_c2159 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ret.write<qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type > ((qt_gsi::Converter<QDialogButtonBox::ButtonRole>::target_type)qt_gsi::CppToQtAdaptor<QDialogButtonBox::ButtonRole>(((QDialogButtonBox *)cls)->buttonRole (arg1)));
 }
 
@@ -276,7 +276,7 @@ static void _call_f_removeButton_2159 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialogButtonBox *)cls)->removeButton (arg1);
 }
@@ -296,7 +296,7 @@ static void _call_f_setCenterButtons_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialogButtonBox *)cls)->setCenterButtons (arg1);
 }
@@ -316,7 +316,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialogButtonBox *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -336,7 +336,7 @@ static void _call_f_setStandardButtons_4307 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDialogButtonBox::StandardButton> arg1 = args.read<QFlags<QDialogButtonBox::StandardButton> > (heap);
+  QFlags<QDialogButtonBox::StandardButton> arg1 = gsi::arg_reader<QFlags<QDialogButtonBox::StandardButton> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialogButtonBox *)cls)->setStandardButtons (arg1);
 }
@@ -356,7 +356,7 @@ static void _call_f_standardButton_c2159 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ret.write<qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type > ((qt_gsi::Converter<QDialogButtonBox::StandardButton>::target_type)qt_gsi::CppToQtAdaptor<QDialogButtonBox::StandardButton>(((QDialogButtonBox *)cls)->standardButton (arg1)));
 }
 
@@ -392,8 +392,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDialogButtonBox::tr (arg1, arg2));
 }
 
@@ -416,9 +416,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDialogButtonBox::tr (arg1, arg2, arg3));
 }
 
@@ -439,8 +439,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDialogButtonBox::trUtf8 (arg1, arg2));
 }
 
@@ -463,9 +463,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDialogButtonBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1392,7 +1392,7 @@ static void _call_ctor_QDialogButtonBox_Adaptor_1315 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDialogButtonBox_Adaptor *> (new QDialogButtonBox_Adaptor (arg1));
 }
 
@@ -1412,8 +1412,8 @@ static void _call_ctor_QDialogButtonBox_Adaptor_3120 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDialogButtonBox_Adaptor *> (new QDialogButtonBox_Adaptor (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref(), arg2));
 }
 
@@ -1435,9 +1435,9 @@ static void _call_ctor_QDialogButtonBox_Adaptor_7319 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDialogButtonBox::StandardButton> arg1 = args.read<QFlags<QDialogButtonBox::StandardButton> > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap) : (const qt_gsi::Converter<Qt::Orientation>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::Orientation>(heap, Qt::Horizontal));
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QFlags<QDialogButtonBox::StandardButton> arg1 = gsi::arg_reader<QFlags<QDialogButtonBox::StandardButton> >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::Orientation>(heap, Qt::Horizontal), heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDialogButtonBox_Adaptor *> (new QDialogButtonBox_Adaptor (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3));
 }
 
@@ -1541,7 +1541,7 @@ static void _call_emitter_clicked_2159 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ((QDialogButtonBox_Adaptor *)cls)->emitter_QDialogButtonBox_clicked_2159 (arg1);
 }
 
@@ -1611,9 +1611,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialogButtonBox_Adaptor *)cls)->fp_QDialogButtonBox_create_2208 (arg1, arg2, arg3);
 }
@@ -1632,7 +1632,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QDialogButtonBox_Adaptor *)cls)->emitter_QDialogButtonBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1676,8 +1676,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDialogButtonBox_Adaptor *)cls)->fp_QDialogButtonBox_destroy_1620 (arg1, arg2);
 }
@@ -1696,7 +1696,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDialogButtonBox_Adaptor *)cls)->emitter_QDialogButtonBox_destroyed_1302 (arg1);
 }
 
@@ -2483,7 +2483,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDialogButtonBox_Adaptor *)cls)->fp_QDialogButtonBox_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDirIterator.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDirIterator.cc
@@ -231,8 +231,8 @@ static void _call_ctor_QDirIterator_Adaptor_5251 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDir &arg1 = args.read<const QDir & > (heap);
-  QFlags<QDirIterator::IteratorFlag> arg2 = args ? args.read<QFlags<QDirIterator::IteratorFlag> > (heap) : (QFlags<QDirIterator::IteratorFlag>)(QDirIterator::NoIteratorFlags);
+  const QDir &arg1 = gsi::arg_reader<const QDir & >() (args, heap);
+  QFlags<QDirIterator::IteratorFlag> arg2 = args ? gsi::arg_reader<QFlags<QDirIterator::IteratorFlag> >() (args, heap) : gsi::arg_maker<QFlags<QDirIterator::IteratorFlag> >() (QDirIterator::NoIteratorFlags, heap);
   ret.write<QDirIterator_Adaptor *> (new QDirIterator_Adaptor (arg1, arg2));
 }
 
@@ -252,8 +252,8 @@ static void _call_ctor_QDirIterator_Adaptor_5595 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<QDirIterator::IteratorFlag> arg2 = args ? args.read<QFlags<QDirIterator::IteratorFlag> > (heap) : (QFlags<QDirIterator::IteratorFlag>)(QDirIterator::NoIteratorFlags);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QDirIterator::IteratorFlag> arg2 = args ? gsi::arg_reader<QFlags<QDirIterator::IteratorFlag> >() (args, heap) : gsi::arg_maker<QFlags<QDirIterator::IteratorFlag> >() (QDirIterator::NoIteratorFlags, heap);
   ret.write<QDirIterator_Adaptor *> (new QDirIterator_Adaptor (arg1, arg2));
 }
 
@@ -275,9 +275,9 @@ static void _call_ctor_QDirIterator_Adaptor_7717 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<QDir::Filter> arg2 = args.read<QFlags<QDir::Filter> > (heap);
-  QFlags<QDirIterator::IteratorFlag> arg3 = args ? args.read<QFlags<QDirIterator::IteratorFlag> > (heap) : (QFlags<QDirIterator::IteratorFlag>)(QDirIterator::NoIteratorFlags);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QDir::Filter> arg2 = gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap);
+  QFlags<QDirIterator::IteratorFlag> arg3 = args ? gsi::arg_reader<QFlags<QDirIterator::IteratorFlag> >() (args, heap) : gsi::arg_maker<QFlags<QDirIterator::IteratorFlag> >() (QDirIterator::NoIteratorFlags, heap);
   ret.write<QDirIterator_Adaptor *> (new QDirIterator_Adaptor (arg1, arg2, arg3));
 }
 
@@ -301,10 +301,10 @@ static void _call_ctor_QDirIterator_Adaptor_10046 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
-  QFlags<QDir::Filter> arg3 = args ? args.read<QFlags<QDir::Filter> > (heap) : (QFlags<QDir::Filter>)(QDir::NoFilter);
-  QFlags<QDirIterator::IteratorFlag> arg4 = args ? args.read<QFlags<QDirIterator::IteratorFlag> > (heap) : (QFlags<QDirIterator::IteratorFlag>)(QDirIterator::NoIteratorFlags);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
+  QFlags<QDir::Filter> arg3 = args ? gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap) : gsi::arg_maker<QFlags<QDir::Filter> >() (QDir::NoFilter, heap);
+  QFlags<QDirIterator::IteratorFlag> arg4 = args ? gsi::arg_reader<QFlags<QDirIterator::IteratorFlag> >() (args, heap) : gsi::arg_maker<QFlags<QDirIterator::IteratorFlag> >() (QDirIterator::NoIteratorFlags, heap);
   ret.write<QDirIterator_Adaptor *> (new QDirIterator_Adaptor (arg1, arg2, arg3, arg4));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDirModel.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDirModel.cc
@@ -75,7 +75,7 @@ static void _call_f_columnCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QDirModel *)cls)->columnCount (arg1));
 }
 
@@ -96,8 +96,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QDirModel *)cls)->data (arg1, arg2));
 }
 
@@ -124,11 +124,11 @@ static void _call_f_dropMimeData_7425 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QModelIndex &arg5 = args.read<const QModelIndex & > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg5 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QDirModel *)cls)->dropMimeData (arg1, qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg2).cref(), arg3, arg4, arg5));
 }
 
@@ -147,7 +147,7 @@ static void _call_f_fileIcon_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QIcon > ((QIcon)((QDirModel *)cls)->fileIcon (arg1));
 }
 
@@ -166,7 +166,7 @@ static void _call_f_fileInfo_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFileInfo > ((QFileInfo)((QDirModel *)cls)->fileInfo (arg1));
 }
 
@@ -185,7 +185,7 @@ static void _call_f_fileName_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QString > ((QString)((QDirModel *)cls)->fileName (arg1));
 }
 
@@ -204,7 +204,7 @@ static void _call_f_filePath_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QString > ((QString)((QDirModel *)cls)->filePath (arg1));
 }
 
@@ -238,7 +238,7 @@ static void _call_f_flags_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFlags<Qt::ItemFlag> > ((QFlags<Qt::ItemFlag>)((QDirModel *)cls)->flags (arg1));
 }
 
@@ -257,7 +257,7 @@ static void _call_f_hasChildren_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QDirModel *)cls)->hasChildren (arg1));
 }
 
@@ -280,9 +280,9 @@ static void _call_f_headerData_c3231 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QDirModel *)cls)->headerData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3));
 }
 
@@ -320,9 +320,9 @@ static void _call_f_index_c3713 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<QModelIndex > ((QModelIndex)((QDirModel *)cls)->index (arg1, arg2, arg3));
 }
 
@@ -343,8 +343,8 @@ static void _call_f_index_c2684 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QDirModel *)cls)->index (arg1, arg2));
 }
 
@@ -363,7 +363,7 @@ static void _call_f_isDir_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QDirModel *)cls)->isDir (arg1));
 }
 
@@ -412,7 +412,7 @@ static void _call_f_mimeData_c3010 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   ret.write<QMimeData * > ((QMimeData *)((QDirModel *)cls)->mimeData (arg1));
 }
 
@@ -448,8 +448,8 @@ static void _call_f_mkdir_4312 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QDirModel *)cls)->mkdir (arg1, arg2));
 }
 
@@ -483,7 +483,7 @@ static void _call_f_parent_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QDirModel *)cls)->parent (arg1));
 }
 
@@ -517,7 +517,7 @@ static void _call_f_refresh_2395 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel *)cls)->refresh (arg1);
 }
@@ -537,7 +537,7 @@ static void _call_f_remove_2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QDirModel *)cls)->remove (arg1));
 }
 
@@ -571,7 +571,7 @@ static void _call_f_rmdir_2395 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QDirModel *)cls)->rmdir (arg1));
 }
 
@@ -590,7 +590,7 @@ static void _call_f_rowCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QDirModel *)cls)->rowCount (arg1));
 }
 
@@ -613,9 +613,9 @@ static void _call_f_setData_5065 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QDirModel *)cls)->setData (arg1, arg2, arg3));
 }
 
@@ -634,7 +634,7 @@ static void _call_f_setFilter_2230 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDir::Filter> arg1 = args.read<QFlags<QDir::Filter> > (heap);
+  QFlags<QDir::Filter> arg1 = gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel *)cls)->setFilter (arg1);
 }
@@ -654,7 +654,7 @@ static void _call_f_setIconProvider_2323 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFileIconProvider *arg1 = args.read<QFileIconProvider * > (heap);
+  QFileIconProvider *arg1 = gsi::arg_reader<QFileIconProvider * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel *)cls)->setIconProvider (arg1);
 }
@@ -674,7 +674,7 @@ static void _call_f_setLazyChildCount_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel *)cls)->setLazyChildCount (arg1);
 }
@@ -694,7 +694,7 @@ static void _call_f_setNameFilters_2437 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel *)cls)->setNameFilters (arg1);
 }
@@ -714,7 +714,7 @@ static void _call_f_setReadOnly_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel *)cls)->setReadOnly (arg1);
 }
@@ -734,7 +734,7 @@ static void _call_f_setResolveSymlinks_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel *)cls)->setResolveSymlinks (arg1);
 }
@@ -754,7 +754,7 @@ static void _call_f_setSorting_2418 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDir::SortFlag> arg1 = args.read<QFlags<QDir::SortFlag> > (heap);
+  QFlags<QDir::SortFlag> arg1 = gsi::arg_reader<QFlags<QDir::SortFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel *)cls)->setSorting (arg1);
 }
@@ -776,8 +776,8 @@ static void _call_f_sort_2340 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SortOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel *)cls)->sort (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -829,8 +829,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDirModel::tr (arg1, arg2));
 }
 
@@ -853,9 +853,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDirModel::tr (arg1, arg2, arg3));
 }
 
@@ -876,8 +876,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDirModel::trUtf8 (arg1, arg2));
 }
 
@@ -900,9 +900,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDirModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1732,10 +1732,10 @@ static void _call_ctor_QDirModel_Adaptor_8063 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
-  QFlags<QDir::Filter> arg2 = args.read<QFlags<QDir::Filter> > (heap);
-  QFlags<QDir::SortFlag> arg3 = args.read<QFlags<QDir::SortFlag> > (heap);
-  QObject *arg4 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
+  QFlags<QDir::Filter> arg2 = gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap);
+  QFlags<QDir::SortFlag> arg3 = gsi::arg_reader<QFlags<QDir::SortFlag> >() (args, heap);
+  QObject *arg4 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QDirModel_Adaptor *> (new QDirModel_Adaptor (arg1, arg2, arg3, arg4));
 }
 
@@ -1753,7 +1753,7 @@ static void _call_ctor_QDirModel_Adaptor_1302 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QDirModel_Adaptor *> (new QDirModel_Adaptor (arg1));
 }
 
@@ -1775,9 +1775,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel_Adaptor *)cls)->fp_QDirModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -1800,9 +1800,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel_Adaptor *)cls)->fp_QDirModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1829,11 +1829,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QDirModel_Adaptor *)cls)->fp_QDirModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1859,11 +1859,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QDirModel_Adaptor *)cls)->fp_QDirModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1885,9 +1885,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel_Adaptor *)cls)->fp_QDirModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -1910,9 +1910,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel_Adaptor *)cls)->fp_QDirModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -1994,8 +1994,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel_Adaptor *)cls)->fp_QDirModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -2016,8 +2016,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel_Adaptor *)cls)->fp_QDirModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -2087,9 +2087,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QDirModel_Adaptor *)cls)->fp_QDirModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -2111,9 +2111,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QDirModel_Adaptor *)cls)->fp_QDirModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -2135,9 +2135,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QDirModel_Adaptor *)cls)->fp_QDirModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -2207,8 +2207,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QDirModel_Adaptor *)cls)->emitter_QDirModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -2232,10 +2232,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QDirModel_Adaptor *)cls)->fp_QDirModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -2253,7 +2253,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDirModel_Adaptor *)cls)->emitter_QDirModel_destroyed_1302 (arg1);
 }
 
@@ -2332,8 +2332,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel_Adaptor *)cls)->fp_QDirModel_encodeData_c4599 (arg1, arg2);
 }
@@ -2609,9 +2609,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QDirModel_Adaptor *)cls)->emitter_QDirModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -2881,7 +2881,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDirModel_Adaptor *)cls)->fp_QDirModel_receivers_c1731 (arg1));
 }
 
@@ -3116,7 +3116,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDirModel_Adaptor *)cls)->fp_QDirModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDockWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDockWidget.cc
@@ -142,7 +142,7 @@ static void _call_f_isAreaAllowed_c2123 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QDockWidget *)cls)->isAreaAllowed (qt_gsi::QtToCppAdaptor<Qt::DockWidgetArea>(arg1).cref()));
 }
 
@@ -176,7 +176,7 @@ static void _call_f_setAllowedAreas_2819 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DockWidgetArea> arg1 = args.read<QFlags<Qt::DockWidgetArea> > (heap);
+  QFlags<Qt::DockWidgetArea> arg1 = gsi::arg_reader<QFlags<Qt::DockWidgetArea> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDockWidget *)cls)->setAllowedAreas (arg1);
 }
@@ -196,7 +196,7 @@ static void _call_f_setFeatures_4039 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDockWidget::DockWidgetFeature> arg1 = args.read<QFlags<QDockWidget::DockWidgetFeature> > (heap);
+  QFlags<QDockWidget::DockWidgetFeature> arg1 = gsi::arg_reader<QFlags<QDockWidget::DockWidgetFeature> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDockWidget *)cls)->setFeatures (arg1);
 }
@@ -216,7 +216,7 @@ static void _call_f_setFloating_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDockWidget *)cls)->setFloating (arg1);
 }
@@ -236,7 +236,7 @@ static void _call_f_setTitleBarWidget_1315 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDockWidget *)cls)->setTitleBarWidget (arg1);
 }
@@ -256,7 +256,7 @@ static void _call_f_setWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDockWidget *)cls)->setWidget (arg1);
 }
@@ -323,8 +323,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDockWidget::tr (arg1, arg2));
 }
 
@@ -347,9 +347,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDockWidget::tr (arg1, arg2, arg3));
 }
 
@@ -370,8 +370,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDockWidget::trUtf8 (arg1, arg2));
 }
 
@@ -394,9 +394,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDockWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1330,9 +1330,9 @@ static void _call_ctor_QDockWidget_Adaptor_5619 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg3 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg3 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QDockWidget_Adaptor *> (new QDockWidget_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1352,8 +1352,8 @@ static void _call_ctor_QDockWidget_Adaptor_3702 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QDockWidget_Adaptor *> (new QDockWidget_Adaptor (arg1, arg2));
 }
 
@@ -1395,7 +1395,7 @@ static void _call_emitter_allowedAreasChanged_2819 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DockWidgetArea> arg1 = args.read<QFlags<Qt::DockWidgetArea> > (heap);
+  QFlags<Qt::DockWidgetArea> arg1 = gsi::arg_reader<QFlags<Qt::DockWidgetArea> >() (args, heap);
   ((QDockWidget_Adaptor *)cls)->emitter_QDockWidget_allowedAreasChanged_2819 (arg1);
 }
 
@@ -1513,9 +1513,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDockWidget_Adaptor *)cls)->fp_QDockWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -1534,7 +1534,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QDockWidget_Adaptor *)cls)->emitter_QDockWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1578,8 +1578,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDockWidget_Adaptor *)cls)->fp_QDockWidget_destroy_1620 (arg1, arg2);
 }
@@ -1598,7 +1598,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDockWidget_Adaptor *)cls)->emitter_QDockWidget_destroyed_1302 (arg1);
 }
 
@@ -1640,7 +1640,7 @@ static void _call_emitter_dockLocationChanged_2123 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & >() (args, heap);
   ((QDockWidget_Adaptor *)cls)->emitter_QDockWidget_dockLocationChanged_2123 (arg1);
 }
 
@@ -1851,7 +1851,7 @@ static void _call_emitter_featuresChanged_4039 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDockWidget::DockWidgetFeature> arg1 = args.read<QFlags<QDockWidget::DockWidgetFeature> > (heap);
+  QFlags<QDockWidget::DockWidgetFeature> arg1 = gsi::arg_reader<QFlags<QDockWidget::DockWidgetFeature> >() (args, heap);
   ((QDockWidget_Adaptor *)cls)->emitter_QDockWidget_featuresChanged_4039 (arg1);
 }
 
@@ -2039,7 +2039,7 @@ static void _call_fp_initStyleOption_c2862 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionDockWidget *arg1 = args.read<QStyleOptionDockWidget * > (heap);
+  QStyleOptionDockWidget *arg1 = gsi::arg_reader<QStyleOptionDockWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDockWidget_Adaptor *)cls)->fp_QDockWidget_initStyleOption_c2862 (arg1);
 }
@@ -2426,7 +2426,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDockWidget_Adaptor *)cls)->fp_QDockWidget_receivers_c1731 (arg1));
 }
 
@@ -2636,7 +2636,7 @@ static void _call_emitter_topLevelChanged_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QDockWidget_Adaptor *)cls)->emitter_QDockWidget_topLevelChanged_864 (arg1);
 }
 
@@ -2669,7 +2669,7 @@ static void _call_emitter_visibilityChanged_864 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QDockWidget_Adaptor *)cls)->emitter_QDockWidget_visibilityChanged_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDoubleSpinBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDoubleSpinBox.cc
@@ -143,7 +143,7 @@ static void _call_f_fixup_c1330 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox *)cls)->fixup (arg1);
 }
@@ -208,7 +208,7 @@ static void _call_f_setDecimals_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox *)cls)->setDecimals (arg1);
 }
@@ -228,7 +228,7 @@ static void _call_f_setMaximum_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox *)cls)->setMaximum (arg1);
 }
@@ -248,7 +248,7 @@ static void _call_f_setMinimum_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox *)cls)->setMinimum (arg1);
 }
@@ -268,7 +268,7 @@ static void _call_f_setPrefix_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox *)cls)->setPrefix (arg1);
 }
@@ -290,8 +290,8 @@ static void _call_f_setRange_2034 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox *)cls)->setRange (arg1, arg2);
 }
@@ -311,7 +311,7 @@ static void _call_f_setSingleStep_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox *)cls)->setSingleStep (arg1);
 }
@@ -331,7 +331,7 @@ static void _call_f_setSuffix_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox *)cls)->setSuffix (arg1);
 }
@@ -351,7 +351,7 @@ static void _call_f_setValue_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox *)cls)->setValue (arg1);
 }
@@ -401,7 +401,7 @@ static void _call_f_textFromValue_c1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QString > ((QString)((QDoubleSpinBox *)cls)->textFromValue (arg1));
 }
 
@@ -422,8 +422,8 @@ static void _call_f_validate_c2171 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
-  int &arg2 = args.read<int & > (heap);
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
+  int &arg2 = gsi::arg_reader<int & >() (args, heap);
   ret.write<qt_gsi::Converter<QValidator::State>::target_type > ((qt_gsi::Converter<QValidator::State>::target_type)qt_gsi::CppToQtAdaptor<QValidator::State>(((QDoubleSpinBox *)cls)->validate (arg1, arg2)));
 }
 
@@ -457,7 +457,7 @@ static void _call_f_valueFromText_c2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<double > ((double)((QDoubleSpinBox *)cls)->valueFromText (arg1));
 }
 
@@ -478,8 +478,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDoubleSpinBox::tr (arg1, arg2));
 }
 
@@ -502,9 +502,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDoubleSpinBox::tr (arg1, arg2, arg3));
 }
 
@@ -525,8 +525,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDoubleSpinBox::trUtf8 (arg1, arg2));
 }
 
@@ -549,9 +549,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDoubleSpinBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1573,7 +1573,7 @@ static void _call_ctor_QDoubleSpinBox_Adaptor_1315 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QDoubleSpinBox_Adaptor *> (new QDoubleSpinBox_Adaptor (arg1));
 }
 
@@ -1735,9 +1735,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox_Adaptor *)cls)->fp_QDoubleSpinBox_create_2208 (arg1, arg2, arg3);
 }
@@ -1756,7 +1756,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QDoubleSpinBox_Adaptor *)cls)->emitter_QDoubleSpinBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1800,8 +1800,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox_Adaptor *)cls)->fp_QDoubleSpinBox_destroy_1620 (arg1, arg2);
 }
@@ -1820,7 +1820,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDoubleSpinBox_Adaptor *)cls)->emitter_QDoubleSpinBox_destroyed_1302 (arg1);
 }
 
@@ -2263,7 +2263,7 @@ static void _call_fp_initStyleOption_c2572 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionSpinBox *arg1 = args.read<QStyleOptionSpinBox * > (heap);
+  QStyleOptionSpinBox *arg1 = gsi::arg_reader<QStyleOptionSpinBox * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox_Adaptor *)cls)->fp_QDoubleSpinBox_initStyleOption_c2572 (arg1);
 }
@@ -2664,7 +2664,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDoubleSpinBox_Adaptor *)cls)->fp_QDoubleSpinBox_receivers_c1731 (arg1));
 }
 
@@ -2735,7 +2735,7 @@ static void _call_fp_setLineEdit_1485 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLineEdit *arg1 = args.read<QLineEdit * > (heap);
+  QLineEdit *arg1 = gsi::arg_reader<QLineEdit * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleSpinBox_Adaptor *)cls)->fp_QDoubleSpinBox_setLineEdit_1485 (arg1);
 }
@@ -3000,7 +3000,7 @@ static void _call_emitter_valueChanged_1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ((QDoubleSpinBox_Adaptor *)cls)->emitter_QDoubleSpinBox_valueChanged_1071 (arg1);
 }
 
@@ -3018,7 +3018,7 @@ static void _call_emitter_valueChanged_2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QDoubleSpinBox_Adaptor *)cls)->emitter_QDoubleSpinBox_valueChanged_2025 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDoubleValidator.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDoubleValidator.cc
@@ -114,7 +114,7 @@ static void _call_f_setBottom_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleValidator *)cls)->setBottom (arg1);
 }
@@ -134,7 +134,7 @@ static void _call_f_setDecimals_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleValidator *)cls)->setDecimals (arg1);
 }
@@ -154,7 +154,7 @@ static void _call_f_setNotation_3014 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDoubleValidator::Notation>::target_type & arg1 = args.read<const qt_gsi::Converter<QDoubleValidator::Notation>::target_type & > (heap);
+  const qt_gsi::Converter<QDoubleValidator::Notation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDoubleValidator::Notation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleValidator *)cls)->setNotation (qt_gsi::QtToCppAdaptor<QDoubleValidator::Notation>(arg1).cref());
 }
@@ -178,9 +178,9 @@ static void _call_f_setRange_2693 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleValidator *)cls)->setRange (arg1, arg2, arg3);
 }
@@ -200,7 +200,7 @@ static void _call_f_setTop_1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDoubleValidator *)cls)->setTop (arg1);
 }
@@ -237,8 +237,8 @@ static void _call_f_validate_c2171 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
-  int &arg2 = args.read<int & > (heap);
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
+  int &arg2 = gsi::arg_reader<int & >() (args, heap);
   ret.write<qt_gsi::Converter<QValidator::State>::target_type > ((qt_gsi::Converter<QValidator::State>::target_type)qt_gsi::CppToQtAdaptor<QValidator::State>(((QDoubleValidator *)cls)->validate (arg1, arg2)));
 }
 
@@ -259,8 +259,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDoubleValidator::tr (arg1, arg2));
 }
 
@@ -283,9 +283,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDoubleValidator::tr (arg1, arg2, arg3));
 }
 
@@ -306,8 +306,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDoubleValidator::trUtf8 (arg1, arg2));
 }
 
@@ -330,9 +330,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDoubleValidator::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -567,7 +567,7 @@ static void _call_ctor_QDoubleValidator_Adaptor_1302 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QDoubleValidator_Adaptor *> (new QDoubleValidator_Adaptor (arg1));
 }
 
@@ -591,10 +591,10 @@ static void _call_ctor_QDoubleValidator_Adaptor_3887 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  int arg3 = args.read<int > (heap);
-  QObject *arg4 = args.read<QObject * > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  QObject *arg4 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QDoubleValidator_Adaptor *> (new QDoubleValidator_Adaptor (arg1, arg2, arg3, arg4));
 }
 
@@ -660,7 +660,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDoubleValidator_Adaptor *)cls)->emitter_QDoubleValidator_destroyed_1302 (arg1);
 }
 
@@ -775,7 +775,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDoubleValidator_Adaptor *)cls)->fp_QDoubleValidator_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDrag.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDrag.cc
@@ -72,7 +72,7 @@ static void _call_f_exec_2456 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DropAction> arg1 = args ? args.read<QFlags<Qt::DropAction> > (heap) : (QFlags<Qt::DropAction>)(Qt::MoveAction);
+  QFlags<Qt::DropAction> arg1 = args ? gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap) : gsi::arg_maker<QFlags<Qt::DropAction> >() (Qt::MoveAction, heap);
   ret.write<qt_gsi::Converter<Qt::DropAction>::target_type > ((qt_gsi::Converter<Qt::DropAction>::target_type)qt_gsi::CppToQtAdaptor<Qt::DropAction>(((QDrag *)cls)->exec (arg1)));
 }
 
@@ -93,8 +93,8 @@ static void _call_f_exec_4108 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DropAction> arg1 = args.read<QFlags<Qt::DropAction> > (heap);
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
+  QFlags<Qt::DropAction> arg1 = gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
   ret.write<qt_gsi::Converter<Qt::DropAction>::target_type > ((qt_gsi::Converter<Qt::DropAction>::target_type)qt_gsi::CppToQtAdaptor<Qt::DropAction>(((QDrag *)cls)->exec (arg1, qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg2).cref())));
 }
 
@@ -160,8 +160,8 @@ static void _call_f_setDragCursor_3669 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDrag *)cls)->setDragCursor (arg1, qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg2).cref());
 }
@@ -181,7 +181,7 @@ static void _call_f_setHotSpot_1916 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDrag *)cls)->setHotSpot (arg1);
 }
@@ -201,7 +201,7 @@ static void _call_f_setMimeData_1473 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMimeData *arg1 = args.read<QMimeData * > (heap);
+  QMimeData *arg1 = gsi::arg_reader<QMimeData * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDrag *)cls)->setMimeData (arg1);
 }
@@ -221,7 +221,7 @@ static void _call_f_setPixmap_2017 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDrag *)cls)->setPixmap (arg1);
 }
@@ -256,7 +256,7 @@ static void _call_f_start_2456 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DropAction> arg1 = args ? args.read<QFlags<Qt::DropAction> > (heap) : (QFlags<Qt::DropAction>)(Qt::CopyAction);
+  QFlags<Qt::DropAction> arg1 = args ? gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap) : gsi::arg_maker<QFlags<Qt::DropAction> >() (Qt::CopyAction, heap);
   ret.write<qt_gsi::Converter<Qt::DropAction>::target_type > ((qt_gsi::Converter<Qt::DropAction>::target_type)qt_gsi::CppToQtAdaptor<Qt::DropAction>(((QDrag *)cls)->start (arg1)));
 }
 
@@ -292,8 +292,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDrag::tr (arg1, arg2));
 }
 
@@ -316,9 +316,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDrag::tr (arg1, arg2, arg3));
 }
 
@@ -339,8 +339,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QDrag::trUtf8 (arg1, arg2));
 }
 
@@ -363,9 +363,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QDrag::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -562,7 +562,7 @@ static void _call_ctor_QDrag_Adaptor_1315 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QDrag_Adaptor *> (new QDrag_Adaptor (arg1));
 }
 
@@ -580,7 +580,7 @@ static void _call_emitter_actionChanged_1760 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
   ((QDrag_Adaptor *)cls)->emitter_QDrag_actionChanged_1760 (arg1);
 }
 
@@ -646,7 +646,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QDrag_Adaptor *)cls)->emitter_QDrag_destroyed_1302 (arg1);
 }
 
@@ -737,7 +737,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QDrag_Adaptor *)cls)->fp_QDrag_receivers_c1731 (arg1));
 }
 
@@ -769,7 +769,7 @@ static void _call_emitter_targetChanged_1315 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ((QDrag_Adaptor *)cls)->emitter_QDrag_targetChanged_1315 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDragEnterEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDragEnterEvent.cc
@@ -144,11 +144,11 @@ static void _call_ctor_QDragEnterEvent_Adaptor_11787 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  QFlags<Qt::DropAction> arg2 = args.read<QFlags<Qt::DropAction> > (heap);
-  const QMimeData *arg3 = args.read<const QMimeData * > (heap);
-  QFlags<Qt::MouseButton> arg4 = args.read<QFlags<Qt::MouseButton> > (heap);
-  QFlags<Qt::KeyboardModifier> arg5 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  QFlags<Qt::DropAction> arg2 = gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap);
+  const QMimeData *arg3 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  QFlags<Qt::MouseButton> arg4 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg5 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   ret.write<QDragEnterEvent_Adaptor *> (new QDragEnterEvent_Adaptor (arg1, arg2, arg3, arg4, arg5));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDragMoveEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDragMoveEvent.cc
@@ -70,7 +70,7 @@ static void _call_f_accept_1792 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDragMoveEvent *)cls)->accept (arg1);
 }
@@ -121,7 +121,7 @@ static void _call_f_ignore_1792 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDragMoveEvent *)cls)->ignore (arg1);
 }
@@ -244,12 +244,12 @@ static void _call_ctor_QDragMoveEvent_Adaptor_13244 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  QFlags<Qt::DropAction> arg2 = args.read<QFlags<Qt::DropAction> > (heap);
-  const QMimeData *arg3 = args.read<const QMimeData * > (heap);
-  QFlags<Qt::MouseButton> arg4 = args.read<QFlags<Qt::MouseButton> > (heap);
-  QFlags<Qt::KeyboardModifier> arg5 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg6 = args ? args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap) : (const qt_gsi::Converter<QEvent::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::DragMove));
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  QFlags<Qt::DropAction> arg2 = gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap);
+  const QMimeData *arg3 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  QFlags<Qt::MouseButton> arg4 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg5 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg6 = args ? gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QEvent::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::DragMove), heap);
   ret.write<QDragMoveEvent_Adaptor *> (new QDragMoveEvent_Adaptor (arg1, arg2, arg3, arg4, arg5, qt_gsi::QtToCppAdaptor<QEvent::Type>(arg6).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDragResponseEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDragResponseEvent.cc
@@ -101,7 +101,7 @@ static void _call_ctor_QDragResponseEvent_Adaptor_864 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ret.write<QDragResponseEvent_Adaptor *> (new QDragResponseEvent_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQDropEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQDropEvent.cc
@@ -84,7 +84,7 @@ static void _call_f_encodedData_c1731 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QDropEvent *)cls)->encodedData (arg1));
 }
 
@@ -103,7 +103,7 @@ static void _call_f_format_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<const char * > ((const char *)((QDropEvent *)cls)->format (arg1));
 }
 
@@ -212,7 +212,7 @@ static void _call_f_provides_c1731 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<bool > ((bool)((QDropEvent *)cls)->provides (arg1));
 }
 
@@ -231,7 +231,7 @@ static void _call_f_setDropAction_1760 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDropEvent *)cls)->setDropAction (qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg1).cref());
 }
@@ -426,12 +426,12 @@ static void _call_ctor_QDropEvent_Adaptor_13244 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  QFlags<Qt::DropAction> arg2 = args.read<QFlags<Qt::DropAction> > (heap);
-  const QMimeData *arg3 = args.read<const QMimeData * > (heap);
-  QFlags<Qt::MouseButton> arg4 = args.read<QFlags<Qt::MouseButton> > (heap);
-  QFlags<Qt::KeyboardModifier> arg5 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg6 = args ? args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap) : (const qt_gsi::Converter<QEvent::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::Drop));
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  QFlags<Qt::DropAction> arg2 = gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap);
+  const QMimeData *arg3 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  QFlags<Qt::MouseButton> arg4 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg5 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg6 = args ? gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QEvent::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::Drop), heap);
   ret.write<QDropEvent_Adaptor *> (new QDropEvent_Adaptor (arg1, arg2, arg3, arg4, arg5, qt_gsi::QtToCppAdaptor<QEvent::Type>(arg6).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQErrorMessage.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQErrorMessage.cc
@@ -111,7 +111,7 @@ static void _call_f_showMessage_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QErrorMessage *)cls)->showMessage (arg1);
 }
@@ -133,8 +133,8 @@ static void _call_f_showMessage_3942 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QErrorMessage *)cls)->showMessage (arg1, arg2);
 }
@@ -171,8 +171,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QErrorMessage::tr (arg1, arg2));
 }
 
@@ -195,9 +195,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QErrorMessage::tr (arg1, arg2, arg3));
 }
 
@@ -218,8 +218,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QErrorMessage::trUtf8 (arg1, arg2));
 }
 
@@ -242,9 +242,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QErrorMessage::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1175,7 +1175,7 @@ static void _call_ctor_QErrorMessage_Adaptor_1315 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QErrorMessage_Adaptor *> (new QErrorMessage_Adaptor (arg1));
 }
 
@@ -1251,7 +1251,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QErrorMessage_Adaptor *)cls)->fp_QErrorMessage_adjustPosition_1315 (arg1);
 }
@@ -1370,9 +1370,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QErrorMessage_Adaptor *)cls)->fp_QErrorMessage_create_2208 (arg1, arg2, arg3);
 }
@@ -1391,7 +1391,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QErrorMessage_Adaptor *)cls)->emitter_QErrorMessage_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1435,8 +1435,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QErrorMessage_Adaptor *)cls)->fp_QErrorMessage_destroy_1620 (arg1, arg2);
 }
@@ -1455,7 +1455,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QErrorMessage_Adaptor *)cls)->emitter_QErrorMessage_destroyed_1302 (arg1);
 }
 
@@ -1714,7 +1714,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QErrorMessage_Adaptor *)cls)->emitter_QErrorMessage_finished_767 (arg1);
 }
 
@@ -2270,7 +2270,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QErrorMessage_Adaptor *)cls)->fp_QErrorMessage_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFileDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFileDialog.cc
@@ -296,7 +296,7 @@ static void _call_f_labelText_c2681 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFileDialog::DialogLabel>::target_type & arg1 = args.read<const qt_gsi::Converter<QFileDialog::DialogLabel>::target_type & > (heap);
+  const qt_gsi::Converter<QFileDialog::DialogLabel>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFileDialog::DialogLabel>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QFileDialog *)cls)->labelText (qt_gsi::QtToCppAdaptor<QFileDialog::DialogLabel>(arg1).cref()));
 }
 
@@ -348,8 +348,8 @@ static void _call_f_open_2925 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->open (arg1, arg2);
 }
@@ -414,7 +414,7 @@ static void _call_f_restoreState_2309 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<bool > ((bool)((QFileDialog *)cls)->restoreState (arg1));
 }
 
@@ -448,7 +448,7 @@ static void _call_f_selectFile_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->selectFile (arg1);
 }
@@ -468,7 +468,7 @@ static void _call_f_selectFilter_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->selectFilter (arg1);
 }
@@ -488,7 +488,7 @@ static void _call_f_selectNameFilter_2025 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->selectNameFilter (arg1);
 }
@@ -553,7 +553,7 @@ static void _call_f_setAcceptMode_2590 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFileDialog::AcceptMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QFileDialog::AcceptMode>::target_type & > (heap);
+  const qt_gsi::Converter<QFileDialog::AcceptMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFileDialog::AcceptMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setAcceptMode (qt_gsi::QtToCppAdaptor<QFileDialog::AcceptMode>(arg1).cref());
 }
@@ -573,7 +573,7 @@ static void _call_f_setConfirmOverwrite_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setConfirmOverwrite (arg1);
 }
@@ -593,7 +593,7 @@ static void _call_f_setDefaultSuffix_2025 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setDefaultSuffix (arg1);
 }
@@ -613,7 +613,7 @@ static void _call_f_setDirectory_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setDirectory (arg1);
 }
@@ -633,7 +633,7 @@ static void _call_f_setDirectory_1681 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDir &arg1 = args.read<const QDir & > (heap);
+  const QDir &arg1 = gsi::arg_reader<const QDir & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setDirectory (arg1);
 }
@@ -653,7 +653,7 @@ static void _call_f_setFileMode_2382 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFileDialog::FileMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QFileDialog::FileMode>::target_type & > (heap);
+  const qt_gsi::Converter<QFileDialog::FileMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFileDialog::FileMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setFileMode (qt_gsi::QtToCppAdaptor<QFileDialog::FileMode>(arg1).cref());
 }
@@ -673,7 +673,7 @@ static void _call_f_setFilter_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setFilter (arg1);
 }
@@ -693,7 +693,7 @@ static void _call_f_setFilter_2230 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDir::Filter> arg1 = args.read<QFlags<QDir::Filter> > (heap);
+  QFlags<QDir::Filter> arg1 = gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setFilter (arg1);
 }
@@ -713,7 +713,7 @@ static void _call_f_setFilters_2437 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setFilters (arg1);
 }
@@ -733,7 +733,7 @@ static void _call_f_setHistory_2437 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setHistory (arg1);
 }
@@ -753,7 +753,7 @@ static void _call_f_setIconProvider_2323 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFileIconProvider *arg1 = args.read<QFileIconProvider * > (heap);
+  QFileIconProvider *arg1 = gsi::arg_reader<QFileIconProvider * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setIconProvider (arg1);
 }
@@ -773,7 +773,7 @@ static void _call_f_setItemDelegate_2717 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemDelegate *arg1 = args.read<QAbstractItemDelegate * > (heap);
+  QAbstractItemDelegate *arg1 = gsi::arg_reader<QAbstractItemDelegate * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setItemDelegate (arg1);
 }
@@ -795,8 +795,8 @@ static void _call_f_setLabelText_4598 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFileDialog::DialogLabel>::target_type & arg1 = args.read<const qt_gsi::Converter<QFileDialog::DialogLabel>::target_type & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const qt_gsi::Converter<QFileDialog::DialogLabel>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFileDialog::DialogLabel>::target_type & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setLabelText (qt_gsi::QtToCppAdaptor<QFileDialog::DialogLabel>(arg1).cref(), arg2);
 }
@@ -816,7 +816,7 @@ static void _call_f_setNameFilter_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setNameFilter (arg1);
 }
@@ -836,7 +836,7 @@ static void _call_f_setNameFilterDetailsVisible_864 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setNameFilterDetailsVisible (arg1);
 }
@@ -856,7 +856,7 @@ static void _call_f_setNameFilters_2437 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setNameFilters (arg1);
 }
@@ -878,8 +878,8 @@ static void _call_f_setOption_2998 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFileDialog::Option>::target_type & arg1 = args.read<const qt_gsi::Converter<QFileDialog::Option>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QFileDialog::Option>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFileDialog::Option>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setOption (qt_gsi::QtToCppAdaptor<QFileDialog::Option>(arg1).cref(), arg2);
 }
@@ -899,7 +899,7 @@ static void _call_f_setOptions_2938 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QFileDialog::Option> arg1 = args.read<QFlags<QFileDialog::Option> > (heap);
+  QFlags<QFileDialog::Option> arg1 = gsi::arg_reader<QFlags<QFileDialog::Option> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setOptions (arg1);
 }
@@ -919,7 +919,7 @@ static void _call_f_setProxyModel_2566 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractProxyModel *arg1 = args.read<QAbstractProxyModel * > (heap);
+  QAbstractProxyModel *arg1 = gsi::arg_reader<QAbstractProxyModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setProxyModel (arg1);
 }
@@ -939,7 +939,7 @@ static void _call_f_setReadOnly_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setReadOnly (arg1);
 }
@@ -959,7 +959,7 @@ static void _call_f_setResolveSymlinks_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setResolveSymlinks (arg1);
 }
@@ -979,7 +979,7 @@ static void _call_f_setSidebarUrls_2316 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QUrl> &arg1 = args.read<const QList<QUrl> & > (heap);
+  const QList<QUrl> &arg1 = gsi::arg_reader<const QList<QUrl> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setSidebarUrls (arg1);
 }
@@ -999,7 +999,7 @@ static void _call_f_setViewMode_2409 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFileDialog::ViewMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QFileDialog::ViewMode>::target_type & > (heap);
+  const qt_gsi::Converter<QFileDialog::ViewMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFileDialog::ViewMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setViewMode (qt_gsi::QtToCppAdaptor<QFileDialog::ViewMode>(arg1).cref());
 }
@@ -1019,7 +1019,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog *)cls)->setVisible (arg1);
 }
@@ -1054,7 +1054,7 @@ static void _call_f_testOption_c2242 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFileDialog::Option>::target_type & arg1 = args.read<const qt_gsi::Converter<QFileDialog::Option>::target_type & > (heap);
+  const qt_gsi::Converter<QFileDialog::Option>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFileDialog::Option>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QFileDialog *)cls)->testOption (qt_gsi::QtToCppAdaptor<QFileDialog::Option>(arg1).cref()));
 }
 
@@ -1094,10 +1094,10 @@ static void _call_f_getExistingDirectory_7979 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  QFlags<QFileDialog::Option> arg4 = args ? args.read<QFlags<QFileDialog::Option> > (heap) : (QFlags<QFileDialog::Option>)(QFileDialog::ShowDirsOnly);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  QFlags<QFileDialog::Option> arg4 = args ? gsi::arg_reader<QFlags<QFileDialog::Option> >() (args, heap) : gsi::arg_maker<QFlags<QFileDialog::Option> >() (QFileDialog::ShowDirsOnly, heap);
   ret.write<QString > ((QString)QFileDialog::getExistingDirectory (arg1, arg2, arg3, arg4));
 }
 
@@ -1126,12 +1126,12 @@ static void _call_f_getOpenFileName_11122 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  QString *arg5 = args ? args.read<QString * > (heap) : (QString *)(0);
-  QFlags<QFileDialog::Option> arg6 = args ? args.read<QFlags<QFileDialog::Option> > (heap) : (QFlags<QFileDialog::Option>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  QString *arg5 = args ? gsi::arg_reader<QString * >() (args, heap) : gsi::arg_maker<QString * >() (0, heap);
+  QFlags<QFileDialog::Option> arg6 = args ? gsi::arg_reader<QFlags<QFileDialog::Option> >() (args, heap) : gsi::arg_maker<QFlags<QFileDialog::Option> >() (0, heap);
   ret.write<QString > ((QString)QFileDialog::getOpenFileName (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -1160,12 +1160,12 @@ static void _call_f_getOpenFileNames_11122 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  QString *arg5 = args ? args.read<QString * > (heap) : (QString *)(0);
-  QFlags<QFileDialog::Option> arg6 = args ? args.read<QFlags<QFileDialog::Option> > (heap) : (QFlags<QFileDialog::Option>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  QString *arg5 = args ? gsi::arg_reader<QString * >() (args, heap) : gsi::arg_maker<QString * >() (0, heap);
+  QFlags<QFileDialog::Option> arg6 = args ? gsi::arg_reader<QFlags<QFileDialog::Option> >() (args, heap) : gsi::arg_maker<QFlags<QFileDialog::Option> >() (0, heap);
   ret.write<QStringList > ((QStringList)QFileDialog::getOpenFileNames (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -1194,12 +1194,12 @@ static void _call_f_getSaveFileName_11122 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  QString *arg5 = args ? args.read<QString * > (heap) : (QString *)(0);
-  QFlags<QFileDialog::Option> arg6 = args ? args.read<QFlags<QFileDialog::Option> > (heap) : (QFlags<QFileDialog::Option>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  QString *arg5 = args ? gsi::arg_reader<QString * >() (args, heap) : gsi::arg_maker<QString * >() (0, heap);
+  QFlags<QFileDialog::Option> arg6 = args ? gsi::arg_reader<QFlags<QFileDialog::Option> >() (args, heap) : gsi::arg_maker<QFlags<QFileDialog::Option> >() (0, heap);
   ret.write<QString > ((QString)QFileDialog::getSaveFileName (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -1220,8 +1220,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFileDialog::tr (arg1, arg2));
 }
 
@@ -1244,9 +1244,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFileDialog::tr (arg1, arg2, arg3));
 }
 
@@ -1267,8 +1267,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFileDialog::trUtf8 (arg1, arg2));
 }
 
@@ -1291,9 +1291,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFileDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2340,8 +2340,8 @@ static void _call_ctor_QFileDialog_Adaptor_3702 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QFlags<Qt::WindowType> arg2 = args.read<QFlags<Qt::WindowType> > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QFlags<Qt::WindowType> arg2 = gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap);
   ret.write<QFileDialog_Adaptor *> (new QFileDialog_Adaptor (arg1, arg2));
 }
 
@@ -2365,10 +2365,10 @@ static void _call_ctor_QFileDialog_Adaptor_7066 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QFileDialog_Adaptor *> (new QFileDialog_Adaptor (arg1, arg2, arg3, arg4));
 }
 
@@ -2444,7 +2444,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog_Adaptor *)cls)->fp_QFileDialog_adjustPosition_1315 (arg1);
 }
@@ -2563,9 +2563,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog_Adaptor *)cls)->fp_QFileDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -2584,7 +2584,7 @@ static void _call_emitter_currentChanged_2025 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFileDialog_Adaptor *)cls)->emitter_QFileDialog_currentChanged_2025 (arg1);
 }
 
@@ -2602,7 +2602,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QFileDialog_Adaptor *)cls)->emitter_QFileDialog_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2646,8 +2646,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileDialog_Adaptor *)cls)->fp_QFileDialog_destroy_1620 (arg1, arg2);
 }
@@ -2666,7 +2666,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QFileDialog_Adaptor *)cls)->emitter_QFileDialog_destroyed_1302 (arg1);
 }
 
@@ -2684,7 +2684,7 @@ static void _call_emitter_directoryEntered_2025 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFileDialog_Adaptor *)cls)->emitter_QFileDialog_directoryEntered_2025 (arg1);
 }
 
@@ -2943,7 +2943,7 @@ static void _call_emitter_fileSelected_2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFileDialog_Adaptor *)cls)->emitter_QFileDialog_fileSelected_2025 (arg1);
 }
 
@@ -2961,7 +2961,7 @@ static void _call_emitter_filesSelected_2437 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   ((QFileDialog_Adaptor *)cls)->emitter_QFileDialog_filesSelected_2437 (arg1);
 }
 
@@ -2979,7 +2979,7 @@ static void _call_emitter_filterSelected_2025 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFileDialog_Adaptor *)cls)->emitter_QFileDialog_filterSelected_2025 (arg1);
 }
 
@@ -2997,7 +2997,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QFileDialog_Adaptor *)cls)->emitter_QFileDialog_finished_767 (arg1);
 }
 
@@ -3553,7 +3553,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QFileDialog_Adaptor *)cls)->fp_QFileDialog_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFileIconProvider.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFileIconProvider.cc
@@ -52,7 +52,7 @@ static void _call_f_icon_c3064 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFileIconProvider::IconType>::target_type & arg1 = args.read<const qt_gsi::Converter<QFileIconProvider::IconType>::target_type & > (heap);
+  const qt_gsi::Converter<QFileIconProvider::IconType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFileIconProvider::IconType>::target_type & >() (args, heap);
   ret.write<QIcon > ((QIcon)((QFileIconProvider *)cls)->icon (qt_gsi::QtToCppAdaptor<QFileIconProvider::IconType>(arg1).cref()));
 }
 
@@ -71,7 +71,7 @@ static void _call_f_icon_c2174 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFileInfo &arg1 = args.read<const QFileInfo & > (heap);
+  const QFileInfo &arg1 = gsi::arg_reader<const QFileInfo & >() (args, heap);
   ret.write<QIcon > ((QIcon)((QFileIconProvider *)cls)->icon (arg1));
 }
 
@@ -90,7 +90,7 @@ static void _call_f_type_c2174 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFileInfo &arg1 = args.read<const QFileInfo & > (heap);
+  const QFileInfo &arg1 = gsi::arg_reader<const QFileInfo & >() (args, heap);
   ret.write<QString > ((QString)((QFileIconProvider *)cls)->type (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFileOpenEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFileOpenEvent.cc
@@ -124,7 +124,7 @@ static void _call_ctor_QFileOpenEvent_Adaptor_2025 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QFileOpenEvent_Adaptor *> (new QFileOpenEvent_Adaptor (arg1));
 }
 
@@ -142,7 +142,7 @@ static void _call_ctor_QFileOpenEvent_Adaptor_1701 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QFileOpenEvent_Adaptor *> (new QFileOpenEvent_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFileSystemModel.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFileSystemModel.cc
@@ -77,7 +77,7 @@ static void _call_f_canFetchMore_c2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QFileSystemModel *)cls)->canFetchMore (arg1));
 }
 
@@ -96,7 +96,7 @@ static void _call_f_columnCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QFileSystemModel *)cls)->columnCount (arg1));
 }
 
@@ -117,8 +117,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QFileSystemModel *)cls)->data (arg1, arg2));
 }
 
@@ -145,11 +145,11 @@ static void _call_f_dropMimeData_7425 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QModelIndex &arg5 = args.read<const QModelIndex & > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg5 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QFileSystemModel *)cls)->dropMimeData (arg1, qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg2).cref(), arg3, arg4, arg5));
 }
 
@@ -168,7 +168,7 @@ static void _call_f_fetchMore_2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel *)cls)->fetchMore (arg1);
 }
@@ -188,7 +188,7 @@ static void _call_f_fileIcon_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QIcon > ((QIcon)((QFileSystemModel *)cls)->fileIcon (arg1));
 }
 
@@ -207,7 +207,7 @@ static void _call_f_fileInfo_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFileInfo > ((QFileInfo)((QFileSystemModel *)cls)->fileInfo (arg1));
 }
 
@@ -226,7 +226,7 @@ static void _call_f_fileName_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QString > ((QString)((QFileSystemModel *)cls)->fileName (arg1));
 }
 
@@ -245,7 +245,7 @@ static void _call_f_filePath_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QString > ((QString)((QFileSystemModel *)cls)->filePath (arg1));
 }
 
@@ -279,7 +279,7 @@ static void _call_f_flags_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFlags<Qt::ItemFlag> > ((QFlags<Qt::ItemFlag>)((QFileSystemModel *)cls)->flags (arg1));
 }
 
@@ -298,7 +298,7 @@ static void _call_f_hasChildren_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QFileSystemModel *)cls)->hasChildren (arg1));
 }
 
@@ -321,9 +321,9 @@ static void _call_f_headerData_c3231 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QFileSystemModel *)cls)->headerData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3));
 }
 
@@ -361,9 +361,9 @@ static void _call_f_index_c3713 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<QModelIndex > ((QModelIndex)((QFileSystemModel *)cls)->index (arg1, arg2, arg3));
 }
 
@@ -384,8 +384,8 @@ static void _call_f_index_c2684 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QFileSystemModel *)cls)->index (arg1, arg2));
 }
 
@@ -404,7 +404,7 @@ static void _call_f_isDir_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QFileSystemModel *)cls)->isDir (arg1));
 }
 
@@ -438,7 +438,7 @@ static void _call_f_lastModified_c2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QDateTime > ((QDateTime)((QFileSystemModel *)cls)->lastModified (arg1));
 }
 
@@ -457,7 +457,7 @@ static void _call_f_mimeData_c3010 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   ret.write<QMimeData * > ((QMimeData *)((QFileSystemModel *)cls)->mimeData (arg1));
 }
 
@@ -493,8 +493,8 @@ static void _call_f_mkdir_4312 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QFileSystemModel *)cls)->mkdir (arg1, arg2));
 }
 
@@ -513,7 +513,7 @@ static void _call_f_myComputer_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QFileSystemModel *)cls)->myComputer (arg1));
 }
 
@@ -562,7 +562,7 @@ static void _call_f_parent_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QFileSystemModel *)cls)->parent (arg1));
 }
 
@@ -581,7 +581,7 @@ static void _call_f_permissions_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFlags<QFile::Permission> > ((QFlags<QFile::Permission>)((QFileSystemModel *)cls)->permissions (arg1));
 }
 
@@ -600,7 +600,7 @@ static void _call_f_remove_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QFileSystemModel *)cls)->remove (arg1));
 }
 
@@ -634,7 +634,7 @@ static void _call_f_rmdir_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QFileSystemModel *)cls)->rmdir (arg1));
 }
 
@@ -683,7 +683,7 @@ static void _call_f_rowCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QFileSystemModel *)cls)->rowCount (arg1));
 }
 
@@ -706,9 +706,9 @@ static void _call_f_setData_5065 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QFileSystemModel *)cls)->setData (arg1, arg2, arg3));
 }
 
@@ -727,7 +727,7 @@ static void _call_f_setFilter_2230 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QDir::Filter> arg1 = args.read<QFlags<QDir::Filter> > (heap);
+  QFlags<QDir::Filter> arg1 = gsi::arg_reader<QFlags<QDir::Filter> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel *)cls)->setFilter (arg1);
 }
@@ -747,7 +747,7 @@ static void _call_f_setIconProvider_2323 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFileIconProvider *arg1 = args.read<QFileIconProvider * > (heap);
+  QFileIconProvider *arg1 = gsi::arg_reader<QFileIconProvider * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel *)cls)->setIconProvider (arg1);
 }
@@ -767,7 +767,7 @@ static void _call_f_setNameFilterDisables_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel *)cls)->setNameFilterDisables (arg1);
 }
@@ -787,7 +787,7 @@ static void _call_f_setNameFilters_2437 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel *)cls)->setNameFilters (arg1);
 }
@@ -807,7 +807,7 @@ static void _call_f_setReadOnly_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel *)cls)->setReadOnly (arg1);
 }
@@ -827,7 +827,7 @@ static void _call_f_setResolveSymlinks_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel *)cls)->setResolveSymlinks (arg1);
 }
@@ -847,7 +847,7 @@ static void _call_f_setRootPath_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QFileSystemModel *)cls)->setRootPath (arg1));
 }
 
@@ -866,7 +866,7 @@ static void _call_f_size_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<qint64 > ((qint64)((QFileSystemModel *)cls)->size (arg1));
 }
 
@@ -887,8 +887,8 @@ static void _call_f_sort_2340 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SortOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel *)cls)->sort (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -923,7 +923,7 @@ static void _call_f_type_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QString > ((QString)((QFileSystemModel *)cls)->type (arg1));
 }
 
@@ -944,8 +944,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFileSystemModel::tr (arg1, arg2));
 }
 
@@ -968,9 +968,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFileSystemModel::tr (arg1, arg2, arg3));
 }
 
@@ -991,8 +991,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFileSystemModel::trUtf8 (arg1, arg2));
 }
 
@@ -1015,9 +1015,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFileSystemModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1849,7 +1849,7 @@ static void _call_ctor_QFileSystemModel_Adaptor_1302 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QFileSystemModel_Adaptor *> (new QFileSystemModel_Adaptor (arg1));
 }
 
@@ -1871,9 +1871,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -1896,9 +1896,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1925,11 +1925,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1955,11 +1955,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1981,9 +1981,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -2006,9 +2006,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -2090,8 +2090,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -2112,8 +2112,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -2183,9 +2183,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -2207,9 +2207,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -2231,9 +2231,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -2303,8 +2303,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QFileSystemModel_Adaptor *)cls)->emitter_QFileSystemModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -2328,10 +2328,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -2349,7 +2349,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QFileSystemModel_Adaptor *)cls)->emitter_QFileSystemModel_destroyed_1302 (arg1);
 }
 
@@ -2428,8 +2428,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_encodeData_c4599 (arg1, arg2);
 }
@@ -2630,9 +2630,9 @@ static void _call_emitter_fileRenamed_5859 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFileSystemModel_Adaptor *)cls)->emitter_QFileSystemModel_fileRenamed_5859 (arg1, arg2, arg3);
 }
 
@@ -2729,9 +2729,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QFileSystemModel_Adaptor *)cls)->emitter_QFileSystemModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -3001,7 +3001,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_receivers_c1731 (arg1));
 }
 
@@ -3112,7 +3112,7 @@ static void _call_emitter_rootPathChanged_2025 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFileSystemModel_Adaptor *)cls)->emitter_QFileSystemModel_rootPathChanged_2025 (arg1);
 }
 
@@ -3254,7 +3254,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFileSystemModel_Adaptor *)cls)->fp_QFileSystemModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFocusEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFocusEvent.cc
@@ -157,8 +157,8 @@ static void _call_ctor_QFocusEvent_Adaptor_3334 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::FocusReason>::target_type & > (heap) : (const qt_gsi::Converter<Qt::FocusReason>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::FocusReason>(heap, Qt::OtherFocusReason));
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::FocusReason>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::FocusReason>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::FocusReason>(heap, Qt::OtherFocusReason), heap);
   ret.write<QFocusEvent_Adaptor *> (new QFocusEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), qt_gsi::QtToCppAdaptor<Qt::FocusReason>(arg2).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFocusFrame.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFocusFrame.cc
@@ -112,7 +112,7 @@ static void _call_f_setWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFocusFrame *)cls)->setWidget (arg1);
 }
@@ -149,8 +149,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFocusFrame::tr (arg1, arg2));
 }
 
@@ -173,9 +173,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFocusFrame::tr (arg1, arg2, arg3));
 }
 
@@ -196,8 +196,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFocusFrame::trUtf8 (arg1, arg2));
 }
 
@@ -220,9 +220,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFocusFrame::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1083,7 +1083,7 @@ static void _call_ctor_QFocusFrame_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QFocusFrame_Adaptor *> (new QFocusFrame_Adaptor (arg1));
 }
 
@@ -1225,9 +1225,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFocusFrame_Adaptor *)cls)->fp_QFocusFrame_create_2208 (arg1, arg2, arg3);
 }
@@ -1246,7 +1246,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QFocusFrame_Adaptor *)cls)->emitter_QFocusFrame_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1290,8 +1290,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFocusFrame_Adaptor *)cls)->fp_QFocusFrame_destroy_1620 (arg1, arg2);
 }
@@ -1310,7 +1310,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QFocusFrame_Adaptor *)cls)->emitter_QFocusFrame_destroyed_1302 (arg1);
 }
 
@@ -1715,7 +1715,7 @@ static void _call_fp_initStyleOption_c1865 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOption *arg1 = args.read<QStyleOption * > (heap);
+  QStyleOption *arg1 = gsi::arg_reader<QStyleOption * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFocusFrame_Adaptor *)cls)->fp_QFocusFrame_initStyleOption_c1865 (arg1);
 }
@@ -2102,7 +2102,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QFocusFrame_Adaptor *)cls)->fp_QFocusFrame_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFont.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFont.cc
@@ -77,10 +77,10 @@ static void _call_ctor_QFont_4099 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(-1);
-  int arg3 = args ? args.read<int > (heap) : (int)(-1);
-  bool arg4 = args ? args.read<bool > (heap) : (bool)(false);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  bool arg4 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<QFont *> (new QFont (arg1, arg2, arg3, arg4));
 }
 
@@ -101,8 +101,8 @@ static void _call_ctor_QFont_3496 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
-  QPaintDevice *arg2 = args.read<QPaintDevice * > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
+  QPaintDevice *arg2 = gsi::arg_reader<QPaintDevice * >() (args, heap);
   ret.write<QFont *> (new QFont (arg1, arg2));
 }
 
@@ -121,7 +121,7 @@ static void _call_ctor_QFont_1801 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<QFont *> (new QFont (arg1));
 }
 
@@ -230,7 +230,7 @@ static void _call_f_fromString_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QFont *)cls)->fromString (arg1));
 }
 
@@ -264,7 +264,7 @@ static void _call_f_isCopyOf_c1801 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<bool > ((bool)((QFont *)cls)->isCopyOf (arg1));
 }
 
@@ -388,7 +388,7 @@ static void _call_f_operator_excl__eq__c1801 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<bool > ((bool)((QFont *)cls)->operator!= (arg1));
 }
 
@@ -407,7 +407,7 @@ static void _call_f_operator_lt__c1801 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<bool > ((bool)((QFont *)cls)->operator< (arg1));
 }
 
@@ -426,7 +426,7 @@ static void _call_f_operator_eq__1801 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<QFont & > ((QFont &)((QFont *)cls)->operator= (arg1));
 }
 
@@ -445,7 +445,7 @@ static void _call_f_operator_eq__eq__c1801 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<bool > ((bool)((QFont *)cls)->operator== (arg1));
 }
 
@@ -554,7 +554,7 @@ static void _call_f_resolve_c1801 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<QFont > ((QFont)((QFont *)cls)->resolve (arg1));
 }
 
@@ -573,7 +573,7 @@ static void _call_f_setBold_864 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setBold (arg1);
 }
@@ -593,7 +593,7 @@ static void _call_f_setCapitalization_2508 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFont::Capitalization>::target_type & arg1 = args.read<const qt_gsi::Converter<QFont::Capitalization>::target_type & > (heap);
+  const qt_gsi::Converter<QFont::Capitalization>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFont::Capitalization>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setCapitalization (qt_gsi::QtToCppAdaptor<QFont::Capitalization>(arg1).cref());
 }
@@ -613,7 +613,7 @@ static void _call_f_setFamily_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setFamily (arg1);
 }
@@ -633,7 +633,7 @@ static void _call_f_setFixedPitch_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setFixedPitch (arg1);
 }
@@ -653,7 +653,7 @@ static void _call_f_setItalic_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setItalic (arg1);
 }
@@ -673,7 +673,7 @@ static void _call_f_setKerning_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setKerning (arg1);
 }
@@ -695,8 +695,8 @@ static void _call_f_setLetterSpacing_3130 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFont::SpacingType>::target_type & arg1 = args.read<const qt_gsi::Converter<QFont::SpacingType>::target_type & > (heap);
-  double arg2 = args.read<double > (heap);
+  const qt_gsi::Converter<QFont::SpacingType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFont::SpacingType>::target_type & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setLetterSpacing (qt_gsi::QtToCppAdaptor<QFont::SpacingType>(arg1).cref(), arg2);
 }
@@ -716,7 +716,7 @@ static void _call_f_setOverline_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setOverline (arg1);
 }
@@ -736,7 +736,7 @@ static void _call_f_setPixelSize_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setPixelSize (arg1);
 }
@@ -756,7 +756,7 @@ static void _call_f_setPointSize_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setPointSize (arg1);
 }
@@ -776,7 +776,7 @@ static void _call_f_setPointSizeF_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setPointSizeF (arg1);
 }
@@ -796,7 +796,7 @@ static void _call_f_setRawMode_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setRawMode (arg1);
 }
@@ -816,7 +816,7 @@ static void _call_f_setRawName_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setRawName (arg1);
 }
@@ -836,7 +836,7 @@ static void _call_f_setStretch_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setStretch (arg1);
 }
@@ -856,7 +856,7 @@ static void _call_f_setStrikeOut_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setStrikeOut (arg1);
 }
@@ -876,7 +876,7 @@ static void _call_f_setStyle_1569 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFont::Style>::target_type & arg1 = args.read<const qt_gsi::Converter<QFont::Style>::target_type & > (heap);
+  const qt_gsi::Converter<QFont::Style>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFont::Style>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setStyle (qt_gsi::QtToCppAdaptor<QFont::Style>(arg1).cref());
 }
@@ -898,8 +898,8 @@ static void _call_f_setStyleHint_4284 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFont::StyleHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QFont::StyleHint>::target_type & > (heap);
-  const qt_gsi::Converter<QFont::StyleStrategy>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & > (heap) : (const qt_gsi::Converter<QFont::StyleStrategy>::target_type &)(qt_gsi::CppToQtReadAdaptor<QFont::StyleStrategy>(heap, QFont::PreferDefault));
+  const qt_gsi::Converter<QFont::StyleHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFont::StyleHint>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QFont::StyleStrategy>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QFont::StyleStrategy>(heap, QFont::PreferDefault), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setStyleHint (qt_gsi::QtToCppAdaptor<QFont::StyleHint>(arg1).cref(), qt_gsi::QtToCppAdaptor<QFont::StyleStrategy>(arg2).cref());
 }
@@ -919,7 +919,7 @@ static void _call_f_setStyleStrategy_2420 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFont::StyleStrategy>::target_type & arg1 = args.read<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & > (heap);
+  const qt_gsi::Converter<QFont::StyleStrategy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setStyleStrategy (qt_gsi::QtToCppAdaptor<QFont::StyleStrategy>(arg1).cref());
 }
@@ -939,7 +939,7 @@ static void _call_f_setUnderline_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setUnderline (arg1);
 }
@@ -959,7 +959,7 @@ static void _call_f_setWeight_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setWeight (arg1);
 }
@@ -979,7 +979,7 @@ static void _call_f_setWordSpacing_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFont *)cls)->setWordSpacing (arg1);
 }
@@ -1168,8 +1168,8 @@ static void _call_f_insertSubstitution_3942 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QFont::insertSubstitution (arg1, arg2);
 }
@@ -1191,8 +1191,8 @@ static void _call_f_insertSubstitutions_4354 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QFont::insertSubstitutions (arg1, arg2);
 }
@@ -1212,7 +1212,7 @@ static void _call_f_removeSubstitution_2025 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QFont::removeSubstitution (arg1);
 }
@@ -1232,7 +1232,7 @@ static void _call_f_substitute_2025 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QFont::substitute (arg1));
 }
 
@@ -1251,7 +1251,7 @@ static void _call_f_substitutes_2025 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStringList > ((QStringList)QFont::substitutes (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFontComboBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFontComboBox.cc
@@ -149,7 +149,7 @@ static void _call_f_setCurrentFont_1801 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontComboBox *)cls)->setCurrentFont (arg1);
 }
@@ -169,7 +169,7 @@ static void _call_f_setFontFilters_3550 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QFontComboBox::FontFilter> arg1 = args.read<QFlags<QFontComboBox::FontFilter> > (heap);
+  QFlags<QFontComboBox::FontFilter> arg1 = gsi::arg_reader<QFlags<QFontComboBox::FontFilter> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontComboBox *)cls)->setFontFilters (arg1);
 }
@@ -189,7 +189,7 @@ static void _call_f_setWritingSystem_3214 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & arg1 = args.read<const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & > (heap);
+  const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontComboBox *)cls)->setWritingSystem (qt_gsi::QtToCppAdaptor<QFontDatabase::WritingSystem>(arg1).cref());
 }
@@ -241,8 +241,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFontComboBox::tr (arg1, arg2));
 }
 
@@ -265,9 +265,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFontComboBox::tr (arg1, arg2, arg3));
 }
 
@@ -288,8 +288,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFontComboBox::trUtf8 (arg1, arg2));
 }
 
@@ -312,9 +312,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFontComboBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1268,7 +1268,7 @@ static void _call_ctor_QFontComboBox_Adaptor_1315 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QFontComboBox_Adaptor *> (new QFontComboBox_Adaptor (arg1));
 }
 
@@ -1310,7 +1310,7 @@ static void _call_emitter_activated_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_activated_767 (arg1);
 }
 
@@ -1328,7 +1328,7 @@ static void _call_emitter_activated_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_activated_2025 (arg1);
 }
 
@@ -1446,9 +1446,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontComboBox_Adaptor *)cls)->fp_QFontComboBox_create_2208 (arg1, arg2, arg3);
 }
@@ -1467,7 +1467,7 @@ static void _call_emitter_currentFontChanged_1801 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_currentFontChanged_1801 (arg1);
 }
 
@@ -1485,7 +1485,7 @@ static void _call_emitter_currentIndexChanged_767 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_currentIndexChanged_767 (arg1);
 }
 
@@ -1503,7 +1503,7 @@ static void _call_emitter_currentIndexChanged_2025 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_currentIndexChanged_2025 (arg1);
 }
 
@@ -1521,7 +1521,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1565,8 +1565,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontComboBox_Adaptor *)cls)->fp_QFontComboBox_destroy_1620 (arg1, arg2);
 }
@@ -1585,7 +1585,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_destroyed_1302 (arg1);
 }
 
@@ -1723,7 +1723,7 @@ static void _call_emitter_editTextChanged_2025 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_editTextChanged_2025 (arg1);
 }
 
@@ -2028,7 +2028,7 @@ static void _call_emitter_highlighted_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_highlighted_767 (arg1);
 }
 
@@ -2046,7 +2046,7 @@ static void _call_emitter_highlighted_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFontComboBox_Adaptor *)cls)->emitter_QFontComboBox_highlighted_2025 (arg1);
 }
 
@@ -2064,7 +2064,7 @@ static void _call_fp_initStyleOption_c2658 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionComboBox *arg1 = args.read<QStyleOptionComboBox * > (heap);
+  QStyleOptionComboBox *arg1 = gsi::arg_reader<QStyleOptionComboBox * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontComboBox_Adaptor *)cls)->fp_QFontComboBox_initStyleOption_c2658 (arg1);
 }
@@ -2451,7 +2451,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QFontComboBox_Adaptor *)cls)->fp_QFontComboBox_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFontDatabase.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFontDatabase.cc
@@ -69,8 +69,8 @@ static void _call_f_bold_c3942 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QFontDatabase *)cls)->bold (arg1, arg2));
 }
 
@@ -89,7 +89,7 @@ static void _call_f_families_c3214 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & > (heap) : (const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<QFontDatabase::WritingSystem>(heap, QFontDatabase::Any));
+  const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QFontDatabase::WritingSystem>(heap, QFontDatabase::Any), heap);
   ret.write<QStringList > ((QStringList)((QFontDatabase *)cls)->families (qt_gsi::QtToCppAdaptor<QFontDatabase::WritingSystem>(arg1).cref()));
 }
 
@@ -112,9 +112,9 @@ static void _call_f_font_c4601 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  int arg3 = args.read<int > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFont > ((QFont)((QFontDatabase *)cls)->font (arg1, arg2, arg3));
 }
 
@@ -135,8 +135,8 @@ static void _call_f_isBitmapScalable_c3942 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)((QFontDatabase *)cls)->isBitmapScalable (arg1, arg2));
 }
 
@@ -157,8 +157,8 @@ static void _call_f_isFixedPitch_c3942 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)((QFontDatabase *)cls)->isFixedPitch (arg1, arg2));
 }
 
@@ -179,8 +179,8 @@ static void _call_f_isScalable_c3942 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)((QFontDatabase *)cls)->isScalable (arg1, arg2));
 }
 
@@ -201,8 +201,8 @@ static void _call_f_isSmoothlyScalable_c3942 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)((QFontDatabase *)cls)->isSmoothlyScalable (arg1, arg2));
 }
 
@@ -223,8 +223,8 @@ static void _call_f_italic_c3942 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QFontDatabase *)cls)->italic (arg1, arg2));
 }
 
@@ -245,8 +245,8 @@ static void _call_f_pointSizes_3942 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QList<int> > ((QList<int>)((QFontDatabase *)cls)->pointSizes (arg1, arg2));
 }
 
@@ -267,8 +267,8 @@ static void _call_f_smoothSizes_3942 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QList<int> > ((QList<int>)((QFontDatabase *)cls)->smoothSizes (arg1, arg2));
 }
 
@@ -287,7 +287,7 @@ static void _call_f_styleString_1801 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<QString > ((QString)((QFontDatabase *)cls)->styleString (arg1));
 }
 
@@ -306,7 +306,7 @@ static void _call_f_styleString_2197 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontInfo &arg1 = args.read<const QFontInfo & > (heap);
+  const QFontInfo &arg1 = gsi::arg_reader<const QFontInfo & >() (args, heap);
   ret.write<QString > ((QString)((QFontDatabase *)cls)->styleString (arg1));
 }
 
@@ -325,7 +325,7 @@ static void _call_f_styles_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStringList > ((QStringList)((QFontDatabase *)cls)->styles (arg1));
 }
 
@@ -346,8 +346,8 @@ static void _call_f_weight_c3942 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QFontDatabase *)cls)->weight (arg1, arg2));
 }
 
@@ -381,7 +381,7 @@ static void _call_f_writingSystems_c2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QList<QFontDatabase::WritingSystem> > ((QList<QFontDatabase::WritingSystem>)((QFontDatabase *)cls)->writingSystems (arg1));
 }
 
@@ -400,7 +400,7 @@ static void _call_f_addApplicationFont_2025 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)QFontDatabase::addApplicationFont (arg1));
 }
 
@@ -419,7 +419,7 @@ static void _call_f_addApplicationFontFromData_2309 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<int > ((int)QFontDatabase::addApplicationFontFromData (arg1));
 }
 
@@ -438,7 +438,7 @@ static void _call_f_applicationFontFamilies_767 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QStringList > ((QStringList)QFontDatabase::applicationFontFamilies (arg1));
 }
 
@@ -472,7 +472,7 @@ static void _call_f_removeApplicationFont_767 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)QFontDatabase::removeApplicationFont (arg1));
 }
 
@@ -521,7 +521,7 @@ static void _call_f_writingSystemName_3214 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & arg1 = args.read<const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & > (heap);
+  const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QFontDatabase::writingSystemName (qt_gsi::QtToCppAdaptor<QFontDatabase::WritingSystem>(arg1).cref()));
 }
 
@@ -540,7 +540,7 @@ static void _call_f_writingSystemSample_3214 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & arg1 = args.read<const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & > (heap);
+  const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFontDatabase::WritingSystem>::target_type & >() (args, heap);
   ret.write<QString > ((QString)QFontDatabase::writingSystemSample (qt_gsi::QtToCppAdaptor<QFontDatabase::WritingSystem>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFontDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFontDialog.cc
@@ -144,8 +144,8 @@ static void _call_f_open_2925 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontDialog *)cls)->open (arg1, arg2);
 }
@@ -195,7 +195,7 @@ static void _call_f_setCurrentFont_1801 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontDialog *)cls)->setCurrentFont (arg1);
 }
@@ -217,8 +217,8 @@ static void _call_f_setOption_4020 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFontDialog::FontDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QFontDialog::FontDialogOption>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QFontDialog::FontDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFontDialog::FontDialogOption>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontDialog *)cls)->setOption (qt_gsi::QtToCppAdaptor<QFontDialog::FontDialogOption>(arg1).cref(), arg2);
 }
@@ -238,7 +238,7 @@ static void _call_f_setOptions_3960 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QFontDialog::FontDialogOption> arg1 = args.read<QFlags<QFontDialog::FontDialogOption> > (heap);
+  QFlags<QFontDialog::FontDialogOption> arg1 = gsi::arg_reader<QFlags<QFontDialog::FontDialogOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontDialog *)cls)->setOptions (arg1);
 }
@@ -258,7 +258,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontDialog *)cls)->setVisible (arg1);
 }
@@ -278,7 +278,7 @@ static void _call_f_testOption_c3264 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFontDialog::FontDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QFontDialog::FontDialogOption>::target_type & > (heap);
+  const qt_gsi::Converter<QFontDialog::FontDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFontDialog::FontDialogOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QFontDialog *)cls)->testOption (qt_gsi::QtToCppAdaptor<QFontDialog::FontDialogOption>(arg1).cref()));
 }
 
@@ -305,11 +305,11 @@ static void _call_f_getFont_9719 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool *arg1 = args.read<bool * > (heap);
-  const QFont &arg2 = args.read<const QFont & > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
-  QFlags<QFontDialog::FontDialogOption> arg5 = args.read<QFlags<QFontDialog::FontDialogOption> > (heap);
+  bool *arg1 = gsi::arg_reader<bool * >() (args, heap);
+  const QFont &arg2 = gsi::arg_reader<const QFont & >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QFontDialog::FontDialogOption> arg5 = gsi::arg_reader<QFlags<QFontDialog::FontDialogOption> >() (args, heap);
   ret.write<QFont > ((QFont)QFontDialog::getFont (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -334,10 +334,10 @@ static void _call_f_getFont_5867 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool *arg1 = args.read<bool * > (heap);
-  const QFont &arg2 = args.read<const QFont & > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
+  bool *arg1 = gsi::arg_reader<bool * >() (args, heap);
+  const QFont &arg2 = gsi::arg_reader<const QFont & >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QFont > ((QFont)QFontDialog::getFont (arg1, arg2, arg3, arg4));
 }
 
@@ -360,9 +360,9 @@ static void _call_f_getFont_3950 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool *arg1 = args.read<bool * > (heap);
-  const QFont &arg2 = args.read<const QFont & > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  bool *arg1 = gsi::arg_reader<bool * >() (args, heap);
+  const QFont &arg2 = gsi::arg_reader<const QFont & >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QFont > ((QFont)QFontDialog::getFont (arg1, arg2, arg3));
 }
 
@@ -383,8 +383,8 @@ static void _call_f_getFont_2257 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool *arg1 = args.read<bool * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  bool *arg1 = gsi::arg_reader<bool * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QFont > ((QFont)QFontDialog::getFont (arg1, arg2));
 }
 
@@ -405,8 +405,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFontDialog::tr (arg1, arg2));
 }
 
@@ -429,9 +429,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFontDialog::tr (arg1, arg2, arg3));
 }
 
@@ -452,8 +452,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFontDialog::trUtf8 (arg1, arg2));
 }
 
@@ -476,9 +476,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFontDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1430,7 +1430,7 @@ static void _call_ctor_QFontDialog_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QFontDialog_Adaptor *> (new QFontDialog_Adaptor (arg1));
 }
 
@@ -1450,8 +1450,8 @@ static void _call_ctor_QFontDialog_Adaptor_3008 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QFontDialog_Adaptor *> (new QFontDialog_Adaptor (arg1, arg2));
 }
 
@@ -1527,7 +1527,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontDialog_Adaptor *)cls)->fp_QFontDialog_adjustPosition_1315 (arg1);
 }
@@ -1646,9 +1646,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontDialog_Adaptor *)cls)->fp_QFontDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -1667,7 +1667,7 @@ static void _call_emitter_currentFontChanged_1801 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ((QFontDialog_Adaptor *)cls)->emitter_QFontDialog_currentFontChanged_1801 (arg1);
 }
 
@@ -1685,7 +1685,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QFontDialog_Adaptor *)cls)->emitter_QFontDialog_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1729,8 +1729,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFontDialog_Adaptor *)cls)->fp_QFontDialog_destroy_1620 (arg1, arg2);
 }
@@ -1749,7 +1749,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QFontDialog_Adaptor *)cls)->emitter_QFontDialog_destroyed_1302 (arg1);
 }
 
@@ -1982,7 +1982,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QFontDialog_Adaptor *)cls)->emitter_QFontDialog_finished_767 (arg1);
 }
 
@@ -2123,7 +2123,7 @@ static void _call_emitter_fontSelected_1801 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ((QFontDialog_Adaptor *)cls)->emitter_QFontDialog_fontSelected_1801 (arg1);
 }
 
@@ -2556,7 +2556,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QFontDialog_Adaptor *)cls)->fp_QFontDialog_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFontInfo.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFontInfo.cc
@@ -51,7 +51,7 @@ static void _call_ctor_QFontInfo_1801 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<QFontInfo *> (new QFontInfo (arg1));
 }
 
@@ -70,7 +70,7 @@ static void _call_ctor_QFontInfo_2197 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontInfo &arg1 = args.read<const QFontInfo & > (heap);
+  const QFontInfo &arg1 = gsi::arg_reader<const QFontInfo & >() (args, heap);
   ret.write<QFontInfo *> (new QFontInfo (arg1));
 }
 
@@ -164,7 +164,7 @@ static void _call_f_operator_eq__2197 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontInfo &arg1 = args.read<const QFontInfo & > (heap);
+  const QFontInfo &arg1 = gsi::arg_reader<const QFontInfo & >() (args, heap);
   ret.write<QFontInfo & > ((QFontInfo &)((QFontInfo *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFontMetrics.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFontMetrics.cc
@@ -54,7 +54,7 @@ static void _call_ctor_QFontMetrics_1801 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<QFontMetrics *> (new QFontMetrics (arg1));
 }
 
@@ -75,8 +75,8 @@ static void _call_ctor_QFontMetrics_3496 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
-  QPaintDevice *arg2 = args.read<QPaintDevice * > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
+  QPaintDevice *arg2 = gsi::arg_reader<QPaintDevice * >() (args, heap);
   ret.write<QFontMetrics *> (new QFontMetrics (arg1, arg2));
 }
 
@@ -95,7 +95,7 @@ static void _call_ctor_QFontMetrics_2528 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
   ret.write<QFontMetrics *> (new QFontMetrics (arg1));
 }
 
@@ -144,7 +144,7 @@ static void _call_f_boundingRect_c899 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<QRect > ((QRect)((QFontMetrics *)cls)->boundingRect (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 
@@ -163,7 +163,7 @@ static void _call_f_boundingRect_c2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QRect > ((QRect)((QFontMetrics *)cls)->boundingRect (arg1));
 }
 
@@ -190,11 +190,11 @@ static void _call_f_boundingRect_c5872 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
-  int *arg5 = args ? args.read<int * > (heap) : (int *)(0);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int *arg5 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<QRect > ((QRect)((QFontMetrics *)cls)->boundingRect (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -227,14 +227,14 @@ static void _call_f_boundingRect_c6824 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  const QString &arg6 = args.read<const QString & > (heap);
-  int arg7 = args ? args.read<int > (heap) : (int)(0);
-  int *arg8 = args ? args.read<int * > (heap) : (int *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg6 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg7 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int *arg8 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<QRect > ((QRect)((QFontMetrics *)cls)->boundingRect (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
 }
 
@@ -255,8 +255,8 @@ static void _call_f_charWidth_c2684 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args.read<int > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QFontMetrics *)cls)->charWidth (arg1, arg2));
 }
 
@@ -296,10 +296,10 @@ static void _call_f_elidedText_c5277 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::TextElideMode>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextElideMode>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QString > ((QString)((QFontMetrics *)cls)->elidedText (arg1, qt_gsi::QtToCppAdaptor<Qt::TextElideMode>(arg2).cref(), arg3, arg4));
 }
 
@@ -333,7 +333,7 @@ static void _call_f_inFont_c899 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetrics *)cls)->inFont (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 
@@ -367,7 +367,7 @@ static void _call_f_leftBearing_c899 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<int > ((int)((QFontMetrics *)cls)->leftBearing (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 
@@ -461,7 +461,7 @@ static void _call_f_operator_excl__eq__2528 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetrics *)cls)->operator != (arg1));
 }
 
@@ -480,7 +480,7 @@ static void _call_f_operator_excl__eq__c2528 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetrics *)cls)->operator != (arg1));
 }
 
@@ -499,7 +499,7 @@ static void _call_f_operator_eq__2528 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
   ret.write<QFontMetrics & > ((QFontMetrics &)((QFontMetrics *)cls)->operator= (arg1));
 }
 
@@ -518,7 +518,7 @@ static void _call_f_operator_eq__eq__2528 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetrics *)cls)->operator== (arg1));
 }
 
@@ -537,7 +537,7 @@ static void _call_f_operator_eq__eq__c2528 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetrics *)cls)->operator== (arg1));
 }
 
@@ -571,7 +571,7 @@ static void _call_f_rightBearing_c899 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<int > ((int)((QFontMetrics *)cls)->rightBearing (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 
@@ -596,10 +596,10 @@ static void _call_f_size_c4188 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<QSize > ((QSize)((QFontMetrics *)cls)->size (arg1, arg2, arg3, arg4));
 }
 
@@ -633,7 +633,7 @@ static void _call_f_tightBoundingRect_c2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QRect > ((QRect)((QFontMetrics *)cls)->tightBoundingRect (arg1));
 }
 
@@ -669,8 +669,8 @@ static void _call_f_width_c2684 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(-1);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<int > ((int)((QFontMetrics *)cls)->width (arg1, arg2));
 }
 
@@ -689,7 +689,7 @@ static void _call_f_width_c899 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<int > ((int)((QFontMetrics *)cls)->width (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFontMetricsF.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFontMetricsF.cc
@@ -55,7 +55,7 @@ static void _call_ctor_QFontMetricsF_1801 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   ret.write<QFontMetricsF *> (new QFontMetricsF (arg1));
 }
 
@@ -76,8 +76,8 @@ static void _call_ctor_QFontMetricsF_3496 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
-  QPaintDevice *arg2 = args.read<QPaintDevice * > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
+  QPaintDevice *arg2 = gsi::arg_reader<QPaintDevice * >() (args, heap);
   ret.write<QFontMetricsF *> (new QFontMetricsF (arg1, arg2));
 }
 
@@ -96,7 +96,7 @@ static void _call_ctor_QFontMetricsF_2528 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
   ret.write<QFontMetricsF *> (new QFontMetricsF (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_ctor_QFontMetricsF_2598 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetricsF &arg1 = args.read<const QFontMetricsF & > (heap);
+  const QFontMetricsF &arg1 = gsi::arg_reader<const QFontMetricsF & >() (args, heap);
   ret.write<QFontMetricsF *> (new QFontMetricsF (arg1));
 }
 
@@ -164,7 +164,7 @@ static void _call_f_boundingRect_c2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QFontMetricsF *)cls)->boundingRect (arg1));
 }
 
@@ -183,7 +183,7 @@ static void _call_f_boundingRect_c899 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QFontMetricsF *)cls)->boundingRect (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 
@@ -210,11 +210,11 @@ static void _call_f_boundingRect_c5942 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
-  int *arg5 = args ? args.read<int * > (heap) : (int *)(0);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int *arg5 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<QRectF > ((QRectF)((QFontMetricsF *)cls)->boundingRect (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -254,10 +254,10 @@ static void _call_f_elidedText_c5581 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::TextElideMode>::target_type & > (heap);
-  double arg3 = args.read<double > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextElideMode>::target_type & >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QString > ((QString)((QFontMetricsF *)cls)->elidedText (arg1, qt_gsi::QtToCppAdaptor<Qt::TextElideMode>(arg2).cref(), arg3, arg4));
 }
 
@@ -291,7 +291,7 @@ static void _call_f_inFont_c899 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetricsF *)cls)->inFont (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 
@@ -325,7 +325,7 @@ static void _call_f_leftBearing_c899 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<double > ((double)((QFontMetricsF *)cls)->leftBearing (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 
@@ -419,7 +419,7 @@ static void _call_f_operator_excl__eq__2598 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetricsF &arg1 = args.read<const QFontMetricsF & > (heap);
+  const QFontMetricsF &arg1 = gsi::arg_reader<const QFontMetricsF & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetricsF *)cls)->operator != (arg1));
 }
 
@@ -438,7 +438,7 @@ static void _call_f_operator_excl__eq__c2598 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetricsF &arg1 = args.read<const QFontMetricsF & > (heap);
+  const QFontMetricsF &arg1 = gsi::arg_reader<const QFontMetricsF & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetricsF *)cls)->operator != (arg1));
 }
 
@@ -457,7 +457,7 @@ static void _call_f_operator_eq__2598 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetricsF &arg1 = args.read<const QFontMetricsF & > (heap);
+  const QFontMetricsF &arg1 = gsi::arg_reader<const QFontMetricsF & >() (args, heap);
   ret.write<QFontMetricsF & > ((QFontMetricsF &)((QFontMetricsF *)cls)->operator= (arg1));
 }
 
@@ -476,7 +476,7 @@ static void _call_f_operator_eq__2528 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
   ret.write<QFontMetricsF & > ((QFontMetricsF &)((QFontMetricsF *)cls)->operator= (arg1));
 }
 
@@ -495,7 +495,7 @@ static void _call_f_operator_eq__eq__2598 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetricsF &arg1 = args.read<const QFontMetricsF & > (heap);
+  const QFontMetricsF &arg1 = gsi::arg_reader<const QFontMetricsF & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetricsF *)cls)->operator== (arg1));
 }
 
@@ -514,7 +514,7 @@ static void _call_f_operator_eq__eq__c2598 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetricsF &arg1 = args.read<const QFontMetricsF & > (heap);
+  const QFontMetricsF &arg1 = gsi::arg_reader<const QFontMetricsF & >() (args, heap);
   ret.write<bool > ((bool)((QFontMetricsF *)cls)->operator== (arg1));
 }
 
@@ -548,7 +548,7 @@ static void _call_f_rightBearing_c899 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<double > ((double)((QFontMetricsF *)cls)->rightBearing (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 
@@ -573,10 +573,10 @@ static void _call_f_size_c4188 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<QSizeF > ((QSizeF)((QFontMetricsF *)cls)->size (arg1, arg2, arg3, arg4));
 }
 
@@ -610,7 +610,7 @@ static void _call_f_tightBoundingRect_c2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QFontMetricsF *)cls)->tightBoundingRect (arg1));
 }
 
@@ -644,7 +644,7 @@ static void _call_f_width_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<double > ((double)((QFontMetricsF *)cls)->width (arg1));
 }
 
@@ -663,7 +663,7 @@ static void _call_f_width_c899 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QChar>::target_type & arg1 = args.read<const qt_gsi::Converter<QChar>::target_type & > (heap);
+  const qt_gsi::Converter<QChar>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QChar>::target_type & >() (args, heap);
   ret.write<double > ((double)((QFontMetricsF *)cls)->width (qt_gsi::QtToCppAdaptor<QChar>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFormLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFormLayout.cc
@@ -75,7 +75,7 @@ static void _call_f_addItem_1740 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayoutItem *arg1 = args.read<QLayoutItem * > (heap);
+  QLayoutItem *arg1 = gsi::arg_reader<QLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->addItem (arg1);
 }
@@ -97,8 +97,8 @@ static void _call_f_addRow_2522 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->addRow (arg1, arg2);
 }
@@ -120,8 +120,8 @@ static void _call_f_addRow_2548 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QLayout *arg2 = args.read<QLayout * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QLayout *arg2 = gsi::arg_reader<QLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->addRow (arg1, arg2);
 }
@@ -143,8 +143,8 @@ static void _call_f_addRow_3232 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->addRow (arg1, arg2);
 }
@@ -166,8 +166,8 @@ static void _call_f_addRow_3258 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QLayout *arg2 = args.read<QLayout * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QLayout *arg2 = gsi::arg_reader<QLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->addRow (arg1, arg2);
 }
@@ -187,7 +187,7 @@ static void _call_f_addRow_1315 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->addRow (arg1);
 }
@@ -207,7 +207,7 @@ static void _call_f_addRow_1341 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->addRow (arg1);
 }
@@ -291,9 +291,9 @@ static void _call_f_getItemPosition_c4166 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int *arg2 = args.read<int * > (heap);
-  qt_gsi::Converter<QFormLayout::ItemRole>::target_type * arg3 = args.read<qt_gsi::Converter<QFormLayout::ItemRole>::target_type * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  qt_gsi::Converter<QFormLayout::ItemRole>::target_type * arg3 = gsi::arg_reader<qt_gsi::Converter<QFormLayout::ItemRole>::target_type * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->getItemPosition (arg1, arg2, qt_gsi::QtToCppAdaptor<QFormLayout::ItemRole>(arg3).ptr());
 }
@@ -317,9 +317,9 @@ static void _call_f_getLayoutPosition_c4740 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  qt_gsi::Converter<QFormLayout::ItemRole>::target_type * arg3 = args.read<qt_gsi::Converter<QFormLayout::ItemRole>::target_type * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  qt_gsi::Converter<QFormLayout::ItemRole>::target_type * arg3 = gsi::arg_reader<qt_gsi::Converter<QFormLayout::ItemRole>::target_type * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->getLayoutPosition (arg1, arg2, qt_gsi::QtToCppAdaptor<QFormLayout::ItemRole>(arg3).ptr());
 }
@@ -343,9 +343,9 @@ static void _call_f_getWidgetPosition_c4714 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  qt_gsi::Converter<QFormLayout::ItemRole>::target_type * arg3 = args.read<qt_gsi::Converter<QFormLayout::ItemRole>::target_type * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  qt_gsi::Converter<QFormLayout::ItemRole>::target_type * arg3 = gsi::arg_reader<qt_gsi::Converter<QFormLayout::ItemRole>::target_type * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->getWidgetPosition (arg1, arg2, qt_gsi::QtToCppAdaptor<QFormLayout::ItemRole>(arg3).ptr());
 }
@@ -380,7 +380,7 @@ static void _call_f_heightForWidth_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QFormLayout *)cls)->heightForWidth (arg1));
 }
 
@@ -418,9 +418,9 @@ static void _call_f_insertRow_3181 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->insertRow (arg1, arg2, arg3);
 }
@@ -444,9 +444,9 @@ static void _call_f_insertRow_3207 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  QLayout *arg3 = args.read<QLayout * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  QLayout *arg3 = gsi::arg_reader<QLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->insertRow (arg1, arg2, arg3);
 }
@@ -470,9 +470,9 @@ static void _call_f_insertRow_3891 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->insertRow (arg1, arg2, arg3);
 }
@@ -496,9 +496,9 @@ static void _call_f_insertRow_3917 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QLayout *arg3 = args.read<QLayout * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QLayout *arg3 = gsi::arg_reader<QLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->insertRow (arg1, arg2, arg3);
 }
@@ -520,8 +520,8 @@ static void _call_f_insertRow_1974 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->insertRow (arg1, arg2);
 }
@@ -543,8 +543,8 @@ static void _call_f_insertRow_2000 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QLayout *arg2 = args.read<QLayout * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QLayout *arg2 = gsi::arg_reader<QLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->insertRow (arg1, arg2);
 }
@@ -582,8 +582,8 @@ static void _call_f_itemAt_c3135 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QFormLayout *)cls)->itemAt (arg1, qt_gsi::QtToCppAdaptor<QFormLayout::ItemRole>(arg2).cref()));
 }
 
@@ -602,7 +602,7 @@ static void _call_f_itemAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QFormLayout *)cls)->itemAt (arg1));
 }
 
@@ -636,7 +636,7 @@ static void _call_f_labelForField_c1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QFormLayout *)cls)->labelForField (arg1));
 }
 
@@ -655,7 +655,7 @@ static void _call_f_labelForField_c1341 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QFormLayout *)cls)->labelForField (arg1));
 }
 
@@ -719,7 +719,7 @@ static void _call_f_setFieldGrowthPolicy_3418 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFormLayout::FieldGrowthPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QFormLayout::FieldGrowthPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QFormLayout::FieldGrowthPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFormLayout::FieldGrowthPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setFieldGrowthPolicy (qt_gsi::QtToCppAdaptor<QFormLayout::FieldGrowthPolicy>(arg1).cref());
 }
@@ -739,7 +739,7 @@ static void _call_f_setFormAlignment_2750 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setFormAlignment (arg1);
 }
@@ -759,7 +759,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setGeometry (arg1);
 }
@@ -779,7 +779,7 @@ static void _call_f_setHorizontalSpacing_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setHorizontalSpacing (arg1);
 }
@@ -803,9 +803,9 @@ static void _call_f_setItem_4767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & > (heap);
-  QLayoutItem *arg3 = args.read<QLayoutItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & >() (args, heap);
+  QLayoutItem *arg3 = gsi::arg_reader<QLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setItem (arg1, qt_gsi::QtToCppAdaptor<QFormLayout::ItemRole>(arg2).cref(), arg3);
 }
@@ -825,7 +825,7 @@ static void _call_f_setLabelAlignment_2750 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setLabelAlignment (arg1);
 }
@@ -849,9 +849,9 @@ static void _call_f_setLayout_4368 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & > (heap);
-  QLayout *arg3 = args.read<QLayout * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & >() (args, heap);
+  QLayout *arg3 = gsi::arg_reader<QLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setLayout (arg1, qt_gsi::QtToCppAdaptor<QFormLayout::ItemRole>(arg2).cref(), arg3);
 }
@@ -871,7 +871,7 @@ static void _call_f_setRowWrapPolicy_3021 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFormLayout::RowWrapPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QFormLayout::RowWrapPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QFormLayout::RowWrapPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFormLayout::RowWrapPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setRowWrapPolicy (qt_gsi::QtToCppAdaptor<QFormLayout::RowWrapPolicy>(arg1).cref());
 }
@@ -891,7 +891,7 @@ static void _call_f_setSpacing_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setSpacing (arg1);
 }
@@ -911,7 +911,7 @@ static void _call_f_setVerticalSpacing_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setVerticalSpacing (arg1);
 }
@@ -935,9 +935,9 @@ static void _call_f_setWidget_4342 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QFormLayout::ItemRole>::target_type & >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout *)cls)->setWidget (arg1, qt_gsi::QtToCppAdaptor<QFormLayout::ItemRole>(arg2).cref(), arg3);
 }
@@ -987,7 +987,7 @@ static void _call_f_takeAt_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QFormLayout *)cls)->takeAt (arg1));
 }
 
@@ -1023,8 +1023,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFormLayout::tr (arg1, arg2));
 }
 
@@ -1047,9 +1047,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFormLayout::tr (arg1, arg2, arg3));
 }
 
@@ -1070,8 +1070,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFormLayout::trUtf8 (arg1, arg2));
 }
 
@@ -1094,9 +1094,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFormLayout::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1644,7 +1644,7 @@ static void _call_ctor_QFormLayout_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QFormLayout_Adaptor *> (new QFormLayout_Adaptor (arg1));
 }
 
@@ -1662,7 +1662,7 @@ static void _call_fp_addChildLayout_1341 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout_Adaptor *)cls)->fp_QFormLayout_addChildLayout_1341 (arg1);
@@ -1682,7 +1682,7 @@ static void _call_fp_addChildWidget_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout_Adaptor *)cls)->fp_QFormLayout_addChildWidget_1315 (arg1);
 }
@@ -1725,7 +1725,7 @@ static void _call_fp_alignmentRect_c1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QFormLayout_Adaptor *)cls)->fp_QFormLayout_alignmentRect_c1792 (arg1));
 }
 
@@ -1810,7 +1810,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QFormLayout_Adaptor *)cls)->emitter_QFormLayout_destroyed_1302 (arg1);
 }
 
@@ -2146,7 +2146,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QFormLayout_Adaptor *)cls)->fp_QFormLayout_receivers_c1731 (arg1));
 }
 
@@ -2306,7 +2306,7 @@ static void _call_fp_widgetEvent_1217 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFormLayout_Adaptor *)cls)->fp_QFormLayout_widgetEvent_1217 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQFrame.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQFrame.cc
@@ -216,7 +216,7 @@ static void _call_f_setFrameRect_1792 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFrame *)cls)->setFrameRect (arg1);
 }
@@ -236,7 +236,7 @@ static void _call_f_setFrameShadow_1738 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFrame::Shadow>::target_type & arg1 = args.read<const qt_gsi::Converter<QFrame::Shadow>::target_type & > (heap);
+  const qt_gsi::Converter<QFrame::Shadow>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFrame::Shadow>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFrame *)cls)->setFrameShadow (qt_gsi::QtToCppAdaptor<QFrame::Shadow>(arg1).cref());
 }
@@ -256,7 +256,7 @@ static void _call_f_setFrameShape_1621 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFrame::Shape>::target_type & arg1 = args.read<const qt_gsi::Converter<QFrame::Shape>::target_type & > (heap);
+  const qt_gsi::Converter<QFrame::Shape>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFrame::Shape>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFrame *)cls)->setFrameShape (qt_gsi::QtToCppAdaptor<QFrame::Shape>(arg1).cref());
 }
@@ -276,7 +276,7 @@ static void _call_f_setFrameStyle_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFrame *)cls)->setFrameStyle (arg1);
 }
@@ -296,7 +296,7 @@ static void _call_f_setLineWidth_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFrame *)cls)->setLineWidth (arg1);
 }
@@ -316,7 +316,7 @@ static void _call_f_setMidLineWidth_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFrame *)cls)->setMidLineWidth (arg1);
 }
@@ -353,8 +353,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFrame::tr (arg1, arg2));
 }
 
@@ -377,9 +377,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFrame::tr (arg1, arg2, arg3));
 }
 
@@ -400,8 +400,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFrame::trUtf8 (arg1, arg2));
 }
 
@@ -424,9 +424,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFrame::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1307,8 +1307,8 @@ static void _call_ctor_QFrame_Adaptor_3702 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QFrame_Adaptor *> (new QFrame_Adaptor (arg1, arg2));
 }
 
@@ -1450,9 +1450,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFrame_Adaptor *)cls)->fp_QFrame_create_2208 (arg1, arg2, arg3);
 }
@@ -1471,7 +1471,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QFrame_Adaptor *)cls)->emitter_QFrame_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1515,8 +1515,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFrame_Adaptor *)cls)->fp_QFrame_destroy_1620 (arg1, arg2);
 }
@@ -1535,7 +1535,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QFrame_Adaptor *)cls)->emitter_QFrame_destroyed_1302 (arg1);
 }
 
@@ -1649,7 +1649,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QFrame_Adaptor *)cls)->fp_QFrame_drawFrame_1426 (arg1);
 }
@@ -2327,7 +2327,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QFrame_Adaptor *)cls)->fp_QFrame_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGesture.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGesture.cc
@@ -129,7 +129,7 @@ static void _call_f_setGestureCancelPolicy_3309 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGesture::GestureCancelPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QGesture::GestureCancelPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QGesture::GestureCancelPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGesture::GestureCancelPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGesture *)cls)->setGestureCancelPolicy (qt_gsi::QtToCppAdaptor<QGesture::GestureCancelPolicy>(arg1).cref());
 }
@@ -149,7 +149,7 @@ static void _call_f_setHotSpot_1986 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGesture *)cls)->setHotSpot (arg1);
 }
@@ -202,8 +202,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGesture::tr (arg1, arg2));
 }
 
@@ -226,9 +226,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGesture::tr (arg1, arg2, arg3));
 }
 
@@ -249,8 +249,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGesture::trUtf8 (arg1, arg2));
 }
 
@@ -273,9 +273,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGesture::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -460,7 +460,7 @@ static void _call_ctor_QGesture_Adaptor_1302 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGesture_Adaptor *> (new QGesture_Adaptor (arg1));
 }
 
@@ -526,7 +526,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGesture_Adaptor *)cls)->emitter_QGesture_destroyed_1302 (arg1);
 }
 
@@ -617,7 +617,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGesture_Adaptor *)cls)->fp_QGesture_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGestureEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGestureEvent.cc
@@ -69,7 +69,7 @@ static void _call_f_accept_1438 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGesture *arg1 = args.read<QGesture * > (heap);
+  QGesture *arg1 = gsi::arg_reader<QGesture * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGestureEvent *)cls)->accept (arg1);
 }
@@ -89,7 +89,7 @@ static void _call_f_accept_1902 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGestureEvent *)cls)->accept (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref());
 }
@@ -139,7 +139,7 @@ static void _call_f_gesture_c1902 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
   ret.write<QGesture * > ((QGesture *)((QGestureEvent *)cls)->gesture (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref()));
 }
 
@@ -189,7 +189,7 @@ static void _call_f_ignore_1438 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGesture *arg1 = args.read<QGesture * > (heap);
+  QGesture *arg1 = gsi::arg_reader<QGesture * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGestureEvent *)cls)->ignore (arg1);
 }
@@ -209,7 +209,7 @@ static void _call_f_ignore_1902 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGestureEvent *)cls)->ignore (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref());
 }
@@ -244,7 +244,7 @@ static void _call_f_isAccepted_c1438 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGesture *arg1 = args.read<QGesture * > (heap);
+  QGesture *arg1 = gsi::arg_reader<QGesture * >() (args, heap);
   ret.write<bool > ((bool)((QGestureEvent *)cls)->isAccepted (arg1));
 }
 
@@ -263,7 +263,7 @@ static void _call_f_isAccepted_c1902 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QGestureEvent *)cls)->isAccepted (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref()));
 }
 
@@ -282,7 +282,7 @@ static void _call_f_mapToGraphicsScene_c1986 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGestureEvent *)cls)->mapToGraphicsScene (arg1));
 }
 
@@ -301,7 +301,7 @@ static void _call_f_setAccepted_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGestureEvent *)cls)->setAccepted (arg1);
 }
@@ -323,8 +323,8 @@ static void _call_f_setAccepted_2194 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGesture *arg1 = args.read<QGesture * > (heap);
-  bool arg2 = args.read<bool > (heap);
+  QGesture *arg1 = gsi::arg_reader<QGesture * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGestureEvent *)cls)->setAccepted (arg1, arg2);
 }
@@ -346,8 +346,8 @@ static void _call_f_setAccepted_2658 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGestureEvent *)cls)->setAccepted (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref(), arg2);
 }
@@ -367,7 +367,7 @@ static void _call_f_setWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGestureEvent *)cls)->setWidget (arg1);
 }
@@ -456,7 +456,7 @@ static void _call_ctor_QGestureEvent_Adaptor_2930 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QGesture *> &arg1 = args.read<const QList<QGesture *> & > (heap);
+  const QList<QGesture *> &arg1 = gsi::arg_reader<const QList<QGesture *> & >() (args, heap);
   ret.write<QGestureEvent_Adaptor *> (new QGestureEvent_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGestureRecognizer.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGestureRecognizer.cc
@@ -53,7 +53,7 @@ static void _call_f_create_1302 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QGesture * > ((QGesture *)((QGestureRecognizer *)cls)->create (arg1));
 }
 
@@ -76,9 +76,9 @@ static void _call_f_recognize_3741 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGesture *arg1 = args.read<QGesture * > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
-  QEvent *arg3 = args.read<QEvent * > (heap);
+  QGesture *arg1 = gsi::arg_reader<QGesture * >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
+  QEvent *arg3 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<QFlags<QGestureRecognizer::ResultFlag> > ((QFlags<QGestureRecognizer::ResultFlag>)((QGestureRecognizer *)cls)->recognize (arg1, arg2, arg3));
 }
 
@@ -97,7 +97,7 @@ static void _call_f_reset_1438 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGesture *arg1 = args.read<QGesture * > (heap);
+  QGesture *arg1 = gsi::arg_reader<QGesture * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGestureRecognizer *)cls)->reset (arg1);
 }
@@ -117,7 +117,7 @@ static void _call_f_registerRecognizer_2486 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGestureRecognizer *arg1 = args.read<QGestureRecognizer * > (heap);
+  QGestureRecognizer *arg1 = gsi::arg_reader<QGestureRecognizer * >() (args, heap);
   ret.write<qt_gsi::Converter<Qt::GestureType>::target_type > ((qt_gsi::Converter<Qt::GestureType>::target_type)qt_gsi::CppToQtAdaptor<Qt::GestureType>(QGestureRecognizer::registerRecognizer (arg1)));
 }
 
@@ -136,7 +136,7 @@ static void _call_f_unregisterRecognizer_1902 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QGestureRecognizer::unregisterRecognizer (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref());
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGradient.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGradient.cc
@@ -96,7 +96,7 @@ static void _call_f_operator_excl__eq__c2208 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGradient &arg1 = args.read<const QGradient & > (heap);
+  const QGradient &arg1 = gsi::arg_reader<const QGradient & >() (args, heap);
   ret.write<bool > ((bool)((QGradient *)cls)->operator!= (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_operator_eq__eq__c2208 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGradient &arg1 = args.read<const QGradient & > (heap);
+  const QGradient &arg1 = gsi::arg_reader<const QGradient & >() (args, heap);
   ret.write<bool > ((bool)((QGradient *)cls)->operator== (arg1));
 }
 
@@ -134,7 +134,7 @@ static void _call_f_operator_eq__eq__2208 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGradient &arg1 = args.read<const QGradient & > (heap);
+  const QGradient &arg1 = gsi::arg_reader<const QGradient & >() (args, heap);
   ret.write<bool > ((bool)((QGradient *)cls)->operator== (arg1));
 }
 
@@ -155,8 +155,8 @@ static void _call_f_setColorAt_2868 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  const QColor &arg2 = args.read<const QColor & > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  const QColor &arg2 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGradient *)cls)->setColorAt (arg1, arg2);
 }
@@ -176,7 +176,7 @@ static void _call_f_setCoordinateMode_2868 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGradient::CoordinateMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QGradient::CoordinateMode>::target_type & > (heap);
+  const qt_gsi::Converter<QGradient::CoordinateMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGradient::CoordinateMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGradient *)cls)->setCoordinateMode (qt_gsi::QtToCppAdaptor<QGradient::CoordinateMode>(arg1).cref());
 }
@@ -196,7 +196,7 @@ static void _call_f_setInterpolationMode_3220 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGradient::InterpolationMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QGradient::InterpolationMode>::target_type & > (heap);
+  const qt_gsi::Converter<QGradient::InterpolationMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGradient::InterpolationMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGradient *)cls)->setInterpolationMode (qt_gsi::QtToCppAdaptor<QGradient::InterpolationMode>(arg1).cref());
 }
@@ -216,7 +216,7 @@ static void _call_f_setSpread_2054 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGradient::Spread>::target_type & arg1 = args.read<const qt_gsi::Converter<QGradient::Spread>::target_type & > (heap);
+  const qt_gsi::Converter<QGradient::Spread>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGradient::Spread>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGradient *)cls)->setSpread (qt_gsi::QtToCppAdaptor<QGradient::Spread>(arg1).cref());
 }
@@ -236,7 +236,7 @@ static void _call_f_setStops_3460 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QGradientStop> &arg1 = args.read<const QVector<QGradientStop> & > (heap);
+  const QVector<QGradientStop> &arg1 = gsi::arg_reader<const QVector<QGradientStop> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGradient *)cls)->setStops (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsAnchor.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsAnchor.cc
@@ -68,7 +68,7 @@ static void _call_f_setSizePolicy_2292 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchor *)cls)->setSizePolicy (qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg1).cref());
 }
@@ -88,7 +88,7 @@ static void _call_f_setSpacing_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchor *)cls)->setSpacing (arg1);
 }
@@ -156,8 +156,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsAnchor::tr (arg1, arg2));
 }
 
@@ -180,9 +180,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsAnchor::tr (arg1, arg2, arg3));
 }
 
@@ -203,8 +203,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsAnchor::trUtf8 (arg1, arg2));
 }
 
@@ -227,9 +227,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsAnchor::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -447,7 +447,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsAnchor_Adaptor *)cls)->emitter_QGraphicsAnchor_destroyed_1302 (arg1);
 }
 
@@ -538,7 +538,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsAnchor_Adaptor *)cls)->fp_QGraphicsAnchor_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsAnchorLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsAnchorLayout.cc
@@ -63,10 +63,10 @@ static void _call_f_addAnchor_8538 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
-  const qt_gsi::Converter<Qt::AnchorPoint>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::AnchorPoint>::target_type & > (heap);
-  QGraphicsLayoutItem *arg3 = args.read<QGraphicsLayoutItem * > (heap);
-  const qt_gsi::Converter<Qt::AnchorPoint>::target_type & arg4 = args.read<const qt_gsi::Converter<Qt::AnchorPoint>::target_type & > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::AnchorPoint>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::AnchorPoint>::target_type & >() (args, heap);
+  QGraphicsLayoutItem *arg3 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::AnchorPoint>::target_type & arg4 = gsi::arg_reader<const qt_gsi::Converter<Qt::AnchorPoint>::target_type & >() (args, heap);
   ret.write<QGraphicsAnchor * > ((QGraphicsAnchor *)((QGraphicsAnchorLayout *)cls)->addAnchor (arg1, qt_gsi::QtToCppAdaptor<Qt::AnchorPoint>(arg2).cref(), arg3, qt_gsi::QtToCppAdaptor<Qt::AnchorPoint>(arg4).cref()));
 }
 
@@ -89,9 +89,9 @@ static void _call_f_addAnchors_7507 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
-  QGraphicsLayoutItem *arg2 = args.read<QGraphicsLayoutItem * > (heap);
-  QFlags<Qt::Orientation> arg3 = args ? args.read<QFlags<Qt::Orientation> > (heap) : (QFlags<Qt::Orientation>)(Qt::Horizontal | Qt::Vertical);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  QGraphicsLayoutItem *arg2 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  QFlags<Qt::Orientation> arg3 = args ? gsi::arg_reader<QFlags<Qt::Orientation> >() (args, heap) : gsi::arg_maker<QFlags<Qt::Orientation> >() (Qt::Horizontal | Qt::Vertical, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout *)cls)->addAnchors (arg1, arg2, arg3);
 }
@@ -117,10 +117,10 @@ static void _call_f_addCornerAnchors_7522 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
-  const qt_gsi::Converter<Qt::Corner>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Corner>::target_type & > (heap);
-  QGraphicsLayoutItem *arg3 = args.read<QGraphicsLayoutItem * > (heap);
-  const qt_gsi::Converter<Qt::Corner>::target_type & arg4 = args.read<const qt_gsi::Converter<Qt::Corner>::target_type & > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::Corner>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Corner>::target_type & >() (args, heap);
+  QGraphicsLayoutItem *arg3 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::Corner>::target_type & arg4 = gsi::arg_reader<const qt_gsi::Converter<Qt::Corner>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout *)cls)->addCornerAnchors (arg1, qt_gsi::QtToCppAdaptor<Qt::Corner>(arg2).cref(), arg3, qt_gsi::QtToCppAdaptor<Qt::Corner>(arg4).cref());
 }
@@ -146,10 +146,10 @@ static void _call_f_anchor_8538 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
-  const qt_gsi::Converter<Qt::AnchorPoint>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::AnchorPoint>::target_type & > (heap);
-  QGraphicsLayoutItem *arg3 = args.read<QGraphicsLayoutItem * > (heap);
-  const qt_gsi::Converter<Qt::AnchorPoint>::target_type & arg4 = args.read<const qt_gsi::Converter<Qt::AnchorPoint>::target_type & > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::AnchorPoint>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::AnchorPoint>::target_type & >() (args, heap);
+  QGraphicsLayoutItem *arg3 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::AnchorPoint>::target_type & arg4 = gsi::arg_reader<const qt_gsi::Converter<Qt::AnchorPoint>::target_type & >() (args, heap);
   ret.write<QGraphicsAnchor * > ((QGraphicsAnchor *)((QGraphicsAnchorLayout *)cls)->anchor (arg1, qt_gsi::QtToCppAdaptor<Qt::AnchorPoint>(arg2).cref(), arg3, qt_gsi::QtToCppAdaptor<Qt::AnchorPoint>(arg4).cref()));
 }
 
@@ -214,7 +214,7 @@ static void _call_f_itemAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QGraphicsLayoutItem * > ((QGraphicsLayoutItem *)((QGraphicsAnchorLayout *)cls)->itemAt (arg1));
 }
 
@@ -233,7 +233,7 @@ static void _call_f_removeAt_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout *)cls)->removeAt (arg1);
 }
@@ -253,7 +253,7 @@ static void _call_f_setGeometry_1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout *)cls)->setGeometry (arg1);
 }
@@ -273,7 +273,7 @@ static void _call_f_setHorizontalSpacing_1071 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout *)cls)->setHorizontalSpacing (arg1);
 }
@@ -293,7 +293,7 @@ static void _call_f_setSpacing_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout *)cls)->setSpacing (arg1);
 }
@@ -313,7 +313,7 @@ static void _call_f_setVerticalSpacing_1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout *)cls)->setVerticalSpacing (arg1);
 }
@@ -561,7 +561,7 @@ static void _call_ctor_QGraphicsAnchorLayout_Adaptor_2557 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args ? args.read<QGraphicsLayoutItem * > (heap) : (QGraphicsLayoutItem *)(0);
+  QGraphicsLayoutItem *arg1 = args ? gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap) : gsi::arg_maker<QGraphicsLayoutItem * >() (0, heap);
   ret.write<QGraphicsAnchorLayout_Adaptor *> (new QGraphicsAnchorLayout_Adaptor (arg1));
 }
 
@@ -579,7 +579,7 @@ static void _call_fp_addChildLayoutItem_2557 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout_Adaptor *)cls)->fp_QGraphicsAnchorLayout_addChildLayoutItem_2557 (arg1);
 }
@@ -741,7 +741,7 @@ static void _call_fp_setGraphicsItem_1919 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout_Adaptor *)cls)->fp_QGraphicsAnchorLayout_setGraphicsItem_1919 (arg1);
 }
@@ -760,7 +760,7 @@ static void _call_fp_setOwnedByLayout_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsAnchorLayout_Adaptor *)cls)->fp_QGraphicsAnchorLayout_setOwnedByLayout_864 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsBlurEffect.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsBlurEffect.cc
@@ -102,7 +102,7 @@ static void _call_f_boundingRectFor_c1862 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsBlurEffect *)cls)->boundingRectFor (arg1));
 }
 
@@ -121,7 +121,7 @@ static void _call_f_setBlurHints_3948 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QGraphicsBlurEffect::BlurHint> arg1 = args.read<QFlags<QGraphicsBlurEffect::BlurHint> > (heap);
+  QFlags<QGraphicsBlurEffect::BlurHint> arg1 = gsi::arg_reader<QFlags<QGraphicsBlurEffect::BlurHint> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsBlurEffect *)cls)->setBlurHints (arg1);
 }
@@ -141,7 +141,7 @@ static void _call_f_setBlurRadius_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsBlurEffect *)cls)->setBlurRadius (arg1);
 }
@@ -163,8 +163,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsBlurEffect::tr (arg1, arg2));
 }
 
@@ -187,9 +187,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsBlurEffect::tr (arg1, arg2, arg3));
 }
 
@@ -210,8 +210,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsBlurEffect::trUtf8 (arg1, arg2));
 }
 
@@ -234,9 +234,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsBlurEffect::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -512,7 +512,7 @@ static void _call_ctor_QGraphicsBlurEffect_Adaptor_1302 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsBlurEffect_Adaptor *> (new QGraphicsBlurEffect_Adaptor (arg1));
 }
 
@@ -530,7 +530,7 @@ static void _call_emitter_blurHintsChanged_3948 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QGraphicsBlurEffect::BlurHint> arg1 = args.read<QFlags<QGraphicsBlurEffect::BlurHint> > (heap);
+  QFlags<QGraphicsBlurEffect::BlurHint> arg1 = gsi::arg_reader<QFlags<QGraphicsBlurEffect::BlurHint> >() (args, heap);
   ((QGraphicsBlurEffect_Adaptor *)cls)->emitter_QGraphicsBlurEffect_blurHintsChanged_3948 (arg1);
 }
 
@@ -548,7 +548,7 @@ static void _call_emitter_blurRadiusChanged_1071 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ((QGraphicsBlurEffect_Adaptor *)cls)->emitter_QGraphicsBlurEffect_blurRadiusChanged_1071 (arg1);
 }
 
@@ -637,7 +637,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsBlurEffect_Adaptor *)cls)->emitter_QGraphicsBlurEffect_destroyed_1302 (arg1);
 }
 
@@ -703,7 +703,7 @@ static void _call_fp_drawSource_1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsBlurEffect_Adaptor *)cls)->fp_QGraphicsBlurEffect_drawSource_1426 (arg1);
 }
@@ -722,7 +722,7 @@ static void _call_emitter_enabledChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QGraphicsBlurEffect_Adaptor *)cls)->emitter_QGraphicsBlurEffect_enabledChanged_864 (arg1);
 }
 
@@ -789,7 +789,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsBlurEffect_Adaptor *)cls)->fp_QGraphicsBlurEffect_receivers_c1731 (arg1));
 }
 
@@ -821,7 +821,7 @@ static void _call_fp_sourceBoundingRect_c2426 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
   ret.write<QRectF > ((QRectF)((QGraphicsBlurEffect_Adaptor *)cls)->fp_QGraphicsBlurEffect_sourceBoundingRect_c2426 (arg1));
 }
 
@@ -881,9 +881,9 @@ static void _call_fp_sourcePixmap_c6763 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
-  QPoint *arg2 = args ? args.read<QPoint * > (heap) : (QPoint *)(0);
-  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & > (heap) : (const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
+  QPoint *arg2 = args ? gsi::arg_reader<QPoint * >() (args, heap) : gsi::arg_maker<QPoint * >() (0, heap);
+  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect), heap);
   ret.write<QPixmap > ((QPixmap)((QGraphicsBlurEffect_Adaptor *)cls)->fp_QGraphicsBlurEffect_sourcePixmap_c6763 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsColorizeEffect.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsColorizeEffect.cc
@@ -88,7 +88,7 @@ static void _call_f_setColor_1905 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsColorizeEffect *)cls)->setColor (arg1);
 }
@@ -108,7 +108,7 @@ static void _call_f_setStrength_1071 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsColorizeEffect *)cls)->setStrength (arg1);
 }
@@ -145,8 +145,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsColorizeEffect::tr (arg1, arg2));
 }
 
@@ -169,9 +169,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsColorizeEffect::tr (arg1, arg2, arg3));
 }
 
@@ -192,8 +192,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsColorizeEffect::trUtf8 (arg1, arg2));
 }
 
@@ -216,9 +216,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsColorizeEffect::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -493,7 +493,7 @@ static void _call_ctor_QGraphicsColorizeEffect_Adaptor_1302 (const qt_gsi::Gener
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsColorizeEffect_Adaptor *> (new QGraphicsColorizeEffect_Adaptor (arg1));
 }
 
@@ -558,7 +558,7 @@ static void _call_emitter_colorChanged_1905 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ((QGraphicsColorizeEffect_Adaptor *)cls)->emitter_QGraphicsColorizeEffect_colorChanged_1905 (arg1);
 }
 
@@ -600,7 +600,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsColorizeEffect_Adaptor *)cls)->emitter_QGraphicsColorizeEffect_destroyed_1302 (arg1);
 }
 
@@ -666,7 +666,7 @@ static void _call_fp_drawSource_1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsColorizeEffect_Adaptor *)cls)->fp_QGraphicsColorizeEffect_drawSource_1426 (arg1);
 }
@@ -685,7 +685,7 @@ static void _call_emitter_enabledChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QGraphicsColorizeEffect_Adaptor *)cls)->emitter_QGraphicsColorizeEffect_enabledChanged_864 (arg1);
 }
 
@@ -752,7 +752,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsColorizeEffect_Adaptor *)cls)->fp_QGraphicsColorizeEffect_receivers_c1731 (arg1));
 }
 
@@ -784,7 +784,7 @@ static void _call_fp_sourceBoundingRect_c2426 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
   ret.write<QRectF > ((QRectF)((QGraphicsColorizeEffect_Adaptor *)cls)->fp_QGraphicsColorizeEffect_sourceBoundingRect_c2426 (arg1));
 }
 
@@ -844,9 +844,9 @@ static void _call_fp_sourcePixmap_c6763 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
-  QPoint *arg2 = args ? args.read<QPoint * > (heap) : (QPoint *)(0);
-  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & > (heap) : (const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
+  QPoint *arg2 = args ? gsi::arg_reader<QPoint * >() (args, heap) : gsi::arg_maker<QPoint * >() (0, heap);
+  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect), heap);
   ret.write<QPixmap > ((QPixmap)((QGraphicsColorizeEffect_Adaptor *)cls)->fp_QGraphicsColorizeEffect_sourcePixmap_c6763 (arg1, arg2, arg3));
 }
 
@@ -864,7 +864,7 @@ static void _call_emitter_strengthChanged_1071 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ((QGraphicsColorizeEffect_Adaptor *)cls)->emitter_QGraphicsColorizeEffect_strengthChanged_1071 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsDropShadowEffect.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsDropShadowEffect.cc
@@ -89,7 +89,7 @@ static void _call_f_boundingRectFor_c1862 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsDropShadowEffect *)cls)->boundingRectFor (arg1));
 }
 
@@ -138,7 +138,7 @@ static void _call_f_setBlurRadius_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsDropShadowEffect *)cls)->setBlurRadius (arg1);
 }
@@ -158,7 +158,7 @@ static void _call_f_setColor_1905 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsDropShadowEffect *)cls)->setColor (arg1);
 }
@@ -178,7 +178,7 @@ static void _call_f_setOffset_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsDropShadowEffect *)cls)->setOffset (arg1);
 }
@@ -200,8 +200,8 @@ static void _call_f_setOffset_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsDropShadowEffect *)cls)->setOffset (arg1, arg2);
 }
@@ -221,7 +221,7 @@ static void _call_f_setOffset_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsDropShadowEffect *)cls)->setOffset (arg1);
 }
@@ -241,7 +241,7 @@ static void _call_f_setXOffset_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsDropShadowEffect *)cls)->setXOffset (arg1);
 }
@@ -261,7 +261,7 @@ static void _call_f_setYOffset_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsDropShadowEffect *)cls)->setYOffset (arg1);
 }
@@ -313,8 +313,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsDropShadowEffect::tr (arg1, arg2));
 }
 
@@ -337,9 +337,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsDropShadowEffect::tr (arg1, arg2, arg3));
 }
 
@@ -360,8 +360,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsDropShadowEffect::trUtf8 (arg1, arg2));
 }
 
@@ -384,9 +384,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsDropShadowEffect::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -677,7 +677,7 @@ static void _call_ctor_QGraphicsDropShadowEffect_Adaptor_1302 (const qt_gsi::Gen
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsDropShadowEffect_Adaptor *> (new QGraphicsDropShadowEffect_Adaptor (arg1));
 }
 
@@ -695,7 +695,7 @@ static void _call_emitter_blurRadiusChanged_1071 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ((QGraphicsDropShadowEffect_Adaptor *)cls)->emitter_QGraphicsDropShadowEffect_blurRadiusChanged_1071 (arg1);
 }
 
@@ -760,7 +760,7 @@ static void _call_emitter_colorChanged_1905 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ((QGraphicsDropShadowEffect_Adaptor *)cls)->emitter_QGraphicsDropShadowEffect_colorChanged_1905 (arg1);
 }
 
@@ -802,7 +802,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsDropShadowEffect_Adaptor *)cls)->emitter_QGraphicsDropShadowEffect_destroyed_1302 (arg1);
 }
 
@@ -868,7 +868,7 @@ static void _call_fp_drawSource_1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsDropShadowEffect_Adaptor *)cls)->fp_QGraphicsDropShadowEffect_drawSource_1426 (arg1);
 }
@@ -887,7 +887,7 @@ static void _call_emitter_enabledChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QGraphicsDropShadowEffect_Adaptor *)cls)->emitter_QGraphicsDropShadowEffect_enabledChanged_864 (arg1);
 }
 
@@ -954,7 +954,7 @@ static void _call_emitter_offsetChanged_1986 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ((QGraphicsDropShadowEffect_Adaptor *)cls)->emitter_QGraphicsDropShadowEffect_offsetChanged_1986 (arg1);
 }
 
@@ -972,7 +972,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsDropShadowEffect_Adaptor *)cls)->fp_QGraphicsDropShadowEffect_receivers_c1731 (arg1));
 }
 
@@ -1004,7 +1004,7 @@ static void _call_fp_sourceBoundingRect_c2426 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
   ret.write<QRectF > ((QRectF)((QGraphicsDropShadowEffect_Adaptor *)cls)->fp_QGraphicsDropShadowEffect_sourceBoundingRect_c2426 (arg1));
 }
 
@@ -1064,9 +1064,9 @@ static void _call_fp_sourcePixmap_c6763 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
-  QPoint *arg2 = args ? args.read<QPoint * > (heap) : (QPoint *)(0);
-  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & > (heap) : (const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
+  QPoint *arg2 = args ? gsi::arg_reader<QPoint * >() (args, heap) : gsi::arg_maker<QPoint * >() (0, heap);
+  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect), heap);
   ret.write<QPixmap > ((QPixmap)((QGraphicsDropShadowEffect_Adaptor *)cls)->fp_QGraphicsDropShadowEffect_sourcePixmap_c6763 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsEffect.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsEffect.cc
@@ -87,7 +87,7 @@ static void _call_f_boundingRectFor_c1862 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsEffect *)cls)->boundingRectFor (arg1));
 }
 
@@ -121,7 +121,7 @@ static void _call_f_setEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsEffect *)cls)->setEnabled (arg1);
 }
@@ -159,8 +159,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsEffect::tr (arg1, arg2));
 }
 
@@ -183,9 +183,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsEffect::tr (arg1, arg2, arg3));
 }
 
@@ -206,8 +206,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsEffect::trUtf8 (arg1, arg2));
 }
 
@@ -230,9 +230,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsEffect::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -495,7 +495,7 @@ static void _call_ctor_QGraphicsEffect_Adaptor_1302 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsEffect_Adaptor *> (new QGraphicsEffect_Adaptor (arg1));
 }
 
@@ -584,7 +584,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsEffect_Adaptor *)cls)->emitter_QGraphicsEffect_destroyed_1302 (arg1);
 }
 
@@ -650,7 +650,7 @@ static void _call_fp_drawSource_1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsEffect_Adaptor *)cls)->fp_QGraphicsEffect_drawSource_1426 (arg1);
 }
@@ -669,7 +669,7 @@ static void _call_emitter_enabledChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QGraphicsEffect_Adaptor *)cls)->emitter_QGraphicsEffect_enabledChanged_864 (arg1);
 }
 
@@ -736,7 +736,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsEffect_Adaptor *)cls)->fp_QGraphicsEffect_receivers_c1731 (arg1));
 }
 
@@ -768,7 +768,7 @@ static void _call_fp_sourceBoundingRect_c2426 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
   ret.write<QRectF > ((QRectF)((QGraphicsEffect_Adaptor *)cls)->fp_QGraphicsEffect_sourceBoundingRect_c2426 (arg1));
 }
 
@@ -828,9 +828,9 @@ static void _call_fp_sourcePixmap_c6763 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
-  QPoint *arg2 = args ? args.read<QPoint * > (heap) : (QPoint *)(0);
-  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & > (heap) : (const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
+  QPoint *arg2 = args ? gsi::arg_reader<QPoint * >() (args, heap) : gsi::arg_maker<QPoint * >() (0, heap);
+  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect), heap);
   ret.write<QPixmap > ((QPixmap)((QGraphicsEffect_Adaptor *)cls)->fp_QGraphicsEffect_sourcePixmap_c6763 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsEllipseItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsEllipseItem.cc
@@ -94,7 +94,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsEllipseItem *)cls)->contains (arg1));
 }
 
@@ -113,7 +113,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsEllipseItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -151,9 +151,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsEllipseItem *)cls)->paint (arg1, arg2, arg3);
 }
@@ -188,7 +188,7 @@ static void _call_f_setRect_1862 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsEllipseItem *)cls)->setRect (arg1);
 }
@@ -214,10 +214,10 @@ static void _call_f_setRect_3960 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsEllipseItem *)cls)->setRect (arg1, arg2, arg3, arg4);
 }
@@ -237,7 +237,7 @@ static void _call_f_setSpanAngle_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsEllipseItem *)cls)->setSpanAngle (arg1);
 }
@@ -257,7 +257,7 @@ static void _call_f_setStartAngle_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsEllipseItem *)cls)->setStartAngle (arg1);
 }
@@ -1010,8 +1010,8 @@ static void _call_ctor_QGraphicsEllipseItem_Adaptor_3825 (const qt_gsi::GenericS
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsEllipseItem_Adaptor *> (new QGraphicsEllipseItem_Adaptor (arg1, arg2));
 }
 
@@ -1033,9 +1033,9 @@ static void _call_ctor_QGraphicsEllipseItem_Adaptor_5579 (const qt_gsi::GenericS
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  QGraphicsItem *arg2 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg3 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  QGraphicsItem *arg2 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg3 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsEllipseItem_Adaptor *> (new QGraphicsEllipseItem_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1063,12 +1063,12 @@ static void _call_ctor_QGraphicsEllipseItem_Adaptor_7677 (const qt_gsi::GenericS
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  QGraphicsItem *arg5 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg6 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  QGraphicsItem *arg5 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg6 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsEllipseItem_Adaptor *> (new QGraphicsEllipseItem_Adaptor (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsGridLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsGridLayout.cc
@@ -66,12 +66,12 @@ static void _call_f_addItem_7835 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  QFlags<Qt::AlignmentFlag> arg6 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg6 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->addItem (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -97,10 +97,10 @@ static void _call_f_addItem_6517 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  QFlags<Qt::AlignmentFlag> arg4 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->addItem (arg1, arg2, arg3, arg4);
 }
@@ -120,7 +120,7 @@ static void _call_f_alignment_c2557 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   ret.write<QFlags<Qt::AlignmentFlag> > ((QFlags<Qt::AlignmentFlag>)((QGraphicsGridLayout *)cls)->alignment (arg1));
 }
 
@@ -139,7 +139,7 @@ static void _call_f_columnAlignment_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFlags<Qt::AlignmentFlag> > ((QFlags<Qt::AlignmentFlag>)((QGraphicsGridLayout *)cls)->columnAlignment (arg1));
 }
 
@@ -173,7 +173,7 @@ static void _call_f_columnMaximumWidth_c767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QGraphicsGridLayout *)cls)->columnMaximumWidth (arg1));
 }
 
@@ -192,7 +192,7 @@ static void _call_f_columnMinimumWidth_c767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QGraphicsGridLayout *)cls)->columnMinimumWidth (arg1));
 }
 
@@ -211,7 +211,7 @@ static void _call_f_columnPreferredWidth_c767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QGraphicsGridLayout *)cls)->columnPreferredWidth (arg1));
 }
 
@@ -230,7 +230,7 @@ static void _call_f_columnSpacing_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QGraphicsGridLayout *)cls)->columnSpacing (arg1));
 }
 
@@ -249,7 +249,7 @@ static void _call_f_columnStretchFactor_c767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QGraphicsGridLayout *)cls)->columnStretchFactor (arg1));
 }
 
@@ -316,8 +316,8 @@ static void _call_f_itemAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QGraphicsLayoutItem * > ((QGraphicsLayoutItem *)((QGraphicsGridLayout *)cls)->itemAt (arg1, arg2));
 }
 
@@ -336,7 +336,7 @@ static void _call_f_itemAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QGraphicsLayoutItem * > ((QGraphicsLayoutItem *)((QGraphicsGridLayout *)cls)->itemAt (arg1));
 }
 
@@ -355,7 +355,7 @@ static void _call_f_removeAt_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->removeAt (arg1);
 }
@@ -375,7 +375,7 @@ static void _call_f_rowAlignment_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFlags<Qt::AlignmentFlag> > ((QFlags<Qt::AlignmentFlag>)((QGraphicsGridLayout *)cls)->rowAlignment (arg1));
 }
 
@@ -409,7 +409,7 @@ static void _call_f_rowMaximumHeight_c767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QGraphicsGridLayout *)cls)->rowMaximumHeight (arg1));
 }
 
@@ -428,7 +428,7 @@ static void _call_f_rowMinimumHeight_c767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QGraphicsGridLayout *)cls)->rowMinimumHeight (arg1));
 }
 
@@ -447,7 +447,7 @@ static void _call_f_rowPreferredHeight_c767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QGraphicsGridLayout *)cls)->rowPreferredHeight (arg1));
 }
 
@@ -466,7 +466,7 @@ static void _call_f_rowSpacing_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QGraphicsGridLayout *)cls)->rowSpacing (arg1));
 }
 
@@ -485,7 +485,7 @@ static void _call_f_rowStretchFactor_c767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QGraphicsGridLayout *)cls)->rowStretchFactor (arg1));
 }
 
@@ -506,8 +506,8 @@ static void _call_f_setAlignment_5199 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
-  QFlags<Qt::AlignmentFlag> arg2 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg2 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setAlignment (arg1, arg2);
 }
@@ -529,8 +529,8 @@ static void _call_f_setColumnAlignment_3409 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QFlags<Qt::AlignmentFlag> arg2 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg2 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setColumnAlignment (arg1, arg2);
 }
@@ -552,8 +552,8 @@ static void _call_f_setColumnFixedWidth_1730 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setColumnFixedWidth (arg1, arg2);
 }
@@ -575,8 +575,8 @@ static void _call_f_setColumnMaximumWidth_1730 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setColumnMaximumWidth (arg1, arg2);
 }
@@ -598,8 +598,8 @@ static void _call_f_setColumnMinimumWidth_1730 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setColumnMinimumWidth (arg1, arg2);
 }
@@ -621,8 +621,8 @@ static void _call_f_setColumnPreferredWidth_1730 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setColumnPreferredWidth (arg1, arg2);
 }
@@ -644,8 +644,8 @@ static void _call_f_setColumnSpacing_1730 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setColumnSpacing (arg1, arg2);
 }
@@ -667,8 +667,8 @@ static void _call_f_setColumnStretchFactor_1426 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setColumnStretchFactor (arg1, arg2);
 }
@@ -688,7 +688,7 @@ static void _call_f_setGeometry_1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setGeometry (arg1);
 }
@@ -708,7 +708,7 @@ static void _call_f_setHorizontalSpacing_1071 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setHorizontalSpacing (arg1);
 }
@@ -730,8 +730,8 @@ static void _call_f_setRowAlignment_3409 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QFlags<Qt::AlignmentFlag> arg2 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg2 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setRowAlignment (arg1, arg2);
 }
@@ -753,8 +753,8 @@ static void _call_f_setRowFixedHeight_1730 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setRowFixedHeight (arg1, arg2);
 }
@@ -776,8 +776,8 @@ static void _call_f_setRowMaximumHeight_1730 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setRowMaximumHeight (arg1, arg2);
 }
@@ -799,8 +799,8 @@ static void _call_f_setRowMinimumHeight_1730 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setRowMinimumHeight (arg1, arg2);
 }
@@ -822,8 +822,8 @@ static void _call_f_setRowPreferredHeight_1730 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setRowPreferredHeight (arg1, arg2);
 }
@@ -845,8 +845,8 @@ static void _call_f_setRowSpacing_1730 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setRowSpacing (arg1, arg2);
 }
@@ -868,8 +868,8 @@ static void _call_f_setRowStretchFactor_1426 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setRowStretchFactor (arg1, arg2);
 }
@@ -889,7 +889,7 @@ static void _call_f_setSpacing_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setSpacing (arg1);
 }
@@ -909,7 +909,7 @@ static void _call_f_setVerticalSpacing_1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout *)cls)->setVerticalSpacing (arg1);
 }
@@ -931,8 +931,8 @@ static void _call_f_sizeHint_c3330 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::SizeHint>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::SizeHint>::target_type & > (heap);
-  const QSizeF &arg2 = args ? args.read<const QSizeF & > (heap) : (const QSizeF &)(QSizeF());
+  const qt_gsi::Converter<Qt::SizeHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::SizeHint>::target_type & >() (args, heap);
+  const QSizeF &arg2 = args ? gsi::arg_reader<const QSizeF & >() (args, heap) : gsi::arg_maker<const QSizeF & >() (QSizeF(), heap);
   ret.write<QSizeF > ((QSizeF)((QGraphicsGridLayout *)cls)->sizeHint (qt_gsi::QtToCppAdaptor<Qt::SizeHint>(arg1).cref(), arg2));
 }
 
@@ -1209,7 +1209,7 @@ static void _call_ctor_QGraphicsGridLayout_Adaptor_2557 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args ? args.read<QGraphicsLayoutItem * > (heap) : (QGraphicsLayoutItem *)(0);
+  QGraphicsLayoutItem *arg1 = args ? gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap) : gsi::arg_maker<QGraphicsLayoutItem * >() (0, heap);
   ret.write<QGraphicsGridLayout_Adaptor *> (new QGraphicsGridLayout_Adaptor (arg1));
 }
 
@@ -1227,7 +1227,7 @@ static void _call_fp_addChildLayoutItem_2557 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout_Adaptor *)cls)->fp_QGraphicsGridLayout_addChildLayoutItem_2557 (arg1);
 }
@@ -1389,7 +1389,7 @@ static void _call_fp_setGraphicsItem_1919 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout_Adaptor *)cls)->fp_QGraphicsGridLayout_setGraphicsItem_1919 (arg1);
 }
@@ -1408,7 +1408,7 @@ static void _call_fp_setOwnedByLayout_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsGridLayout_Adaptor *)cls)->fp_QGraphicsGridLayout_setOwnedByLayout_864 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsItem.cc
@@ -136,7 +136,7 @@ static void _call_f_advance_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->advance (arg1);
 }
@@ -171,7 +171,7 @@ static void _call_f_boundingRegion_c2350 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QGraphicsItem *)cls)->boundingRegion (arg1));
 }
 
@@ -298,8 +298,8 @@ static void _call_f_collidesWithItem_c4977 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<bool > ((bool)((QGraphicsItem *)cls)->collidesWithItem (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref()));
 }
 
@@ -320,8 +320,8 @@ static void _call_f_collidesWithPath_c4877 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<bool > ((bool)((QGraphicsItem *)cls)->collidesWithPath (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref()));
 }
 
@@ -340,7 +340,7 @@ static void _call_f_collidingItems_c2471 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsItem *)cls)->collidingItems (qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg1).cref()));
 }
 
@@ -359,7 +359,7 @@ static void _call_f_commonAncestorItem_c2614 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<QGraphicsItem * > ((QGraphicsItem *)((QGraphicsItem *)cls)->commonAncestorItem (arg1));
 }
 
@@ -378,7 +378,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsItem *)cls)->contains (arg1));
 }
 
@@ -412,7 +412,7 @@ static void _call_f_data_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QGraphicsItem *)cls)->data (arg1));
 }
 
@@ -431,7 +431,7 @@ static void _call_f_deviceTransform_c2350 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QTransform > ((QTransform)((QGraphicsItem *)cls)->deviceTransform (arg1));
 }
 
@@ -469,9 +469,9 @@ static void _call_f_ensureVisible_3180 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
-  int arg2 = args ? args.read<int > (heap) : (int)(50);
-  int arg3 = args ? args.read<int > (heap) : (int)(50);
+  const QRectF &arg1 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->ensureVisible (arg1, arg2, arg3);
 }
@@ -501,12 +501,12 @@ static void _call_f_ensureVisible_5278 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  int arg5 = args ? args.read<int > (heap) : (int)(50);
-  int arg6 = args ? args.read<int > (heap) : (int)(50);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
+  int arg6 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->ensureVisible (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -739,7 +739,7 @@ static void _call_f_installSceneEventFilter_1919 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->installSceneEventFilter (arg1);
 }
@@ -774,7 +774,7 @@ static void _call_f_isAncestorOf_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsItem *)cls)->isAncestorOf (arg1));
 }
 
@@ -838,7 +838,7 @@ static void _call_f_isObscured_c1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsItem *)cls)->isObscured (arg1));
 }
 
@@ -863,10 +863,10 @@ static void _call_f_isObscured_c3960 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsItem *)cls)->isObscured (arg1, arg2, arg3, arg4));
 }
 
@@ -885,7 +885,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -964,7 +964,7 @@ static void _call_f_isVisibleTo_c2614 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsItem *)cls)->isVisibleTo (arg1));
 }
 
@@ -1015,8 +1015,8 @@ static void _call_f_itemTransform_c3556 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<QTransform > ((QTransform)((QGraphicsItem *)cls)->itemTransform (arg1, arg2));
 }
 
@@ -1037,8 +1037,8 @@ static void _call_f_mapFromItem_c4492 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapFromItem (arg1, arg2));
 }
 
@@ -1059,8 +1059,8 @@ static void _call_f_mapFromItem_c4368 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QRectF &arg2 = args.read<const QRectF & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QRectF &arg2 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapFromItem (arg1, arg2));
 }
 
@@ -1081,8 +1081,8 @@ static void _call_f_mapFromItem_c4714 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QPolygonF &arg2 = args.read<const QPolygonF & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QPolygonF &arg2 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapFromItem (arg1, arg2));
 }
 
@@ -1103,8 +1103,8 @@ static void _call_f_mapFromItem_c5020 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QPainterPath &arg2 = args.read<const QPainterPath & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QPainterPath &arg2 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QGraphicsItem *)cls)->mapFromItem (arg1, arg2));
 }
 
@@ -1127,9 +1127,9 @@ static void _call_f_mapFromItem_c4540 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapFromItem (arg1, arg2, arg3));
 }
 
@@ -1156,11 +1156,11 @@ static void _call_f_mapFromItem_c6466 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapFromItem (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1179,7 +1179,7 @@ static void _call_f_mapFromParent_c1986 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapFromParent (arg1));
 }
 
@@ -1198,7 +1198,7 @@ static void _call_f_mapFromParent_c1862 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapFromParent (arg1));
 }
 
@@ -1217,7 +1217,7 @@ static void _call_f_mapFromParent_c2208 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapFromParent (arg1));
 }
 
@@ -1236,7 +1236,7 @@ static void _call_f_mapFromParent_c2514 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QGraphicsItem *)cls)->mapFromParent (arg1));
 }
 
@@ -1257,8 +1257,8 @@ static void _call_f_mapFromParent_c2034 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapFromParent (arg1, arg2));
 }
 
@@ -1283,10 +1283,10 @@ static void _call_f_mapFromParent_c3960 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapFromParent (arg1, arg2, arg3, arg4));
 }
 
@@ -1305,7 +1305,7 @@ static void _call_f_mapFromScene_c1986 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapFromScene (arg1));
 }
 
@@ -1324,7 +1324,7 @@ static void _call_f_mapFromScene_c1862 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapFromScene (arg1));
 }
 
@@ -1343,7 +1343,7 @@ static void _call_f_mapFromScene_c2208 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapFromScene (arg1));
 }
 
@@ -1362,7 +1362,7 @@ static void _call_f_mapFromScene_c2514 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QGraphicsItem *)cls)->mapFromScene (arg1));
 }
 
@@ -1383,8 +1383,8 @@ static void _call_f_mapFromScene_c2034 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapFromScene (arg1, arg2));
 }
 
@@ -1409,10 +1409,10 @@ static void _call_f_mapFromScene_c3960 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapFromScene (arg1, arg2, arg3, arg4));
 }
 
@@ -1433,8 +1433,8 @@ static void _call_f_mapRectFromItem_c4368 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QRectF &arg2 = args.read<const QRectF & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QRectF &arg2 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectFromItem (arg1, arg2));
 }
 
@@ -1461,11 +1461,11 @@ static void _call_f_mapRectFromItem_c6466 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectFromItem (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1484,7 +1484,7 @@ static void _call_f_mapRectFromParent_c1862 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectFromParent (arg1));
 }
 
@@ -1509,10 +1509,10 @@ static void _call_f_mapRectFromParent_c3960 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectFromParent (arg1, arg2, arg3, arg4));
 }
 
@@ -1531,7 +1531,7 @@ static void _call_f_mapRectFromScene_c1862 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectFromScene (arg1));
 }
 
@@ -1556,10 +1556,10 @@ static void _call_f_mapRectFromScene_c3960 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectFromScene (arg1, arg2, arg3, arg4));
 }
 
@@ -1580,8 +1580,8 @@ static void _call_f_mapRectToItem_c4368 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QRectF &arg2 = args.read<const QRectF & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QRectF &arg2 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectToItem (arg1, arg2));
 }
 
@@ -1608,11 +1608,11 @@ static void _call_f_mapRectToItem_c6466 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectToItem (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1631,7 +1631,7 @@ static void _call_f_mapRectToParent_c1862 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectToParent (arg1));
 }
 
@@ -1656,10 +1656,10 @@ static void _call_f_mapRectToParent_c3960 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectToParent (arg1, arg2, arg3, arg4));
 }
 
@@ -1678,7 +1678,7 @@ static void _call_f_mapRectToScene_c1862 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectToScene (arg1));
 }
 
@@ -1703,10 +1703,10 @@ static void _call_f_mapRectToScene_c3960 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsItem *)cls)->mapRectToScene (arg1, arg2, arg3, arg4));
 }
 
@@ -1727,8 +1727,8 @@ static void _call_f_mapToItem_c4492 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapToItem (arg1, arg2));
 }
 
@@ -1749,8 +1749,8 @@ static void _call_f_mapToItem_c4368 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QRectF &arg2 = args.read<const QRectF & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QRectF &arg2 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapToItem (arg1, arg2));
 }
 
@@ -1771,8 +1771,8 @@ static void _call_f_mapToItem_c4714 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QPolygonF &arg2 = args.read<const QPolygonF & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QPolygonF &arg2 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapToItem (arg1, arg2));
 }
 
@@ -1793,8 +1793,8 @@ static void _call_f_mapToItem_c5020 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const QPainterPath &arg2 = args.read<const QPainterPath & > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const QPainterPath &arg2 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QGraphicsItem *)cls)->mapToItem (arg1, arg2));
 }
 
@@ -1817,9 +1817,9 @@ static void _call_f_mapToItem_c4540 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapToItem (arg1, arg2, arg3));
 }
 
@@ -1846,11 +1846,11 @@ static void _call_f_mapToItem_c6466 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapToItem (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1869,7 +1869,7 @@ static void _call_f_mapToParent_c1986 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapToParent (arg1));
 }
 
@@ -1888,7 +1888,7 @@ static void _call_f_mapToParent_c1862 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapToParent (arg1));
 }
 
@@ -1907,7 +1907,7 @@ static void _call_f_mapToParent_c2208 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapToParent (arg1));
 }
 
@@ -1926,7 +1926,7 @@ static void _call_f_mapToParent_c2514 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QGraphicsItem *)cls)->mapToParent (arg1));
 }
 
@@ -1947,8 +1947,8 @@ static void _call_f_mapToParent_c2034 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapToParent (arg1, arg2));
 }
 
@@ -1973,10 +1973,10 @@ static void _call_f_mapToParent_c3960 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapToParent (arg1, arg2, arg3, arg4));
 }
 
@@ -1995,7 +1995,7 @@ static void _call_f_mapToScene_c1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapToScene (arg1));
 }
 
@@ -2014,7 +2014,7 @@ static void _call_f_mapToScene_c1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapToScene (arg1));
 }
 
@@ -2033,7 +2033,7 @@ static void _call_f_mapToScene_c2208 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapToScene (arg1));
 }
 
@@ -2052,7 +2052,7 @@ static void _call_f_mapToScene_c2514 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QGraphicsItem *)cls)->mapToScene (arg1));
 }
 
@@ -2073,8 +2073,8 @@ static void _call_f_mapToScene_c2034 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItem *)cls)->mapToScene (arg1, arg2));
 }
 
@@ -2099,10 +2099,10 @@ static void _call_f_mapToScene_c3960 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsItem *)cls)->mapToScene (arg1, arg2, arg3, arg4));
 }
 
@@ -2138,8 +2138,8 @@ static void _call_f_moveBy_2034 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->moveBy (arg1, arg2);
 }
@@ -2193,9 +2193,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->paint (arg1, arg2, arg3);
 }
@@ -2305,7 +2305,7 @@ static void _call_f_removeSceneEventFilter_1919 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->removeSceneEventFilter (arg1);
 }
@@ -2357,7 +2357,7 @@ static void _call_f_rotate_1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->rotate (arg1);
 }
@@ -2394,8 +2394,8 @@ static void _call_f_scale_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->scale (arg1, arg2);
 }
@@ -2509,9 +2509,9 @@ static void _call_f_scroll_3788 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  const QRectF &arg3 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  const QRectF &arg3 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->scroll (arg1, arg2, arg3);
 }
@@ -2531,7 +2531,7 @@ static void _call_f_setAcceptDrops_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setAcceptDrops (arg1);
 }
@@ -2551,7 +2551,7 @@ static void _call_f_setAcceptHoverEvents_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setAcceptHoverEvents (arg1);
 }
@@ -2571,7 +2571,7 @@ static void _call_f_setAcceptTouchEvents_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setAcceptTouchEvents (arg1);
 }
@@ -2591,7 +2591,7 @@ static void _call_f_setAcceptedMouseButtons_2602 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::MouseButton> arg1 = args.read<QFlags<Qt::MouseButton> > (heap);
+  QFlags<Qt::MouseButton> arg1 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setAcceptedMouseButtons (arg1);
 }
@@ -2611,7 +2611,7 @@ static void _call_f_setAcceptsHoverEvents_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setAcceptsHoverEvents (arg1);
 }
@@ -2631,7 +2631,7 @@ static void _call_f_setActive_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setActive (arg1);
 }
@@ -2651,7 +2651,7 @@ static void _call_f_setBoundingRegionGranularity_1071 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setBoundingRegionGranularity (arg1);
 }
@@ -2673,8 +2673,8 @@ static void _call_f_setCacheMode_4403 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsItem::CacheMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsItem::CacheMode>::target_type & > (heap);
-  const QSize &arg2 = args ? args.read<const QSize & > (heap) : (const QSize &)(QSize());
+  const qt_gsi::Converter<QGraphicsItem::CacheMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsItem::CacheMode>::target_type & >() (args, heap);
+  const QSize &arg2 = args ? gsi::arg_reader<const QSize & >() (args, heap) : gsi::arg_maker<const QSize & >() (QSize(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setCacheMode (qt_gsi::QtToCppAdaptor<QGraphicsItem::CacheMode>(arg1).cref(), arg2);
 }
@@ -2694,7 +2694,7 @@ static void _call_f_setCursor_2032 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QCursor &arg1 = args.read<const QCursor & > (heap);
+  const QCursor &arg1 = gsi::arg_reader<const QCursor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setCursor (arg1);
 }
@@ -2716,8 +2716,8 @@ static void _call_f_setData_2778 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setData (arg1, arg2);
 }
@@ -2737,7 +2737,7 @@ static void _call_f_setEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setEnabled (arg1);
 }
@@ -2757,7 +2757,7 @@ static void _call_f_setFiltersChildEvents_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setFiltersChildEvents (arg1);
 }
@@ -2779,8 +2779,8 @@ static void _call_f_setFlag_4199 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsItem::GraphicsItemFlag>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsItem::GraphicsItemFlag>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QGraphicsItem::GraphicsItemFlag>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsItem::GraphicsItemFlag>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setFlag (qt_gsi::QtToCppAdaptor<QGraphicsItem::GraphicsItemFlag>(arg1).cref(), arg2);
 }
@@ -2800,7 +2800,7 @@ static void _call_f_setFlags_4139 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QGraphicsItem::GraphicsItemFlag> arg1 = args.read<QFlags<QGraphicsItem::GraphicsItemFlag> > (heap);
+  QFlags<QGraphicsItem::GraphicsItemFlag> arg1 = gsi::arg_reader<QFlags<QGraphicsItem::GraphicsItemFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setFlags (arg1);
 }
@@ -2820,7 +2820,7 @@ static void _call_f_setFocus_1877 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::FocusReason>::target_type & > (heap) : (const qt_gsi::Converter<Qt::FocusReason>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::FocusReason>(heap, Qt::OtherFocusReason));
+  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::FocusReason>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::FocusReason>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::FocusReason>(heap, Qt::OtherFocusReason), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setFocus (qt_gsi::QtToCppAdaptor<Qt::FocusReason>(arg1).cref());
 }
@@ -2840,7 +2840,7 @@ static void _call_f_setFocusProxy_1919 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setFocusProxy (arg1);
 }
@@ -2860,7 +2860,7 @@ static void _call_f_setGraphicsEffect_2109 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsEffect *arg1 = args.read<QGraphicsEffect * > (heap);
+  QGraphicsEffect *arg1 = gsi::arg_reader<QGraphicsEffect * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setGraphicsEffect (arg1);
 }
@@ -2880,7 +2880,7 @@ static void _call_f_setGroup_2444 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItemGroup *arg1 = args.read<QGraphicsItemGroup * > (heap);
+  QGraphicsItemGroup *arg1 = gsi::arg_reader<QGraphicsItemGroup * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setGroup (arg1);
 }
@@ -2900,7 +2900,7 @@ static void _call_f_setHandlesChildEvents_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setHandlesChildEvents (arg1);
 }
@@ -2920,7 +2920,7 @@ static void _call_f_setInputMethodHints_2985 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::InputMethodHint> arg1 = args.read<QFlags<Qt::InputMethodHint> > (heap);
+  QFlags<Qt::InputMethodHint> arg1 = gsi::arg_reader<QFlags<Qt::InputMethodHint> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setInputMethodHints (arg1);
 }
@@ -2942,8 +2942,8 @@ static void _call_f_setMatrix_2779 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setMatrix (arg1, arg2);
 }
@@ -2963,7 +2963,7 @@ static void _call_f_setOpacity_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setOpacity (arg1);
 }
@@ -2983,7 +2983,7 @@ static void _call_f_setPanelModality_3180 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsItem::PanelModality>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsItem::PanelModality>::target_type & > (heap);
+  const qt_gsi::Converter<QGraphicsItem::PanelModality>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsItem::PanelModality>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setPanelModality (qt_gsi::QtToCppAdaptor<QGraphicsItem::PanelModality>(arg1).cref());
 }
@@ -3003,7 +3003,7 @@ static void _call_f_setParentItem_1919 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setParentItem (arg1);
 }
@@ -3023,7 +3023,7 @@ static void _call_f_setPos_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setPos (arg1);
 }
@@ -3045,8 +3045,8 @@ static void _call_f_setPos_2034 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setPos (arg1, arg2);
 }
@@ -3066,7 +3066,7 @@ static void _call_f_setRotation_1071 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setRotation (arg1);
 }
@@ -3086,7 +3086,7 @@ static void _call_f_setScale_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setScale (arg1);
 }
@@ -3106,7 +3106,7 @@ static void _call_f_setSelected_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setSelected (arg1);
 }
@@ -3126,7 +3126,7 @@ static void _call_f_setToolTip_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setToolTip (arg1);
 }
@@ -3148,8 +3148,8 @@ static void _call_f_setTransform_3106 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setTransform (arg1, arg2);
 }
@@ -3169,7 +3169,7 @@ static void _call_f_setTransformOriginPoint_1986 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setTransformOriginPoint (arg1);
 }
@@ -3191,8 +3191,8 @@ static void _call_f_setTransformOriginPoint_2034 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setTransformOriginPoint (arg1, arg2);
 }
@@ -3212,7 +3212,7 @@ static void _call_f_setTransformations_3968 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QGraphicsTransform *> &arg1 = args.read<const QList<QGraphicsTransform *> & > (heap);
+  const QList<QGraphicsTransform *> &arg1 = gsi::arg_reader<const QList<QGraphicsTransform *> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setTransformations (arg1);
 }
@@ -3232,7 +3232,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setVisible (arg1);
 }
@@ -3252,7 +3252,7 @@ static void _call_f_setX_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setX (arg1);
 }
@@ -3272,7 +3272,7 @@ static void _call_f_setY_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setY (arg1);
 }
@@ -3292,7 +3292,7 @@ static void _call_f_setZValue_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->setZValue (arg1);
 }
@@ -3329,8 +3329,8 @@ static void _call_f_shear_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->shear (arg1, arg2);
 }
@@ -3366,7 +3366,7 @@ static void _call_f_stackBefore_2614 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->stackBefore (arg1);
 }
@@ -3508,8 +3508,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->translate (arg1, arg2);
 }
@@ -3592,7 +3592,7 @@ static void _call_f_update_1862 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
+  const QRectF &arg1 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->update (arg1);
 }
@@ -3618,10 +3618,10 @@ static void _call_f_update_3960 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItem *)cls)->update (arg1, arg2, arg3, arg4);
 }
@@ -4515,8 +4515,8 @@ static void _call_ctor_QGraphicsItem_Adaptor_3825 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsItem_Adaptor *> (new QGraphicsItem_Adaptor (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsItemAnimation.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsItemAnimation.cc
@@ -88,7 +88,7 @@ static void _call_f_horizontalScaleAt_c1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QGraphicsItemAnimation *)cls)->horizontalScaleAt (arg1));
 }
 
@@ -107,7 +107,7 @@ static void _call_f_horizontalShearAt_c1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QGraphicsItemAnimation *)cls)->horizontalShearAt (arg1));
 }
 
@@ -141,7 +141,7 @@ static void _call_f_matrixAt_c1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QMatrix > ((QMatrix)((QGraphicsItemAnimation *)cls)->matrixAt (arg1));
 }
 
@@ -160,7 +160,7 @@ static void _call_f_posAt_c1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsItemAnimation *)cls)->posAt (arg1));
 }
 
@@ -210,7 +210,7 @@ static void _call_f_rotationAt_c1071 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QGraphicsItemAnimation *)cls)->rotationAt (arg1));
 }
 
@@ -259,7 +259,7 @@ static void _call_f_setItem_1919 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemAnimation *)cls)->setItem (arg1);
 }
@@ -281,8 +281,8 @@ static void _call_f_setPosAt_2949 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemAnimation *)cls)->setPosAt (arg1, arg2);
 }
@@ -304,8 +304,8 @@ static void _call_f_setRotationAt_2034 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemAnimation *)cls)->setRotationAt (arg1, arg2);
 }
@@ -329,9 +329,9 @@ static void _call_f_setScaleAt_2997 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemAnimation *)cls)->setScaleAt (arg1, arg2, arg3);
 }
@@ -355,9 +355,9 @@ static void _call_f_setShearAt_2997 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemAnimation *)cls)->setShearAt (arg1, arg2, arg3);
 }
@@ -377,7 +377,7 @@ static void _call_f_setStep_1071 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemAnimation *)cls)->setStep (arg1);
 }
@@ -397,7 +397,7 @@ static void _call_f_setTimeLine_1494 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTimeLine *arg1 = args.read<QTimeLine * > (heap);
+  QTimeLine *arg1 = gsi::arg_reader<QTimeLine * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemAnimation *)cls)->setTimeLine (arg1);
 }
@@ -421,9 +421,9 @@ static void _call_f_setTranslationAt_2997 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemAnimation *)cls)->setTranslationAt (arg1, arg2, arg3);
 }
@@ -488,7 +488,7 @@ static void _call_f_verticalScaleAt_c1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QGraphicsItemAnimation *)cls)->verticalScaleAt (arg1));
 }
 
@@ -507,7 +507,7 @@ static void _call_f_verticalShearAt_c1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QGraphicsItemAnimation *)cls)->verticalShearAt (arg1));
 }
 
@@ -526,7 +526,7 @@ static void _call_f_xTranslationAt_c1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QGraphicsItemAnimation *)cls)->xTranslationAt (arg1));
 }
 
@@ -545,7 +545,7 @@ static void _call_f_yTranslationAt_c1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QGraphicsItemAnimation *)cls)->yTranslationAt (arg1));
 }
 
@@ -566,8 +566,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsItemAnimation::tr (arg1, arg2));
 }
 
@@ -590,9 +590,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsItemAnimation::tr (arg1, arg2, arg3));
 }
 
@@ -613,8 +613,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsItemAnimation::trUtf8 (arg1, arg2));
 }
 
@@ -637,9 +637,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsItemAnimation::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -874,7 +874,7 @@ static void _call_ctor_QGraphicsItemAnimation_Adaptor_1302 (const qt_gsi::Generi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsItemAnimation_Adaptor *> (new QGraphicsItemAnimation_Adaptor (arg1));
 }
 
@@ -988,7 +988,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsItemAnimation_Adaptor *)cls)->emitter_QGraphicsItemAnimation_destroyed_1302 (arg1);
 }
 
@@ -1079,7 +1079,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsItemAnimation_Adaptor *)cls)->fp_QGraphicsItemAnimation_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsItemGroup.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsItemGroup.cc
@@ -76,7 +76,7 @@ static void _call_f_addToGroup_1919 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemGroup *)cls)->addToGroup (arg1);
@@ -112,7 +112,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsItemGroup *)cls)->isObscuredBy (arg1));
 }
 
@@ -150,9 +150,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemGroup *)cls)->paint (arg1, arg2, arg3);
 }
@@ -172,7 +172,7 @@ static void _call_f_removeFromGroup_1919 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsItemGroup *)cls)->removeFromGroup (arg1);
 }
@@ -837,8 +837,8 @@ static void _call_ctor_QGraphicsItemGroup_Adaptor_3825 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsItemGroup_Adaptor *> (new QGraphicsItemGroup_Adaptor (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsLayout.cc
@@ -93,10 +93,10 @@ static void _call_f_getContentsMargins_c4704 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayout *)cls)->getContentsMargins (arg1, arg2, arg3, arg4);
 }
@@ -147,7 +147,7 @@ static void _call_f_itemAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QGraphicsLayoutItem * > ((QGraphicsLayoutItem *)((QGraphicsLayout *)cls)->itemAt (arg1));
 }
 
@@ -166,7 +166,7 @@ static void _call_f_removeAt_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayout *)cls)->removeAt (arg1);
 }
@@ -192,10 +192,10 @@ static void _call_f_setContentsMargins_3960 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayout *)cls)->setContentsMargins (arg1, arg2, arg3, arg4);
 }
@@ -231,7 +231,7 @@ static void _call_f_widgetEvent_1217 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayout *)cls)->widgetEvent (arg1);
 }
@@ -464,7 +464,7 @@ static void _call_ctor_QGraphicsLayout_Adaptor_2557 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args ? args.read<QGraphicsLayoutItem * > (heap) : (QGraphicsLayoutItem *)(0);
+  QGraphicsLayoutItem *arg1 = args ? gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap) : gsi::arg_maker<QGraphicsLayoutItem * >() (0, heap);
   ret.write<QGraphicsLayout_Adaptor *> (new QGraphicsLayout_Adaptor (arg1));
 }
 
@@ -482,7 +482,7 @@ static void _call_fp_addChildLayoutItem_2557 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayout_Adaptor *)cls)->fp_QGraphicsLayout_addChildLayoutItem_2557 (arg1);
 }
@@ -644,7 +644,7 @@ static void _call_fp_setGraphicsItem_1919 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayout_Adaptor *)cls)->fp_QGraphicsLayout_setGraphicsItem_1919 (arg1);
 }
@@ -663,7 +663,7 @@ static void _call_fp_setOwnedByLayout_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayout_Adaptor *)cls)->fp_QGraphicsLayout_setOwnedByLayout_864 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsLayoutItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsLayoutItem.cc
@@ -71,8 +71,8 @@ static void _call_f_effectiveSizeHint_c3330 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::SizeHint>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::SizeHint>::target_type & > (heap);
-  const QSizeF &arg2 = args ? args.read<const QSizeF & > (heap) : (const QSizeF &)(QSizeF());
+  const qt_gsi::Converter<Qt::SizeHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::SizeHint>::target_type & >() (args, heap);
+  const QSizeF &arg2 = args ? gsi::arg_reader<const QSizeF & >() (args, heap) : gsi::arg_maker<const QSizeF & >() (QSizeF(), heap);
   ret.write<QSizeF > ((QSizeF)((QGraphicsLayoutItem *)cls)->effectiveSizeHint (qt_gsi::QtToCppAdaptor<Qt::SizeHint>(arg1).cref(), arg2));
 }
 
@@ -112,10 +112,10 @@ static void _call_f_getContentsMargins_c4704 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->getContentsMargins (arg1, arg2, arg3, arg4);
 }
@@ -330,7 +330,7 @@ static void _call_f_setGeometry_1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setGeometry (arg1);
 }
@@ -350,7 +350,7 @@ static void _call_f_setMaximumHeight_1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setMaximumHeight (arg1);
 }
@@ -370,7 +370,7 @@ static void _call_f_setMaximumSize_1875 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setMaximumSize (arg1);
 }
@@ -392,8 +392,8 @@ static void _call_f_setMaximumSize_2034 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setMaximumSize (arg1, arg2);
 }
@@ -413,7 +413,7 @@ static void _call_f_setMaximumWidth_1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setMaximumWidth (arg1);
 }
@@ -433,7 +433,7 @@ static void _call_f_setMinimumHeight_1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setMinimumHeight (arg1);
 }
@@ -453,7 +453,7 @@ static void _call_f_setMinimumSize_1875 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setMinimumSize (arg1);
 }
@@ -475,8 +475,8 @@ static void _call_f_setMinimumSize_2034 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setMinimumSize (arg1, arg2);
 }
@@ -496,7 +496,7 @@ static void _call_f_setMinimumWidth_1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setMinimumWidth (arg1);
 }
@@ -516,7 +516,7 @@ static void _call_f_setParentLayoutItem_2557 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setParentLayoutItem (arg1);
 }
@@ -536,7 +536,7 @@ static void _call_f_setPreferredHeight_1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setPreferredHeight (arg1);
 }
@@ -556,7 +556,7 @@ static void _call_f_setPreferredSize_1875 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setPreferredSize (arg1);
 }
@@ -578,8 +578,8 @@ static void _call_f_setPreferredSize_2034 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setPreferredSize (arg1, arg2);
 }
@@ -599,7 +599,7 @@ static void _call_f_setPreferredWidth_1071 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setPreferredWidth (arg1);
 }
@@ -619,7 +619,7 @@ static void _call_f_setSizePolicy_2429 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizePolicy &arg1 = args.read<const QSizePolicy & > (heap);
+  const QSizePolicy &arg1 = gsi::arg_reader<const QSizePolicy & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setSizePolicy (arg1);
 }
@@ -643,9 +643,9 @@ static void _call_f_setSizePolicy_7191 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap) : (const qt_gsi::Converter<QSizePolicy::ControlType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSizePolicy::ControlType>(heap, QSizePolicy::DefaultType));
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSizePolicy::ControlType>(heap, QSizePolicy::DefaultType), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem *)cls)->setSizePolicy (qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg1).cref(), qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg2).cref(), qt_gsi::QtToCppAdaptor<QSizePolicy::ControlType>(arg3).cref());
 }
@@ -853,8 +853,8 @@ static void _call_ctor_QGraphicsLayoutItem_Adaptor_3313 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args ? args.read<QGraphicsLayoutItem * > (heap) : (QGraphicsLayoutItem *)(0);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  QGraphicsLayoutItem *arg1 = args ? gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap) : gsi::arg_maker<QGraphicsLayoutItem * >() (0, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<QGraphicsLayoutItem_Adaptor *> (new QGraphicsLayoutItem_Adaptor (arg1, arg2));
 }
 
@@ -929,7 +929,7 @@ static void _call_fp_setGraphicsItem_1919 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem_Adaptor *)cls)->fp_QGraphicsLayoutItem_setGraphicsItem_1919 (arg1);
 }
@@ -948,7 +948,7 @@ static void _call_fp_setOwnedByLayout_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLayoutItem_Adaptor *)cls)->fp_QGraphicsLayoutItem_setOwnedByLayout_864 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsLineItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsLineItem.cc
@@ -94,7 +94,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsLineItem *)cls)->contains (arg1));
 }
 
@@ -113,7 +113,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsLineItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -166,9 +166,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLineItem *)cls)->paint (arg1, arg2, arg3);
 }
@@ -203,7 +203,7 @@ static void _call_f_setLine_1856 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLineItem *)cls)->setLine (arg1);
 }
@@ -229,10 +229,10 @@ static void _call_f_setLine_3960 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLineItem *)cls)->setLine (arg1, arg2, arg3, arg4);
 }
@@ -252,7 +252,7 @@ static void _call_f_setPen_1685 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPen &arg1 = args.read<const QPen & > (heap);
+  const QPen &arg1 = gsi::arg_reader<const QPen & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLineItem *)cls)->setPen (arg1);
 }
@@ -973,8 +973,8 @@ static void _call_ctor_QGraphicsLineItem_Adaptor_3825 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsLineItem_Adaptor *> (new QGraphicsLineItem_Adaptor (arg1, arg2));
 }
 
@@ -996,9 +996,9 @@ static void _call_ctor_QGraphicsLineItem_Adaptor_5573 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
-  QGraphicsItem *arg2 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg3 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
+  QGraphicsItem *arg2 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg3 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsLineItem_Adaptor *> (new QGraphicsLineItem_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1026,12 +1026,12 @@ static void _call_ctor_QGraphicsLineItem_Adaptor_7677 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  QGraphicsItem *arg5 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg6 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  QGraphicsItem *arg5 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg6 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsLineItem_Adaptor *> (new QGraphicsLineItem_Adaptor (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsLinearLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsLinearLayout.cc
@@ -56,7 +56,7 @@ static void _call_f_addItem_2557 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->addItem (arg1);
 }
@@ -76,7 +76,7 @@ static void _call_f_addStretch_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->addStretch (arg1);
 }
@@ -96,7 +96,7 @@ static void _call_f_alignment_c2557 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   ret.write<QFlags<Qt::AlignmentFlag> > ((QFlags<Qt::AlignmentFlag>)((QGraphicsLinearLayout *)cls)->alignment (arg1));
 }
 
@@ -130,7 +130,7 @@ static void _call_f_dump_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->dump (arg1);
 }
@@ -152,8 +152,8 @@ static void _call_f_insertItem_3216 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QGraphicsLayoutItem *arg2 = args.read<QGraphicsLayoutItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QGraphicsLayoutItem *arg2 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->insertItem (arg1, arg2);
 }
@@ -175,8 +175,8 @@ static void _call_f_insertStretch_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->insertStretch (arg1, arg2);
 }
@@ -212,7 +212,7 @@ static void _call_f_itemAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QGraphicsLayoutItem * > ((QGraphicsLayoutItem *)((QGraphicsLinearLayout *)cls)->itemAt (arg1));
 }
 
@@ -231,7 +231,7 @@ static void _call_f_itemSpacing_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QGraphicsLinearLayout *)cls)->itemSpacing (arg1));
 }
 
@@ -265,7 +265,7 @@ static void _call_f_removeAt_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->removeAt (arg1);
 }
@@ -285,7 +285,7 @@ static void _call_f_removeItem_2557 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->removeItem (arg1);
 }
@@ -307,8 +307,8 @@ static void _call_f_setAlignment_5199 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
-  QFlags<Qt::AlignmentFlag> arg2 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg2 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->setAlignment (arg1, arg2);
 }
@@ -328,7 +328,7 @@ static void _call_f_setGeometry_1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->setGeometry (arg1);
 }
@@ -350,8 +350,8 @@ static void _call_f_setItemSpacing_1730 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->setItemSpacing (arg1, arg2);
 }
@@ -371,7 +371,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -391,7 +391,7 @@ static void _call_f_setSpacing_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->setSpacing (arg1);
 }
@@ -413,8 +413,8 @@ static void _call_f_setStretchFactor_3216 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout *)cls)->setStretchFactor (arg1, arg2);
 }
@@ -436,8 +436,8 @@ static void _call_f_sizeHint_c3330 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::SizeHint>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::SizeHint>::target_type & > (heap);
-  const QSizeF &arg2 = args ? args.read<const QSizeF & > (heap) : (const QSizeF &)(QSizeF());
+  const qt_gsi::Converter<Qt::SizeHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::SizeHint>::target_type & >() (args, heap);
+  const QSizeF &arg2 = args ? gsi::arg_reader<const QSizeF & >() (args, heap) : gsi::arg_maker<const QSizeF & >() (QSizeF(), heap);
   ret.write<QSizeF > ((QSizeF)((QGraphicsLinearLayout *)cls)->sizeHint (qt_gsi::QtToCppAdaptor<Qt::SizeHint>(arg1).cref(), arg2));
 }
 
@@ -471,7 +471,7 @@ static void _call_f_stretchFactor_c2557 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   ret.write<int > ((int)((QGraphicsLinearLayout *)cls)->stretchFactor (arg1));
 }
 
@@ -723,7 +723,7 @@ static void _call_ctor_QGraphicsLinearLayout_Adaptor_2557 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args ? args.read<QGraphicsLayoutItem * > (heap) : (QGraphicsLayoutItem *)(0);
+  QGraphicsLayoutItem *arg1 = args ? gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap) : gsi::arg_maker<QGraphicsLayoutItem * >() (0, heap);
   ret.write<QGraphicsLinearLayout_Adaptor *> (new QGraphicsLinearLayout_Adaptor (arg1));
 }
 
@@ -743,8 +743,8 @@ static void _call_ctor_QGraphicsLinearLayout_Adaptor_4362 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  QGraphicsLayoutItem *arg2 = args ? args.read<QGraphicsLayoutItem * > (heap) : (QGraphicsLayoutItem *)(0);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  QGraphicsLayoutItem *arg2 = args ? gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap) : gsi::arg_maker<QGraphicsLayoutItem * >() (0, heap);
   ret.write<QGraphicsLinearLayout_Adaptor *> (new QGraphicsLinearLayout_Adaptor (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref(), arg2));
 }
 
@@ -762,7 +762,7 @@ static void _call_fp_addChildLayoutItem_2557 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayoutItem *arg1 = args.read<QGraphicsLayoutItem * > (heap);
+  QGraphicsLayoutItem *arg1 = gsi::arg_reader<QGraphicsLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout_Adaptor *)cls)->fp_QGraphicsLinearLayout_addChildLayoutItem_2557 (arg1);
 }
@@ -924,7 +924,7 @@ static void _call_fp_setGraphicsItem_1919 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout_Adaptor *)cls)->fp_QGraphicsLinearLayout_setGraphicsItem_1919 (arg1);
 }
@@ -943,7 +943,7 @@ static void _call_fp_setOwnedByLayout_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsLinearLayout_Adaptor *)cls)->fp_QGraphicsLinearLayout_setOwnedByLayout_864 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsObject.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsObject.cc
@@ -110,8 +110,8 @@ static void _call_f_grabGesture_4352 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
-  QFlags<Qt::GestureFlag> arg2 = args ? args.read<QFlags<Qt::GestureFlag> > (heap) : (QFlags<Qt::GestureFlag>)(Qt::GestureFlags());
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
+  QFlags<Qt::GestureFlag> arg2 = args ? gsi::arg_reader<QFlags<Qt::GestureFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::GestureFlag> >() (Qt::GestureFlags(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsObject *)cls)->grabGesture (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref(), arg2);
 }
@@ -131,7 +131,7 @@ static void _call_f_ungrabGesture_1902 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsObject *)cls)->ungrabGesture (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref());
 }
@@ -153,8 +153,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsObject::tr (arg1, arg2));
 }
 
@@ -177,9 +177,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsObject::tr (arg1, arg2, arg3));
 }
 
@@ -200,8 +200,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsObject::trUtf8 (arg1, arg2));
 }
 
@@ -224,9 +224,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsObject::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1096,7 +1096,7 @@ static void _call_ctor_QGraphicsObject_Adaptor_1919 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
   ret.write<QGraphicsObject_Adaptor *> (new QGraphicsObject_Adaptor (arg1));
 }
 
@@ -1319,7 +1319,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsObject_Adaptor *)cls)->emitter_QGraphicsObject_destroyed_1302 (arg1);
 }
 
@@ -1995,7 +1995,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsObject_Adaptor *)cls)->fp_QGraphicsObject_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsOpacityEffect.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsOpacityEffect.cc
@@ -103,7 +103,7 @@ static void _call_f_setOpacity_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsOpacityEffect *)cls)->setOpacity (arg1);
 }
@@ -123,7 +123,7 @@ static void _call_f_setOpacityMask_1910 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsOpacityEffect *)cls)->setOpacityMask (arg1);
 }
@@ -145,8 +145,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsOpacityEffect::tr (arg1, arg2));
 }
 
@@ -169,9 +169,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsOpacityEffect::tr (arg1, arg2, arg3));
 }
 
@@ -192,8 +192,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsOpacityEffect::trUtf8 (arg1, arg2));
 }
 
@@ -216,9 +216,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsOpacityEffect::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -493,7 +493,7 @@ static void _call_ctor_QGraphicsOpacityEffect_Adaptor_1302 (const qt_gsi::Generi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsOpacityEffect_Adaptor *> (new QGraphicsOpacityEffect_Adaptor (arg1));
 }
 
@@ -582,7 +582,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsOpacityEffect_Adaptor *)cls)->emitter_QGraphicsOpacityEffect_destroyed_1302 (arg1);
 }
 
@@ -648,7 +648,7 @@ static void _call_fp_drawSource_1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsOpacityEffect_Adaptor *)cls)->fp_QGraphicsOpacityEffect_drawSource_1426 (arg1);
 }
@@ -667,7 +667,7 @@ static void _call_emitter_enabledChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QGraphicsOpacityEffect_Adaptor *)cls)->emitter_QGraphicsOpacityEffect_enabledChanged_864 (arg1);
 }
 
@@ -734,7 +734,7 @@ static void _call_emitter_opacityChanged_1071 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ((QGraphicsOpacityEffect_Adaptor *)cls)->emitter_QGraphicsOpacityEffect_opacityChanged_1071 (arg1);
 }
 
@@ -752,7 +752,7 @@ static void _call_emitter_opacityMaskChanged_1910 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   ((QGraphicsOpacityEffect_Adaptor *)cls)->emitter_QGraphicsOpacityEffect_opacityMaskChanged_1910 (arg1);
 }
 
@@ -770,7 +770,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsOpacityEffect_Adaptor *)cls)->fp_QGraphicsOpacityEffect_receivers_c1731 (arg1));
 }
 
@@ -802,7 +802,7 @@ static void _call_fp_sourceBoundingRect_c2426 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
   ret.write<QRectF > ((QRectF)((QGraphicsOpacityEffect_Adaptor *)cls)->fp_QGraphicsOpacityEffect_sourceBoundingRect_c2426 (arg1));
 }
 
@@ -862,9 +862,9 @@ static void _call_fp_sourcePixmap_c6763 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & > (heap) : (const qt_gsi::Converter<Qt::CoordinateSystem>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates));
-  QPoint *arg2 = args ? args.read<QPoint * > (heap) : (QPoint *)(0);
-  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & > (heap) : (const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect));
+  const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::CoordinateSystem>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::CoordinateSystem>(heap, Qt::LogicalCoordinates), heap);
+  QPoint *arg2 = args ? gsi::arg_reader<QPoint * >() (args, heap) : gsi::arg_maker<QPoint * >() (0, heap);
+  const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QGraphicsEffect::PixmapPadMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QGraphicsEffect::PixmapPadMode>(heap, QGraphicsEffect::PadToEffectiveBoundingRect), heap);
   ret.write<QPixmap > ((QPixmap)((QGraphicsOpacityEffect_Adaptor *)cls)->fp_QGraphicsOpacityEffect_sourcePixmap_c6763 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsPathItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsPathItem.cc
@@ -94,7 +94,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsPathItem *)cls)->contains (arg1));
 }
 
@@ -113,7 +113,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsPathItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -151,9 +151,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPathItem *)cls)->paint (arg1, arg2, arg3);
 }
@@ -188,7 +188,7 @@ static void _call_f_setPath_2514 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPathItem *)cls)->setPath (arg1);
 }
@@ -888,8 +888,8 @@ static void _call_ctor_QGraphicsPathItem_Adaptor_3825 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsPathItem_Adaptor *> (new QGraphicsPathItem_Adaptor (arg1, arg2));
 }
 
@@ -911,9 +911,9 @@ static void _call_ctor_QGraphicsPathItem_Adaptor_6231 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  QGraphicsItem *arg2 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg3 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  QGraphicsItem *arg2 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg3 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsPathItem_Adaptor *> (new QGraphicsPathItem_Adaptor (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsPixmapItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsPixmapItem.cc
@@ -93,7 +93,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsPixmapItem *)cls)->contains (arg1));
 }
 
@@ -112,7 +112,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsPixmapItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -165,9 +165,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPixmapItem *)cls)->paint (arg1, arg2, arg3);
 }
@@ -202,7 +202,7 @@ static void _call_f_setOffset_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPixmapItem *)cls)->setOffset (arg1);
 }
@@ -224,8 +224,8 @@ static void _call_f_setOffset_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPixmapItem *)cls)->setOffset (arg1, arg2);
 }
@@ -245,7 +245,7 @@ static void _call_f_setPixmap_2017 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPixmapItem *)cls)->setPixmap (arg1);
 }
@@ -265,7 +265,7 @@ static void _call_f_setShapeMode_3358 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsPixmapItem::ShapeMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsPixmapItem::ShapeMode>::target_type & > (heap);
+  const qt_gsi::Converter<QGraphicsPixmapItem::ShapeMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsPixmapItem::ShapeMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPixmapItem *)cls)->setShapeMode (qt_gsi::QtToCppAdaptor<QGraphicsPixmapItem::ShapeMode>(arg1).cref());
 }
@@ -285,7 +285,7 @@ static void _call_f_setTransformationMode_2633 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPixmapItem *)cls)->setTransformationMode (qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg1).cref());
 }
@@ -1022,8 +1022,8 @@ static void _call_ctor_QGraphicsPixmapItem_Adaptor_3825 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsPixmapItem_Adaptor *> (new QGraphicsPixmapItem_Adaptor (arg1, arg2));
 }
 
@@ -1045,9 +1045,9 @@ static void _call_ctor_QGraphicsPixmapItem_Adaptor_5734 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
-  QGraphicsItem *arg2 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg3 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  QGraphicsItem *arg2 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg3 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsPixmapItem_Adaptor *> (new QGraphicsPixmapItem_Adaptor (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsPolygonItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsPolygonItem.cc
@@ -94,7 +94,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsPolygonItem *)cls)->contains (arg1));
 }
 
@@ -128,7 +128,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsPolygonItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -166,9 +166,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPolygonItem *)cls)->paint (arg1, arg2, arg3);
 }
@@ -203,7 +203,7 @@ static void _call_f_setFillRule_1548 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::FillRule>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::FillRule>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::FillRule>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPolygonItem *)cls)->setFillRule (qt_gsi::QtToCppAdaptor<Qt::FillRule>(arg1).cref());
 }
@@ -223,7 +223,7 @@ static void _call_f_setPolygon_2208 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsPolygonItem *)cls)->setPolygon (arg1);
 }
@@ -925,8 +925,8 @@ static void _call_ctor_QGraphicsPolygonItem_Adaptor_3825 (const qt_gsi::GenericS
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsPolygonItem_Adaptor *> (new QGraphicsPolygonItem_Adaptor (arg1, arg2));
 }
 
@@ -948,9 +948,9 @@ static void _call_ctor_QGraphicsPolygonItem_Adaptor_5925 (const qt_gsi::GenericS
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
-  QGraphicsItem *arg2 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg3 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
+  QGraphicsItem *arg2 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg3 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsPolygonItem_Adaptor *> (new QGraphicsPolygonItem_Adaptor (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsProxyWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsProxyWidget.cc
@@ -109,7 +109,7 @@ static void _call_f_createProxyForChildWidget_1315 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QGraphicsProxyWidget * > ((QGraphicsProxyWidget *)((QGraphicsProxyWidget *)cls)->createProxyForChildWidget (arg1));
 }
 
@@ -132,9 +132,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsProxyWidget *)cls)->paint (arg1, arg2, arg3);
 }
@@ -154,7 +154,7 @@ static void _call_f_setGeometry_1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsProxyWidget *)cls)->setGeometry (arg1);
 }
@@ -174,7 +174,7 @@ static void _call_f_setWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsProxyWidget *)cls)->setWidget (arg1);
 }
@@ -194,7 +194,7 @@ static void _call_f_subWidgetRect_c2010 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<QRectF > ((QRectF)((QGraphicsProxyWidget *)cls)->subWidgetRect (arg1));
 }
 
@@ -245,8 +245,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsProxyWidget::tr (arg1, arg2));
 }
 
@@ -269,9 +269,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsProxyWidget::tr (arg1, arg2, arg3));
 }
 
@@ -292,8 +292,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsProxyWidget::trUtf8 (arg1, arg2));
 }
 
@@ -316,9 +316,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsProxyWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1499,8 +1499,8 @@ static void _call_ctor_QGraphicsProxyWidget_Adaptor_4306 (const qt_gsi::GenericS
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QGraphicsProxyWidget_Adaptor *> (new QGraphicsProxyWidget_Adaptor (arg1, arg2));
 }
 
@@ -1771,7 +1771,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsProxyWidget_Adaptor *)cls)->emitter_QGraphicsProxyWidget_destroyed_1302 (arg1);
 }
 
@@ -2531,7 +2531,7 @@ static void _call_fp_newProxyWidget_2010 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<QGraphicsProxyWidget * > ((QGraphicsProxyWidget *)((QGraphicsProxyWidget_Adaptor *)cls)->fp_QGraphicsProxyWidget_newProxyWidget_2010 (arg1));
 }
 
@@ -2717,7 +2717,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsProxyWidget_Adaptor *)cls)->fp_QGraphicsProxyWidget_receivers_c1731 (arg1));
 }
 
@@ -2916,7 +2916,7 @@ static void _call_fp_setGraphicsItem_1919 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsProxyWidget_Adaptor *)cls)->fp_QGraphicsProxyWidget_setGraphicsItem_1919 (arg1);
 }
@@ -2935,7 +2935,7 @@ static void _call_fp_setOwnedByLayout_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsProxyWidget_Adaptor *)cls)->fp_QGraphicsProxyWidget_setOwnedByLayout_864 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsRectItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsRectItem.cc
@@ -94,7 +94,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsRectItem *)cls)->contains (arg1));
 }
 
@@ -113,7 +113,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsRectItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -151,9 +151,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsRectItem *)cls)->paint (arg1, arg2, arg3);
 }
@@ -188,7 +188,7 @@ static void _call_f_setRect_1862 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsRectItem *)cls)->setRect (arg1);
 }
@@ -214,10 +214,10 @@ static void _call_f_setRect_3960 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsRectItem *)cls)->setRect (arg1, arg2, arg3, arg4);
 }
@@ -936,8 +936,8 @@ static void _call_ctor_QGraphicsRectItem_Adaptor_3825 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsRectItem_Adaptor *> (new QGraphicsRectItem_Adaptor (arg1, arg2));
 }
 
@@ -959,9 +959,9 @@ static void _call_ctor_QGraphicsRectItem_Adaptor_5579 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  QGraphicsItem *arg2 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg3 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  QGraphicsItem *arg2 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg3 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsRectItem_Adaptor *> (new QGraphicsRectItem_Adaptor (arg1, arg2, arg3));
 }
 
@@ -989,12 +989,12 @@ static void _call_ctor_QGraphicsRectItem_Adaptor_7677 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  QGraphicsItem *arg5 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg6 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  QGraphicsItem *arg5 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg6 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsRectItem_Adaptor *> (new QGraphicsRectItem_Adaptor (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsRotation.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsRotation.cc
@@ -85,7 +85,7 @@ static void _call_f_applyTo_c1556 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMatrix4x4 *arg1 = args.read<QMatrix4x4 * > (heap);
+  QMatrix4x4 *arg1 = gsi::arg_reader<QMatrix4x4 * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsRotation *)cls)->applyTo (arg1);
 }
@@ -135,7 +135,7 @@ static void _call_f_setAngle_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsRotation *)cls)->setAngle (arg1);
 }
@@ -155,7 +155,7 @@ static void _call_f_setAxis_2140 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsRotation *)cls)->setAxis (arg1);
 }
@@ -175,7 +175,7 @@ static void _call_f_setAxis_1154 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Axis>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Axis>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Axis>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Axis>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsRotation *)cls)->setAxis (qt_gsi::QtToCppAdaptor<Qt::Axis>(arg1).cref());
 }
@@ -195,7 +195,7 @@ static void _call_f_setOrigin_2140 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsRotation *)cls)->setOrigin (arg1);
 }
@@ -217,8 +217,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsRotation::tr (arg1, arg2));
 }
 
@@ -241,9 +241,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsRotation::tr (arg1, arg2, arg3));
 }
 
@@ -264,8 +264,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsRotation::trUtf8 (arg1, arg2));
 }
 
@@ -288,9 +288,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsRotation::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -517,7 +517,7 @@ static void _call_ctor_QGraphicsRotation_Adaptor_1302 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsRotation_Adaptor *> (new QGraphicsRotation_Adaptor (arg1));
 }
 
@@ -635,7 +635,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsRotation_Adaptor *)cls)->emitter_QGraphicsRotation_destroyed_1302 (arg1);
 }
 
@@ -740,7 +740,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsRotation_Adaptor *)cls)->fp_QGraphicsRotation_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsScale.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsScale.cc
@@ -70,7 +70,7 @@ static void _call_f_applyTo_c1556 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMatrix4x4 *arg1 = args.read<QMatrix4x4 * > (heap);
+  QMatrix4x4 *arg1 = gsi::arg_reader<QMatrix4x4 * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScale *)cls)->applyTo (arg1);
 }
@@ -105,7 +105,7 @@ static void _call_f_setOrigin_2140 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScale *)cls)->setOrigin (arg1);
 }
@@ -125,7 +125,7 @@ static void _call_f_setXScale_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScale *)cls)->setXScale (arg1);
 }
@@ -145,7 +145,7 @@ static void _call_f_setYScale_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScale *)cls)->setYScale (arg1);
 }
@@ -165,7 +165,7 @@ static void _call_f_setZScale_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScale *)cls)->setZScale (arg1);
 }
@@ -232,8 +232,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsScale::tr (arg1, arg2));
 }
 
@@ -256,9 +256,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsScale::tr (arg1, arg2, arg3));
 }
 
@@ -279,8 +279,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsScale::trUtf8 (arg1, arg2));
 }
 
@@ -303,9 +303,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsScale::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -526,7 +526,7 @@ static void _call_ctor_QGraphicsScale_Adaptor_1302 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsScale_Adaptor *> (new QGraphicsScale_Adaptor (arg1));
 }
 
@@ -616,7 +616,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsScale_Adaptor *)cls)->emitter_QGraphicsScale_destroyed_1302 (arg1);
 }
 
@@ -721,7 +721,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsScale_Adaptor *)cls)->fp_QGraphicsScale_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsScene.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsScene.cc
@@ -116,9 +116,9 @@ static void _call_f_addEllipse_5241 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QPen &arg2 = args ? args.read<const QPen & > (heap) : (const QPen &)(QPen());
-  const QBrush &arg3 = args ? args.read<const QBrush & > (heap) : (const QBrush &)(QBrush());
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QPen &arg2 = args ? gsi::arg_reader<const QPen & >() (args, heap) : gsi::arg_maker<const QPen & >() (QPen(), heap);
+  const QBrush &arg3 = args ? gsi::arg_reader<const QBrush & >() (args, heap) : gsi::arg_maker<const QBrush & >() (QBrush(), heap);
   ret.write<QGraphicsEllipseItem * > ((QGraphicsEllipseItem *)((QGraphicsScene *)cls)->addEllipse (arg1, arg2, arg3));
 }
 
@@ -147,12 +147,12 @@ static void _call_f_addEllipse_7339 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  const QPen &arg5 = args ? args.read<const QPen & > (heap) : (const QPen &)(QPen());
-  const QBrush &arg6 = args ? args.read<const QBrush & > (heap) : (const QBrush &)(QBrush());
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  const QPen &arg5 = args ? gsi::arg_reader<const QPen & >() (args, heap) : gsi::arg_maker<const QPen & >() (QPen(), heap);
+  const QBrush &arg6 = args ? gsi::arg_reader<const QBrush & >() (args, heap) : gsi::arg_maker<const QBrush & >() (QBrush(), heap);
   ret.write<QGraphicsEllipseItem * > ((QGraphicsEllipseItem *)((QGraphicsScene *)cls)->addEllipse (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -171,7 +171,7 @@ static void _call_f_addItem_1919 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->addItem (arg1);
@@ -194,8 +194,8 @@ static void _call_f_addLine_3433 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
-  const QPen &arg2 = args ? args.read<const QPen & > (heap) : (const QPen &)(QPen());
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
+  const QPen &arg2 = args ? gsi::arg_reader<const QPen & >() (args, heap) : gsi::arg_maker<const QPen & >() (QPen(), heap);
   ret.write<QGraphicsLineItem * > ((QGraphicsLineItem *)((QGraphicsScene *)cls)->addLine (arg1, arg2));
 }
 
@@ -222,11 +222,11 @@ static void _call_f_addLine_5537 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  const QPen &arg5 = args ? args.read<const QPen & > (heap) : (const QPen &)(QPen());
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  const QPen &arg5 = args ? gsi::arg_reader<const QPen & >() (args, heap) : gsi::arg_maker<const QPen & >() (QPen(), heap);
   ret.write<QGraphicsLineItem * > ((QGraphicsLineItem *)((QGraphicsScene *)cls)->addLine (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -249,9 +249,9 @@ static void _call_f_addPath_5893 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const QPen &arg2 = args ? args.read<const QPen & > (heap) : (const QPen &)(QPen());
-  const QBrush &arg3 = args ? args.read<const QBrush & > (heap) : (const QBrush &)(QBrush());
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const QPen &arg2 = args ? gsi::arg_reader<const QPen & >() (args, heap) : gsi::arg_maker<const QPen & >() (QPen(), heap);
+  const QBrush &arg3 = args ? gsi::arg_reader<const QBrush & >() (args, heap) : gsi::arg_maker<const QBrush & >() (QBrush(), heap);
   ret.write<QGraphicsPathItem * > ((QGraphicsPathItem *)((QGraphicsScene *)cls)->addPath (arg1, arg2, arg3));
 }
 
@@ -270,7 +270,7 @@ static void _call_f_addPixmap_2017 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QGraphicsPixmapItem * > ((QGraphicsPixmapItem *)((QGraphicsScene *)cls)->addPixmap (arg1));
 }
 
@@ -293,9 +293,9 @@ static void _call_f_addPolygon_5587 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
-  const QPen &arg2 = args ? args.read<const QPen & > (heap) : (const QPen &)(QPen());
-  const QBrush &arg3 = args ? args.read<const QBrush & > (heap) : (const QBrush &)(QBrush());
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
+  const QPen &arg2 = args ? gsi::arg_reader<const QPen & >() (args, heap) : gsi::arg_maker<const QPen & >() (QPen(), heap);
+  const QBrush &arg3 = args ? gsi::arg_reader<const QBrush & >() (args, heap) : gsi::arg_maker<const QBrush & >() (QBrush(), heap);
   ret.write<QGraphicsPolygonItem * > ((QGraphicsPolygonItem *)((QGraphicsScene *)cls)->addPolygon (arg1, arg2, arg3));
 }
 
@@ -318,9 +318,9 @@ static void _call_f_addRect_5241 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QPen &arg2 = args ? args.read<const QPen & > (heap) : (const QPen &)(QPen());
-  const QBrush &arg3 = args ? args.read<const QBrush & > (heap) : (const QBrush &)(QBrush());
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QPen &arg2 = args ? gsi::arg_reader<const QPen & >() (args, heap) : gsi::arg_maker<const QPen & >() (QPen(), heap);
+  const QBrush &arg3 = args ? gsi::arg_reader<const QBrush & >() (args, heap) : gsi::arg_maker<const QBrush & >() (QBrush(), heap);
   ret.write<QGraphicsRectItem * > ((QGraphicsRectItem *)((QGraphicsScene *)cls)->addRect (arg1, arg2, arg3));
 }
 
@@ -349,12 +349,12 @@ static void _call_f_addRect_7339 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  const QPen &arg5 = args ? args.read<const QPen & > (heap) : (const QPen &)(QPen());
-  const QBrush &arg6 = args ? args.read<const QBrush & > (heap) : (const QBrush &)(QBrush());
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  const QPen &arg5 = args ? gsi::arg_reader<const QPen & >() (args, heap) : gsi::arg_maker<const QPen & >() (QPen(), heap);
+  const QBrush &arg6 = args ? gsi::arg_reader<const QBrush & >() (args, heap) : gsi::arg_maker<const QBrush & >() (QBrush(), heap);
   ret.write<QGraphicsRectItem * > ((QGraphicsRectItem *)((QGraphicsScene *)cls)->addRect (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -375,8 +375,8 @@ static void _call_f_addSimpleText_3718 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QFont &arg2 = args ? args.read<const QFont & > (heap) : (const QFont &)(QFont());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QFont &arg2 = args ? gsi::arg_reader<const QFont & >() (args, heap) : gsi::arg_maker<const QFont & >() (QFont(), heap);
   ret.write<QGraphicsSimpleTextItem * > ((QGraphicsSimpleTextItem *)((QGraphicsScene *)cls)->addSimpleText (arg1, arg2));
 }
 
@@ -397,8 +397,8 @@ static void _call_f_addText_3718 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QFont &arg2 = args ? args.read<const QFont & > (heap) : (const QFont &)(QFont());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QFont &arg2 = args ? gsi::arg_reader<const QFont & >() (args, heap) : gsi::arg_maker<const QFont & >() (QFont(), heap);
   ret.write<QGraphicsTextItem * > ((QGraphicsTextItem *)((QGraphicsScene *)cls)->addText (arg1, arg2));
 }
 
@@ -419,8 +419,8 @@ static void _call_f_addWidget_3702 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QGraphicsProxyWidget * > ((QGraphicsProxyWidget *)((QGraphicsScene *)cls)->addWidget (arg1, arg2));
 }
 
@@ -535,8 +535,8 @@ static void _call_f_collidingItems_c4977 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->collidingItems (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref()));
 }
 
@@ -555,7 +555,7 @@ static void _call_f_createItemGroup_3411 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QGraphicsItem *> &arg1 = args.read<const QList<QGraphicsItem *> & > (heap);
+  const QList<QGraphicsItem *> &arg1 = gsi::arg_reader<const QList<QGraphicsItem *> & >() (args, heap);
   ret.write<QGraphicsItemGroup * > ((QGraphicsItemGroup *)((QGraphicsScene *)cls)->createItemGroup (arg1));
 }
 
@@ -574,7 +574,7 @@ static void _call_f_destroyItemGroup_2444 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItemGroup *arg1 = args.read<QGraphicsItemGroup * > (heap);
+  QGraphicsItemGroup *arg1 = gsi::arg_reader<QGraphicsItemGroup * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->destroyItemGroup (arg1);
 }
@@ -669,7 +669,7 @@ static void _call_f_inputMethodQuery_c2420 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QGraphicsScene *)cls)->inputMethodQuery (qt_gsi::QtToCppAdaptor<Qt::InputMethodQuery>(arg1).cref()));
 }
 
@@ -696,11 +696,11 @@ static void _call_f_invalidate_7495 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  QFlags<QGraphicsScene::SceneLayer> arg5 = args ? args.read<QFlags<QGraphicsScene::SceneLayer> > (heap) : (QFlags<QGraphicsScene::SceneLayer>)(QGraphicsScene::AllLayers);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  QFlags<QGraphicsScene::SceneLayer> arg5 = args ? gsi::arg_reader<QFlags<QGraphicsScene::SceneLayer> >() (args, heap) : gsi::arg_maker<QFlags<QGraphicsScene::SceneLayer> >() (QGraphicsScene::AllLayers, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->invalidate (arg1, arg2, arg3, arg4, arg5);
 }
@@ -722,8 +722,8 @@ static void _call_f_invalidate_5397 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
-  QFlags<QGraphicsScene::SceneLayer> arg2 = args ? args.read<QFlags<QGraphicsScene::SceneLayer> > (heap) : (QFlags<QGraphicsScene::SceneLayer>)(QGraphicsScene::AllLayers);
+  const QRectF &arg1 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
+  QFlags<QGraphicsScene::SceneLayer> arg2 = args ? gsi::arg_reader<QFlags<QGraphicsScene::SceneLayer> >() (args, heap) : gsi::arg_maker<QFlags<QGraphicsScene::SceneLayer> >() (QGraphicsScene::AllLayers, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->invalidate (arg1, arg2);
 }
@@ -773,7 +773,7 @@ static void _call_f_itemAt_c1986 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QGraphicsItem * > ((QGraphicsItem *)((QGraphicsScene *)cls)->itemAt (arg1));
 }
 
@@ -794,8 +794,8 @@ static void _call_f_itemAt_c4228 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QTransform &arg2 = args.read<const QTransform & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QTransform &arg2 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QGraphicsItem * > ((QGraphicsItem *)((QGraphicsScene *)cls)->itemAt (arg1, arg2));
 }
 
@@ -816,8 +816,8 @@ static void _call_f_itemAt_c2034 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QGraphicsItem * > ((QGraphicsItem *)((QGraphicsScene *)cls)->itemAt (arg1, arg2));
 }
 
@@ -840,9 +840,9 @@ static void _call_f_itemAt_c4276 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  const QTransform &arg3 = args.read<const QTransform & > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  const QTransform &arg3 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QGraphicsItem * > ((QGraphicsItem *)((QGraphicsScene *)cls)->itemAt (arg1, arg2, arg3));
 }
 
@@ -891,7 +891,7 @@ static void _call_f_items_c1681 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg1).cref()));
 }
 
@@ -916,10 +916,10 @@ static void _call_f_items_c8164 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
-  const QTransform &arg4 = args ? args.read<const QTransform & > (heap) : (const QTransform &)(QTransform());
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
+  const QTransform &arg4 = args ? gsi::arg_reader<const QTransform & >() (args, heap) : gsi::arg_maker<const QTransform & >() (QTransform(), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref(), qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg3).cref(), arg4));
 }
 
@@ -944,10 +944,10 @@ static void _call_f_items_c8040 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
-  const QTransform &arg4 = args ? args.read<const QTransform & > (heap) : (const QTransform &)(QTransform());
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
+  const QTransform &arg4 = args ? gsi::arg_reader<const QTransform & >() (args, heap) : gsi::arg_maker<const QTransform & >() (QTransform(), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref(), qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg3).cref(), arg4));
 }
 
@@ -972,10 +972,10 @@ static void _call_f_items_c8386 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
-  const QTransform &arg4 = args ? args.read<const QTransform & > (heap) : (const QTransform &)(QTransform());
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
+  const QTransform &arg4 = args ? gsi::arg_reader<const QTransform & >() (args, heap) : gsi::arg_maker<const QTransform & >() (QTransform(), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref(), qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg3).cref(), arg4));
 }
 
@@ -1000,10 +1000,10 @@ static void _call_f_items_c8692 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
-  const QTransform &arg4 = args ? args.read<const QTransform & > (heap) : (const QTransform &)(QTransform());
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
+  const QTransform &arg4 = args ? gsi::arg_reader<const QTransform & >() (args, heap) : gsi::arg_maker<const QTransform & >() (QTransform(), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref(), qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg3).cref(), arg4));
 }
 
@@ -1022,7 +1022,7 @@ static void _call_f_items_c1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1));
 }
 
@@ -1043,8 +1043,8 @@ static void _call_f_items_c4225 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref()));
 }
 
@@ -1065,8 +1065,8 @@ static void _call_f_items_c4571 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref()));
 }
 
@@ -1087,8 +1087,8 @@ static void _call_f_items_c4877 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref()));
 }
 
@@ -1115,11 +1115,11 @@ static void _call_f_items_c6323 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg5).cref()));
 }
 
@@ -1150,13 +1150,13 @@ static void _call_f_items_c10138 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg5 = args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg6 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
-  const QTransform &arg7 = args ? args.read<const QTransform & > (heap) : (const QTransform &)(QTransform());
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg5 = gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg6 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
+  const QTransform &arg7 = args ? gsi::arg_reader<const QTransform & >() (args, heap) : gsi::arg_maker<const QTransform & >() (QTransform(), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsScene *)cls)->items (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg5).cref(), qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg6).cref(), arg7));
 }
 
@@ -1220,7 +1220,7 @@ static void _call_f_removeItem_1919 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->removeItem (arg1);
 }
@@ -1246,10 +1246,10 @@ static void _call_f_render_7083 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRectF &arg2 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
-  const QRectF &arg3 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::AspectRatioMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::KeepAspectRatio));
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRectF &arg2 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
+  const QRectF &arg3 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::KeepAspectRatio), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->render (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg4).cref());
 }
@@ -1316,8 +1316,8 @@ static void _call_f_sendEvent_3028 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
-  QEvent *arg2 = args.read<QEvent * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
+  QEvent *arg2 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsScene *)cls)->sendEvent (arg1, arg2));
 }
 
@@ -1336,7 +1336,7 @@ static void _call_f_setActivePanel_1919 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setActivePanel (arg1);
 }
@@ -1356,7 +1356,7 @@ static void _call_f_setActiveWindow_2132 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsWidget *arg1 = args.read<QGraphicsWidget * > (heap);
+  QGraphicsWidget *arg1 = gsi::arg_reader<QGraphicsWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setActiveWindow (arg1);
 }
@@ -1376,7 +1376,7 @@ static void _call_f_setBackgroundBrush_1910 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setBackgroundBrush (arg1);
 }
@@ -1396,7 +1396,7 @@ static void _call_f_setBspTreeDepth_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setBspTreeDepth (arg1);
 }
@@ -1416,7 +1416,7 @@ static void _call_f_setFocus_1877 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::FocusReason>::target_type & > (heap) : (const qt_gsi::Converter<Qt::FocusReason>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::FocusReason>(heap, Qt::OtherFocusReason));
+  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::FocusReason>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::FocusReason>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::FocusReason>(heap, Qt::OtherFocusReason), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setFocus (qt_gsi::QtToCppAdaptor<Qt::FocusReason>(arg1).cref());
 }
@@ -1438,8 +1438,8 @@ static void _call_f_setFocusItem_3688 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
-  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::FocusReason>::target_type & > (heap) : (const qt_gsi::Converter<Qt::FocusReason>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::FocusReason>(heap, Qt::OtherFocusReason));
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::FocusReason>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::FocusReason>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::FocusReason>(heap, Qt::OtherFocusReason), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setFocusItem (arg1, qt_gsi::QtToCppAdaptor<Qt::FocusReason>(arg2).cref());
 }
@@ -1459,7 +1459,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setFont (arg1);
 }
@@ -1479,7 +1479,7 @@ static void _call_f_setForegroundBrush_1910 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setForegroundBrush (arg1);
 }
@@ -1499,7 +1499,7 @@ static void _call_f_setItemIndexMethod_3456 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsScene::ItemIndexMethod>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsScene::ItemIndexMethod>::target_type & > (heap);
+  const qt_gsi::Converter<QGraphicsScene::ItemIndexMethod>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsScene::ItemIndexMethod>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setItemIndexMethod (qt_gsi::QtToCppAdaptor<QGraphicsScene::ItemIndexMethod>(arg1).cref());
 }
@@ -1519,7 +1519,7 @@ static void _call_f_setPalette_2113 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setPalette (arg1);
 }
@@ -1539,7 +1539,7 @@ static void _call_f_setSceneRect_1862 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setSceneRect (arg1);
 }
@@ -1565,10 +1565,10 @@ static void _call_f_setSceneRect_3960 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setSceneRect (arg1, arg2, arg3, arg4);
 }
@@ -1588,7 +1588,7 @@ static void _call_f_setSelectionArea_2514 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setSelectionArea (arg1);
 }
@@ -1610,8 +1610,8 @@ static void _call_f_setSelectionArea_4756 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const QTransform &arg2 = args.read<const QTransform & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const QTransform &arg2 = gsi::arg_reader<const QTransform & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setSelectionArea (arg1, arg2);
 }
@@ -1633,8 +1633,8 @@ static void _call_f_setSelectionArea_4877 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setSelectionArea (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref());
 }
@@ -1658,9 +1658,9 @@ static void _call_f_setSelectionArea_7119 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap);
-  const QTransform &arg3 = args.read<const QTransform & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap);
+  const QTransform &arg3 = gsi::arg_reader<const QTransform & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setSelectionArea (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref(), arg3);
 }
@@ -1680,7 +1680,7 @@ static void _call_f_setSortCacheEnabled_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setSortCacheEnabled (arg1);
 }
@@ -1700,7 +1700,7 @@ static void _call_f_setStickyFocus_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setStickyFocus (arg1);
 }
@@ -1720,7 +1720,7 @@ static void _call_f_setStyle_1232 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyle *arg1 = args.read<QStyle * > (heap);
+  QStyle *arg1 = gsi::arg_reader<QStyle * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->setStyle (arg1);
 }
@@ -1776,10 +1776,10 @@ static void _call_f_update_3960 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->update (arg1, arg2, arg3, arg4);
 }
@@ -1799,7 +1799,7 @@ static void _call_f_update_1862 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
+  const QRectF &arg1 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsScene *)cls)->update (arg1);
 }
@@ -1851,8 +1851,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsScene::tr (arg1, arg2));
 }
 
@@ -1875,9 +1875,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsScene::tr (arg1, arg2, arg3));
 }
 
@@ -1898,8 +1898,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsScene::trUtf8 (arg1, arg2));
 }
 
@@ -1922,9 +1922,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsScene::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2540,7 +2540,7 @@ static void _call_ctor_QGraphicsScene_Adaptor_1302 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsScene_Adaptor *> (new QGraphicsScene_Adaptor (arg1));
 }
 
@@ -2560,8 +2560,8 @@ static void _call_ctor_QGraphicsScene_Adaptor_3056 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsScene_Adaptor *> (new QGraphicsScene_Adaptor (arg1, arg2));
 }
 
@@ -2587,11 +2587,11 @@ static void _call_ctor_QGraphicsScene_Adaptor_5154 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  QObject *arg5 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  QObject *arg5 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsScene_Adaptor *> (new QGraphicsScene_Adaptor (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -2609,7 +2609,7 @@ static void _call_emitter_changed_2477 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QRectF> &arg1 = args.read<const QList<QRectF> & > (heap);
+  const QList<QRectF> &arg1 = gsi::arg_reader<const QList<QRectF> & >() (args, heap);
   ((QGraphicsScene_Adaptor *)cls)->emitter_QGraphicsScene_changed_2477 (arg1);
 }
 
@@ -2699,7 +2699,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsScene_Adaptor *)cls)->emitter_QGraphicsScene_destroyed_1302 (arg1);
 }
 
@@ -2964,7 +2964,7 @@ static void _call_fp_focusNextPrevChild_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsScene_Adaptor *)cls)->fp_QGraphicsScene_focusNextPrevChild_864 (arg1));
 }
 
@@ -3221,7 +3221,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsScene_Adaptor *)cls)->fp_QGraphicsScene_receivers_c1731 (arg1));
 }
 
@@ -3239,7 +3239,7 @@ static void _call_emitter_sceneRectChanged_1862 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ((QGraphicsScene_Adaptor *)cls)->emitter_QGraphicsScene_sceneRectChanged_1862 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneContextMenuEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneContextMenuEvent.cc
@@ -128,7 +128,7 @@ static void _call_f_setModifiers_3077 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::KeyboardModifier> arg1 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  QFlags<Qt::KeyboardModifier> arg1 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneContextMenuEvent *)cls)->setModifiers (arg1);
 }
@@ -148,7 +148,7 @@ static void _call_f_setPos_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneContextMenuEvent *)cls)->setPos (arg1);
 }
@@ -168,7 +168,7 @@ static void _call_f_setReason_4220 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsSceneContextMenuEvent::Reason>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsSceneContextMenuEvent::Reason>::target_type & > (heap);
+  const qt_gsi::Converter<QGraphicsSceneContextMenuEvent::Reason>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsSceneContextMenuEvent::Reason>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneContextMenuEvent *)cls)->setReason (qt_gsi::QtToCppAdaptor<QGraphicsSceneContextMenuEvent::Reason>(arg1).cref());
 }
@@ -188,7 +188,7 @@ static void _call_f_setScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneContextMenuEvent *)cls)->setScenePos (arg1);
 }
@@ -208,7 +208,7 @@ static void _call_f_setScreenPos_1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneContextMenuEvent *)cls)->setScreenPos (arg1);
 }
@@ -279,7 +279,7 @@ static void _call_ctor_QGraphicsSceneContextMenuEvent_Adaptor_1565 (const qt_gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap) : (const qt_gsi::Converter<QEvent::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None));
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QEvent::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None), heap);
   ret.write<QGraphicsSceneContextMenuEvent_Adaptor *> (new QGraphicsSceneContextMenuEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneDragDropEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneDragDropEvent.cc
@@ -205,7 +205,7 @@ static void _call_f_setButtons_2602 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::MouseButton> arg1 = args.read<QFlags<Qt::MouseButton> > (heap);
+  QFlags<Qt::MouseButton> arg1 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setButtons (arg1);
 }
@@ -225,7 +225,7 @@ static void _call_f_setDropAction_1760 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setDropAction (qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg1).cref());
 }
@@ -245,7 +245,7 @@ static void _call_f_setMimeData_2168 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setMimeData (arg1);
 }
@@ -265,7 +265,7 @@ static void _call_f_setModifiers_3077 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::KeyboardModifier> arg1 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  QFlags<Qt::KeyboardModifier> arg1 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setModifiers (arg1);
 }
@@ -285,7 +285,7 @@ static void _call_f_setPos_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setPos (arg1);
 }
@@ -305,7 +305,7 @@ static void _call_f_setPossibleActions_2456 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DropAction> arg1 = args.read<QFlags<Qt::DropAction> > (heap);
+  QFlags<Qt::DropAction> arg1 = gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setPossibleActions (arg1);
 }
@@ -325,7 +325,7 @@ static void _call_f_setProposedAction_1760 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setProposedAction (qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg1).cref());
 }
@@ -345,7 +345,7 @@ static void _call_f_setScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setScenePos (arg1);
 }
@@ -365,7 +365,7 @@ static void _call_f_setScreenPos_1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setScreenPos (arg1);
 }
@@ -385,7 +385,7 @@ static void _call_f_setSource_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneDragDropEvent *)cls)->setSource (arg1);
 }
@@ -482,7 +482,7 @@ static void _call_ctor_QGraphicsSceneDragDropEvent_Adaptor_1565 (const qt_gsi::G
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap) : (const qt_gsi::Converter<QEvent::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None));
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QEvent::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None), heap);
   ret.write<QGraphicsSceneDragDropEvent_Adaptor *> (new QGraphicsSceneDragDropEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneEvent.cc
@@ -51,7 +51,7 @@ static void _call_f_setWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneEvent *)cls)->setWidget (arg1);
 }
@@ -123,7 +123,7 @@ static void _call_ctor_QGraphicsSceneEvent_Adaptor_1565 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
   ret.write<QGraphicsSceneEvent_Adaptor *> (new QGraphicsSceneEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneHelpEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneHelpEvent.cc
@@ -83,7 +83,7 @@ static void _call_f_setScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneHelpEvent *)cls)->setScenePos (arg1);
 }
@@ -103,7 +103,7 @@ static void _call_f_setScreenPos_1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneHelpEvent *)cls)->setScreenPos (arg1);
 }
@@ -168,7 +168,7 @@ static void _call_ctor_QGraphicsSceneHelpEvent_Adaptor_1565 (const qt_gsi::Gener
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap) : (const qt_gsi::Converter<QEvent::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None));
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QEvent::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None), heap);
   ret.write<QGraphicsSceneHelpEvent_Adaptor *> (new QGraphicsSceneHelpEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneHoverEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneHoverEvent.cc
@@ -158,7 +158,7 @@ static void _call_f_setLastPos_1986 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneHoverEvent *)cls)->setLastPos (arg1);
 }
@@ -178,7 +178,7 @@ static void _call_f_setLastScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneHoverEvent *)cls)->setLastScenePos (arg1);
 }
@@ -198,7 +198,7 @@ static void _call_f_setLastScreenPos_1916 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneHoverEvent *)cls)->setLastScreenPos (arg1);
 }
@@ -218,7 +218,7 @@ static void _call_f_setModifiers_3077 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::KeyboardModifier> arg1 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  QFlags<Qt::KeyboardModifier> arg1 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneHoverEvent *)cls)->setModifiers (arg1);
 }
@@ -238,7 +238,7 @@ static void _call_f_setPos_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneHoverEvent *)cls)->setPos (arg1);
 }
@@ -258,7 +258,7 @@ static void _call_f_setScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneHoverEvent *)cls)->setScenePos (arg1);
 }
@@ -278,7 +278,7 @@ static void _call_f_setScreenPos_1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneHoverEvent *)cls)->setScreenPos (arg1);
 }
@@ -353,7 +353,7 @@ static void _call_ctor_QGraphicsSceneHoverEvent_Adaptor_1565 (const qt_gsi::Gene
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap) : (const qt_gsi::Converter<QEvent::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None));
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QEvent::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None), heap);
   ret.write<QGraphicsSceneHoverEvent_Adaptor *> (new QGraphicsSceneHoverEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneMouseEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneMouseEvent.cc
@@ -68,7 +68,7 @@ static void _call_f_buttonDownPos_c1906 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsSceneMouseEvent *)cls)->buttonDownPos (qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg1).cref()));
 }
 
@@ -87,7 +87,7 @@ static void _call_f_buttonDownScenePos_c1906 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsSceneMouseEvent *)cls)->buttonDownScenePos (qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg1).cref()));
 }
 
@@ -106,7 +106,7 @@ static void _call_f_buttonDownScreenPos_c1906 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QGraphicsSceneMouseEvent *)cls)->buttonDownScreenPos (qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg1).cref()));
 }
 
@@ -245,7 +245,7 @@ static void _call_f_setButton_1906 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setButton (qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg1).cref());
 }
@@ -267,8 +267,8 @@ static void _call_f_setButtonDownPos_3784 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setButtonDownPos (qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg1).cref(), arg2);
 }
@@ -290,8 +290,8 @@ static void _call_f_setButtonDownScenePos_3784 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setButtonDownScenePos (qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg1).cref(), arg2);
 }
@@ -313,8 +313,8 @@ static void _call_f_setButtonDownScreenPos_3714 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setButtonDownScreenPos (qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg1).cref(), arg2);
 }
@@ -334,7 +334,7 @@ static void _call_f_setButtons_2602 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::MouseButton> arg1 = args.read<QFlags<Qt::MouseButton> > (heap);
+  QFlags<Qt::MouseButton> arg1 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setButtons (arg1);
 }
@@ -354,7 +354,7 @@ static void _call_f_setLastPos_1986 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setLastPos (arg1);
 }
@@ -374,7 +374,7 @@ static void _call_f_setLastScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setLastScenePos (arg1);
 }
@@ -394,7 +394,7 @@ static void _call_f_setLastScreenPos_1916 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setLastScreenPos (arg1);
 }
@@ -414,7 +414,7 @@ static void _call_f_setModifiers_3077 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::KeyboardModifier> arg1 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  QFlags<Qt::KeyboardModifier> arg1 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setModifiers (arg1);
 }
@@ -434,7 +434,7 @@ static void _call_f_setPos_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setPos (arg1);
 }
@@ -454,7 +454,7 @@ static void _call_f_setScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setScenePos (arg1);
 }
@@ -474,7 +474,7 @@ static void _call_f_setScreenPos_1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMouseEvent *)cls)->setScreenPos (arg1);
 }
@@ -559,7 +559,7 @@ static void _call_ctor_QGraphicsSceneMouseEvent_Adaptor_1565 (const qt_gsi::Gene
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap) : (const qt_gsi::Converter<QEvent::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None));
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QEvent::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None), heap);
   ret.write<QGraphicsSceneMouseEvent_Adaptor *> (new QGraphicsSceneMouseEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneMoveEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneMoveEvent.cc
@@ -82,7 +82,7 @@ static void _call_f_setNewPos_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMoveEvent *)cls)->setNewPos (arg1);
 }
@@ -102,7 +102,7 @@ static void _call_f_setOldPos_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneMoveEvent *)cls)->setOldPos (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneResizeEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneResizeEvent.cc
@@ -82,7 +82,7 @@ static void _call_f_setNewSize_1875 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneResizeEvent *)cls)->setNewSize (arg1);
 }
@@ -102,7 +102,7 @@ static void _call_f_setOldSize_1875 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneResizeEvent *)cls)->setOldSize (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneWheelEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSceneWheelEvent.cc
@@ -158,7 +158,7 @@ static void _call_f_setButtons_2602 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::MouseButton> arg1 = args.read<QFlags<Qt::MouseButton> > (heap);
+  QFlags<Qt::MouseButton> arg1 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneWheelEvent *)cls)->setButtons (arg1);
 }
@@ -178,7 +178,7 @@ static void _call_f_setDelta_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneWheelEvent *)cls)->setDelta (arg1);
 }
@@ -198,7 +198,7 @@ static void _call_f_setModifiers_3077 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::KeyboardModifier> arg1 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  QFlags<Qt::KeyboardModifier> arg1 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneWheelEvent *)cls)->setModifiers (arg1);
 }
@@ -218,7 +218,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneWheelEvent *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -238,7 +238,7 @@ static void _call_f_setPos_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneWheelEvent *)cls)->setPos (arg1);
 }
@@ -258,7 +258,7 @@ static void _call_f_setScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneWheelEvent *)cls)->setScenePos (arg1);
 }
@@ -278,7 +278,7 @@ static void _call_f_setScreenPos_1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSceneWheelEvent *)cls)->setScreenPos (arg1);
 }
@@ -353,7 +353,7 @@ static void _call_ctor_QGraphicsSceneWheelEvent_Adaptor_1565 (const qt_gsi::Gene
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap) : (const qt_gsi::Converter<QEvent::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None));
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QEvent::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QEvent::Type>(heap, QEvent::None), heap);
   ret.write<QGraphicsSceneWheelEvent_Adaptor *> (new QGraphicsSceneWheelEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSimpleTextItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsSimpleTextItem.cc
@@ -95,7 +95,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsSimpleTextItem *)cls)->contains (arg1));
 }
 
@@ -129,7 +129,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsSimpleTextItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -167,9 +167,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSimpleTextItem *)cls)->paint (arg1, arg2, arg3);
 }
@@ -189,7 +189,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSimpleTextItem *)cls)->setFont (arg1);
 }
@@ -209,7 +209,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsSimpleTextItem *)cls)->setText (arg1);
 }
@@ -926,8 +926,8 @@ static void _call_ctor_QGraphicsSimpleTextItem_Adaptor_3825 (const qt_gsi::Gener
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsSimpleTextItem_Adaptor *> (new QGraphicsSimpleTextItem_Adaptor (arg1, arg2));
 }
 
@@ -949,9 +949,9 @@ static void _call_ctor_QGraphicsSimpleTextItem_Adaptor_5742 (const qt_gsi::Gener
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QGraphicsItem *arg2 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg3 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QGraphicsItem *arg2 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg3 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsSimpleTextItem_Adaptor *> (new QGraphicsSimpleTextItem_Adaptor (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsTextItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsTextItem.cc
@@ -129,7 +129,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsTextItem *)cls)->contains (arg1));
 }
 
@@ -193,7 +193,7 @@ static void _call_f_isObscuredBy_c2614 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsTextItem *)cls)->isObscuredBy (arg1));
 }
 
@@ -246,9 +246,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->paint (arg1, arg2, arg3);
 }
@@ -268,7 +268,7 @@ static void _call_f_setDefaultTextColor_1905 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setDefaultTextColor (arg1);
 }
@@ -288,7 +288,7 @@ static void _call_f_setDocument_1955 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setDocument (arg1);
 }
@@ -308,7 +308,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setFont (arg1);
 }
@@ -328,7 +328,7 @@ static void _call_f_setHtml_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setHtml (arg1);
 }
@@ -348,7 +348,7 @@ static void _call_f_setOpenExternalLinks_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setOpenExternalLinks (arg1);
 }
@@ -368,7 +368,7 @@ static void _call_f_setPlainText_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setPlainText (arg1);
 }
@@ -388,7 +388,7 @@ static void _call_f_setTabChangesFocus_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setTabChangesFocus (arg1);
 }
@@ -408,7 +408,7 @@ static void _call_f_setTextCursor_2453 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setTextCursor (arg1);
 }
@@ -428,7 +428,7 @@ static void _call_f_setTextInteractionFlags_3396 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::TextInteractionFlag> arg1 = args.read<QFlags<Qt::TextInteractionFlag> > (heap);
+  QFlags<Qt::TextInteractionFlag> arg1 = gsi::arg_reader<QFlags<Qt::TextInteractionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setTextInteractionFlags (arg1);
 }
@@ -448,7 +448,7 @@ static void _call_f_setTextWidth_1071 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTextItem *)cls)->setTextWidth (arg1);
 }
@@ -590,8 +590,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsTextItem::tr (arg1, arg2));
 }
 
@@ -614,9 +614,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsTextItem::tr (arg1, arg2, arg3));
 }
 
@@ -637,8 +637,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsTextItem::trUtf8 (arg1, arg2));
 }
 
@@ -661,9 +661,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsTextItem::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1546,8 +1546,8 @@ static void _call_ctor_QGraphicsTextItem_Adaptor_3825 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg2 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg2 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsTextItem_Adaptor *> (new QGraphicsTextItem_Adaptor (arg1, arg2));
 }
 
@@ -1569,9 +1569,9 @@ static void _call_ctor_QGraphicsTextItem_Adaptor_5742 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QGraphicsItem *arg2 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QGraphicsScene *arg3 = args ? args.read<QGraphicsScene * > (heap) : (QGraphicsScene *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QGraphicsItem *arg2 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QGraphicsScene *arg3 = args ? gsi::arg_reader<QGraphicsScene * >() (args, heap) : gsi::arg_maker<QGraphicsScene * >() (0, heap);
   ret.write<QGraphicsTextItem_Adaptor *> (new QGraphicsTextItem_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1794,7 +1794,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsTextItem_Adaptor *)cls)->emitter_QGraphicsTextItem_destroyed_1302 (arg1);
 }
 
@@ -2282,7 +2282,7 @@ static void _call_emitter_linkActivated_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QGraphicsTextItem_Adaptor *)cls)->emitter_QGraphicsTextItem_linkActivated_2025 (arg1);
 }
 
@@ -2300,7 +2300,7 @@ static void _call_emitter_linkHovered_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QGraphicsTextItem_Adaptor *)cls)->emitter_QGraphicsTextItem_linkHovered_2025 (arg1);
 }
 
@@ -2506,7 +2506,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsTextItem_Adaptor *)cls)->fp_QGraphicsTextItem_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsTransform.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsTransform.cc
@@ -69,7 +69,7 @@ static void _call_f_applyTo_c1556 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMatrix4x4 *arg1 = args.read<QMatrix4x4 * > (heap);
+  QMatrix4x4 *arg1 = gsi::arg_reader<QMatrix4x4 * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsTransform *)cls)->applyTo (arg1);
 }
@@ -91,8 +91,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsTransform::tr (arg1, arg2));
 }
 
@@ -115,9 +115,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsTransform::tr (arg1, arg2, arg3));
 }
 
@@ -138,8 +138,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsTransform::trUtf8 (arg1, arg2));
 }
 
@@ -162,9 +162,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsTransform::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -364,7 +364,7 @@ static void _call_ctor_QGraphicsTransform_Adaptor_1302 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QGraphicsTransform_Adaptor *> (new QGraphicsTransform_Adaptor (arg1));
 }
 
@@ -454,7 +454,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsTransform_Adaptor *)cls)->emitter_QGraphicsTransform_destroyed_1302 (arg1);
 }
 
@@ -545,7 +545,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsTransform_Adaptor *)cls)->fp_QGraphicsTransform_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsView.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsView.cc
@@ -166,7 +166,7 @@ static void _call_f_centerOn_1986 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->centerOn (arg1);
 }
@@ -188,8 +188,8 @@ static void _call_f_centerOn_2034 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->centerOn (arg1, arg2);
 }
@@ -209,7 +209,7 @@ static void _call_f_centerOn_2614 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->centerOn (arg1);
 }
@@ -248,9 +248,9 @@ static void _call_f_ensureVisible_3180 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(50);
-  int arg3 = args ? args.read<int > (heap) : (int)(50);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->ensureVisible (arg1, arg2, arg3);
 }
@@ -280,12 +280,12 @@ static void _call_f_ensureVisible_5278 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  int arg5 = args ? args.read<int > (heap) : (int)(50);
-  int arg6 = args ? args.read<int > (heap) : (int)(50);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
+  int arg6 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->ensureVisible (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -309,9 +309,9 @@ static void _call_f_ensureVisible_3932 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(50);
-  int arg3 = args ? args.read<int > (heap) : (int)(50);
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->ensureVisible (arg1, arg2, arg3);
 }
@@ -333,8 +333,8 @@ static void _call_f_fitInView_4011 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::AspectRatioMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio));
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->fitInView (arg1, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg2).cref());
 }
@@ -362,11 +362,11 @@ static void _call_f_fitInView_6109 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::AspectRatioMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio));
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->fitInView (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg5).cref());
 }
@@ -388,8 +388,8 @@ static void _call_f_fitInView_4763 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QGraphicsItem *arg1 = args.read<const QGraphicsItem * > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::AspectRatioMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio));
+  const QGraphicsItem *arg1 = gsi::arg_reader<const QGraphicsItem * >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->fitInView (arg1, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg2).cref());
 }
@@ -424,7 +424,7 @@ static void _call_f_inputMethodQuery_c2420 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QGraphicsView *)cls)->inputMethodQuery (qt_gsi::QtToCppAdaptor<Qt::InputMethodQuery>(arg1).cref()));
 }
 
@@ -445,8 +445,8 @@ static void _call_f_invalidateScene_5397 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
-  QFlags<QGraphicsScene::SceneLayer> arg2 = args ? args.read<QFlags<QGraphicsScene::SceneLayer> > (heap) : (QFlags<QGraphicsScene::SceneLayer>)(QGraphicsScene::AllLayers);
+  const QRectF &arg1 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
+  QFlags<QGraphicsScene::SceneLayer> arg2 = args ? gsi::arg_reader<QFlags<QGraphicsScene::SceneLayer> >() (args, heap) : gsi::arg_maker<QFlags<QGraphicsScene::SceneLayer> >() (QGraphicsScene::AllLayers, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->invalidateScene (arg1, arg2);
 }
@@ -496,7 +496,7 @@ static void _call_f_itemAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QGraphicsItem * > ((QGraphicsItem *)((QGraphicsView *)cls)->itemAt (arg1));
 }
 
@@ -517,8 +517,8 @@ static void _call_f_itemAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QGraphicsItem * > ((QGraphicsItem *)((QGraphicsView *)cls)->itemAt (arg1, arg2));
 }
 
@@ -552,7 +552,7 @@ static void _call_f_items_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsView *)cls)->items (arg1));
 }
 
@@ -573,8 +573,8 @@ static void _call_f_items_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsView *)cls)->items (arg1, arg2));
 }
 
@@ -595,8 +595,8 @@ static void _call_f_items_c4155 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsView *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref()));
 }
 
@@ -623,11 +623,11 @@ static void _call_f_items_c5107 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsView *)cls)->items (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg5).cref()));
 }
 
@@ -648,8 +648,8 @@ static void _call_f_items_c4501 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsView *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref()));
 }
 
@@ -670,8 +670,8 @@ static void _call_f_items_c4877 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape));
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ItemSelectionMode>(heap, Qt::IntersectsItemShape), heap);
   ret.write<QList<QGraphicsItem *> > ((QList<QGraphicsItem *>)((QGraphicsView *)cls)->items (arg1, qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg2).cref()));
 }
 
@@ -690,7 +690,7 @@ static void _call_f_mapFromScene_c1986 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QGraphicsView *)cls)->mapFromScene (arg1));
 }
 
@@ -709,7 +709,7 @@ static void _call_f_mapFromScene_c1862 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QGraphicsView *)cls)->mapFromScene (arg1));
 }
 
@@ -728,7 +728,7 @@ static void _call_f_mapFromScene_c2208 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QGraphicsView *)cls)->mapFromScene (arg1));
 }
 
@@ -747,7 +747,7 @@ static void _call_f_mapFromScene_c2514 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QGraphicsView *)cls)->mapFromScene (arg1));
 }
 
@@ -768,8 +768,8 @@ static void _call_f_mapFromScene_c2034 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPoint > ((QPoint)((QGraphicsView *)cls)->mapFromScene (arg1, arg2));
 }
 
@@ -794,10 +794,10 @@ static void _call_f_mapFromScene_c3960 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QGraphicsView *)cls)->mapFromScene (arg1, arg2, arg3, arg4));
 }
 
@@ -816,7 +816,7 @@ static void _call_f_mapToScene_c1916 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsView *)cls)->mapToScene (arg1));
 }
 
@@ -835,7 +835,7 @@ static void _call_f_mapToScene_c1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsView *)cls)->mapToScene (arg1));
 }
 
@@ -854,7 +854,7 @@ static void _call_f_mapToScene_c2138 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsView *)cls)->mapToScene (arg1));
 }
 
@@ -873,7 +873,7 @@ static void _call_f_mapToScene_c2514 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QGraphicsView *)cls)->mapToScene (arg1));
 }
 
@@ -894,8 +894,8 @@ static void _call_f_mapToScene_c1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPointF > ((QPointF)((QGraphicsView *)cls)->mapToScene (arg1, arg2));
 }
 
@@ -920,10 +920,10 @@ static void _call_f_mapToScene_c2744 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QGraphicsView *)cls)->mapToScene (arg1, arg2, arg3, arg4));
 }
 
@@ -978,10 +978,10 @@ static void _call_f_render_7013 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRectF &arg2 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
-  const QRect &arg3 = args ? args.read<const QRect & > (heap) : (const QRect &)(QRect());
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::AspectRatioMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::KeepAspectRatio));
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRectF &arg2 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
+  const QRect &arg3 = args ? gsi::arg_reader<const QRect & >() (args, heap) : gsi::arg_maker<const QRect & >() (QRect(), heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::KeepAspectRatio), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->render (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg4).cref());
 }
@@ -1079,7 +1079,7 @@ static void _call_f_rotate_1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->rotate (arg1);
 }
@@ -1116,8 +1116,8 @@ static void _call_f_scale_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->scale (arg1, arg2);
 }
@@ -1167,7 +1167,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setAlignment (arg1);
 }
@@ -1187,7 +1187,7 @@ static void _call_f_setBackgroundBrush_1910 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setBackgroundBrush (arg1);
 }
@@ -1207,7 +1207,7 @@ static void _call_f_setCacheMode_3792 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QGraphicsView::CacheModeFlag> arg1 = args.read<QFlags<QGraphicsView::CacheModeFlag> > (heap);
+  QFlags<QGraphicsView::CacheModeFlag> arg1 = gsi::arg_reader<QFlags<QGraphicsView::CacheModeFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setCacheMode (arg1);
 }
@@ -1227,7 +1227,7 @@ static void _call_f_setDragMode_2632 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsView::DragMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsView::DragMode>::target_type & > (heap);
+  const qt_gsi::Converter<QGraphicsView::DragMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsView::DragMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setDragMode (qt_gsi::QtToCppAdaptor<QGraphicsView::DragMode>(arg1).cref());
 }
@@ -1247,7 +1247,7 @@ static void _call_f_setForegroundBrush_1910 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setForegroundBrush (arg1);
 }
@@ -1267,7 +1267,7 @@ static void _call_f_setInteractive_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setInteractive (arg1);
 }
@@ -1289,8 +1289,8 @@ static void _call_f_setMatrix_2779 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setMatrix (arg1, arg2);
 }
@@ -1312,8 +1312,8 @@ static void _call_f_setOptimizationFlag_4282 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsView::OptimizationFlag>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsView::OptimizationFlag>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QGraphicsView::OptimizationFlag>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsView::OptimizationFlag>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setOptimizationFlag (qt_gsi::QtToCppAdaptor<QGraphicsView::OptimizationFlag>(arg1).cref(), arg2);
 }
@@ -1333,7 +1333,7 @@ static void _call_f_setOptimizationFlags_4222 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QGraphicsView::OptimizationFlag> arg1 = args.read<QFlags<QGraphicsView::OptimizationFlag> > (heap);
+  QFlags<QGraphicsView::OptimizationFlag> arg1 = gsi::arg_reader<QFlags<QGraphicsView::OptimizationFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setOptimizationFlags (arg1);
 }
@@ -1355,8 +1355,8 @@ static void _call_f_setRenderHint_3123 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPainter::RenderHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QPainter::RenderHint>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QPainter::RenderHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPainter::RenderHint>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setRenderHint (qt_gsi::QtToCppAdaptor<QPainter::RenderHint>(arg1).cref(), arg2);
 }
@@ -1376,7 +1376,7 @@ static void _call_f_setRenderHints_3063 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPainter::RenderHint> arg1 = args.read<QFlags<QPainter::RenderHint> > (heap);
+  QFlags<QPainter::RenderHint> arg1 = gsi::arg_reader<QFlags<QPainter::RenderHint> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setRenderHints (arg1);
 }
@@ -1396,7 +1396,7 @@ static void _call_f_setResizeAnchor_3328 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsView::ViewportAnchor>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsView::ViewportAnchor>::target_type & > (heap);
+  const qt_gsi::Converter<QGraphicsView::ViewportAnchor>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsView::ViewportAnchor>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setResizeAnchor (qt_gsi::QtToCppAdaptor<QGraphicsView::ViewportAnchor>(arg1).cref());
 }
@@ -1416,7 +1416,7 @@ static void _call_f_setRubberBandSelectionMode_2471 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ItemSelectionMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setRubberBandSelectionMode (qt_gsi::QtToCppAdaptor<Qt::ItemSelectionMode>(arg1).cref());
 }
@@ -1436,7 +1436,7 @@ static void _call_f_setScene_2014 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsScene *arg1 = args.read<QGraphicsScene * > (heap);
+  QGraphicsScene *arg1 = gsi::arg_reader<QGraphicsScene * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setScene (arg1);
 }
@@ -1456,7 +1456,7 @@ static void _call_f_setSceneRect_1862 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setSceneRect (arg1);
 }
@@ -1482,10 +1482,10 @@ static void _call_f_setSceneRect_3960 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setSceneRect (arg1, arg2, arg3, arg4);
 }
@@ -1507,8 +1507,8 @@ static void _call_f_setTransform_3106 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setTransform (arg1, arg2);
 }
@@ -1528,7 +1528,7 @@ static void _call_f_setTransformationAnchor_3328 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsView::ViewportAnchor>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsView::ViewportAnchor>::target_type & > (heap);
+  const qt_gsi::Converter<QGraphicsView::ViewportAnchor>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsView::ViewportAnchor>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setTransformationAnchor (qt_gsi::QtToCppAdaptor<QGraphicsView::ViewportAnchor>(arg1).cref());
 }
@@ -1548,7 +1548,7 @@ static void _call_f_setViewportUpdateMode_3725 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QGraphicsView::ViewportUpdateMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QGraphicsView::ViewportUpdateMode>::target_type & > (heap);
+  const qt_gsi::Converter<QGraphicsView::ViewportUpdateMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QGraphicsView::ViewportUpdateMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->setViewportUpdateMode (qt_gsi::QtToCppAdaptor<QGraphicsView::ViewportUpdateMode>(arg1).cref());
 }
@@ -1570,8 +1570,8 @@ static void _call_f_shear_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->shear (arg1, arg2);
 }
@@ -1638,8 +1638,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->translate (arg1, arg2);
 }
@@ -1659,7 +1659,7 @@ static void _call_f_updateScene_2477 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QRectF> &arg1 = args.read<const QList<QRectF> & > (heap);
+  const QList<QRectF> &arg1 = gsi::arg_reader<const QList<QRectF> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->updateScene (arg1);
 }
@@ -1679,7 +1679,7 @@ static void _call_f_updateSceneRect_1862 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView *)cls)->updateSceneRect (arg1);
 }
@@ -1731,8 +1731,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsView::tr (arg1, arg2));
 }
 
@@ -1755,9 +1755,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsView::tr (arg1, arg2, arg3));
 }
 
@@ -1778,8 +1778,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsView::trUtf8 (arg1, arg2));
 }
 
@@ -1802,9 +1802,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsView::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2834,7 +2834,7 @@ static void _call_ctor_QGraphicsView_Adaptor_1315 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QGraphicsView_Adaptor *> (new QGraphicsView_Adaptor (arg1));
 }
 
@@ -2854,8 +2854,8 @@ static void _call_ctor_QGraphicsView_Adaptor_3221 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsScene *arg1 = args.read<QGraphicsScene * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QGraphicsScene *arg1 = gsi::arg_reader<QGraphicsScene * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QGraphicsView_Adaptor *> (new QGraphicsView_Adaptor (arg1, arg2));
 }
 
@@ -2997,9 +2997,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView_Adaptor *)cls)->fp_QGraphicsView_create_2208 (arg1, arg2, arg3);
 }
@@ -3018,7 +3018,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QGraphicsView_Adaptor *)cls)->emitter_QGraphicsView_customContextMenuRequested_1916 (arg1);
 }
 
@@ -3062,8 +3062,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView_Adaptor *)cls)->fp_QGraphicsView_destroy_1620 (arg1, arg2);
 }
@@ -3082,7 +3082,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsView_Adaptor *)cls)->emitter_QGraphicsView_destroyed_1302 (arg1);
 }
 
@@ -3250,7 +3250,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView_Adaptor *)cls)->fp_QGraphicsView_drawFrame_1426 (arg1);
 }
@@ -3928,7 +3928,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsView_Adaptor *)cls)->fp_QGraphicsView_receivers_c1731 (arg1));
 }
 
@@ -4032,10 +4032,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView_Adaptor *)cls)->fp_QGraphicsView_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -4054,7 +4054,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView_Adaptor *)cls)->fp_QGraphicsView_setViewportMargins_2115 (arg1);
 }
@@ -4097,7 +4097,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsView_Adaptor *)cls)->fp_QGraphicsView_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGraphicsWidget.cc
@@ -123,7 +123,7 @@ static void _call_f_addAction_1309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->addAction (arg1);
 }
@@ -143,7 +143,7 @@ static void _call_f_addActions_1780 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QList<QAction*> arg1 = args.read<QList<QAction*> > (heap);
+  QList<QAction*> arg1 = gsi::arg_reader<QList<QAction*> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->addActions (arg1);
 }
@@ -275,10 +275,10 @@ static void _call_f_getContentsMargins_c4704 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->getContentsMargins (arg1, arg2, arg3, arg4);
 }
@@ -304,10 +304,10 @@ static void _call_f_getWindowFrameMargins_c4704 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->getWindowFrameMargins (arg1, arg2, arg3, arg4);
 }
@@ -329,8 +329,8 @@ static void _call_f_grabShortcut_4758 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
-  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ShortcutContext>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ShortcutContext>(heap, Qt::WindowShortcut));
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
+  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ShortcutContext>(heap, Qt::WindowShortcut), heap);
   ret.write<int > ((int)((QGraphicsWidget *)cls)->grabShortcut (arg1, qt_gsi::QtToCppAdaptor<Qt::ShortcutContext>(arg2).cref()));
 }
 
@@ -351,8 +351,8 @@ static void _call_f_insertAction_2510 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
-  QAction *arg2 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
+  QAction *arg2 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->insertAction (arg1, arg2);
 }
@@ -374,8 +374,8 @@ static void _call_f_insertActions_2981 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
-  QList<QAction*> arg2 = args.read<QList<QAction*> > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
+  QList<QAction*> arg2 = gsi::arg_reader<QList<QAction*> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->insertActions (arg1, arg2);
 }
@@ -444,9 +444,9 @@ static void _call_f_paint_6301 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->paint (arg1, arg2, arg3);
 }
@@ -470,9 +470,9 @@ static void _call_f_paintWindowFrame_6301 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionGraphicsItem *arg2 = args.read<const QStyleOptionGraphicsItem * > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionGraphicsItem *arg2 = gsi::arg_reader<const QStyleOptionGraphicsItem * >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->paintWindowFrame (arg1, arg2, arg3);
 }
@@ -522,7 +522,7 @@ static void _call_f_releaseShortcut_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->releaseShortcut (arg1);
 }
@@ -542,7 +542,7 @@ static void _call_f_removeAction_1309 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->removeAction (arg1);
 }
@@ -562,7 +562,7 @@ static void _call_f_resize_1875 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->resize (arg1);
 }
@@ -584,8 +584,8 @@ static void _call_f_resize_2034 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->resize (arg1, arg2);
 }
@@ -607,8 +607,8 @@ static void _call_f_setAttribute_3065 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setAttribute (qt_gsi::QtToCppAdaptor<Qt::WidgetAttribute>(arg1).cref(), arg2);
 }
@@ -634,10 +634,10 @@ static void _call_f_setContentsMargins_3960 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setContentsMargins (arg1, arg2, arg3, arg4);
 }
@@ -657,7 +657,7 @@ static void _call_f_setFocusPolicy_1885 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::FocusPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::FocusPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::FocusPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::FocusPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setFocusPolicy (qt_gsi::QtToCppAdaptor<Qt::FocusPolicy>(arg1).cref());
 }
@@ -677,7 +677,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setFont (arg1);
 }
@@ -697,7 +697,7 @@ static void _call_f_setGeometry_1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setGeometry (arg1);
 }
@@ -723,10 +723,10 @@ static void _call_f_setGeometry_3960 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setGeometry (arg1, arg2, arg3, arg4);
 }
@@ -746,7 +746,7 @@ static void _call_f_setLayout_2158 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsLayout *arg1 = args.read<QGraphicsLayout * > (heap);
+  QGraphicsLayout *arg1 = gsi::arg_reader<QGraphicsLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setLayout (arg1);
 }
@@ -766,7 +766,7 @@ static void _call_f_setLayoutDirection_2316 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setLayoutDirection (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref());
 }
@@ -786,7 +786,7 @@ static void _call_f_setPalette_2113 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setPalette (arg1);
 }
@@ -808,8 +808,8 @@ static void _call_f_setShortcutAutoRepeat_1523 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setShortcutAutoRepeat (arg1, arg2);
 }
@@ -831,8 +831,8 @@ static void _call_f_setShortcutEnabled_1523 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setShortcutEnabled (arg1, arg2);
 }
@@ -852,7 +852,7 @@ static void _call_f_setStyle_1232 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyle *arg1 = args.read<QStyle * > (heap);
+  QStyle *arg1 = gsi::arg_reader<QStyle * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setStyle (arg1);
 }
@@ -872,7 +872,7 @@ static void _call_f_setWindowFlags_2495 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::WindowType> arg1 = args.read<QFlags<Qt::WindowType> > (heap);
+  QFlags<Qt::WindowType> arg1 = gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setWindowFlags (arg1);
 }
@@ -898,10 +898,10 @@ static void _call_f_setWindowFrameMargins_3960 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setWindowFrameMargins (arg1, arg2, arg3, arg4);
 }
@@ -921,7 +921,7 @@ static void _call_f_setWindowTitle_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget *)cls)->setWindowTitle (arg1);
 }
@@ -986,7 +986,7 @@ static void _call_f_testAttribute_c2309 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QGraphicsWidget *)cls)->testAttribute (qt_gsi::QtToCppAdaptor<Qt::WidgetAttribute>(arg1).cref()));
 }
 
@@ -1129,8 +1129,8 @@ static void _call_f_setTabOrder_4156 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsWidget *arg1 = args.read<QGraphicsWidget * > (heap);
-  QGraphicsWidget *arg2 = args.read<QGraphicsWidget * > (heap);
+  QGraphicsWidget *arg1 = gsi::arg_reader<QGraphicsWidget * >() (args, heap);
+  QGraphicsWidget *arg2 = gsi::arg_reader<QGraphicsWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QGraphicsWidget::setTabOrder (arg1, arg2);
 }
@@ -1152,8 +1152,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsWidget::tr (arg1, arg2));
 }
 
@@ -1176,9 +1176,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsWidget::tr (arg1, arg2, arg3));
 }
 
@@ -1199,8 +1199,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGraphicsWidget::trUtf8 (arg1, arg2));
 }
 
@@ -1223,9 +1223,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGraphicsWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2497,8 +2497,8 @@ static void _call_ctor_QGraphicsWidget_Adaptor_4306 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args ? args.read<QGraphicsItem * > (heap) : (QGraphicsItem *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QGraphicsItem *arg1 = args ? gsi::arg_reader<QGraphicsItem * >() (args, heap) : gsi::arg_maker<QGraphicsItem * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QGraphicsWidget_Adaptor *> (new QGraphicsWidget_Adaptor (arg1, arg2));
 }
 
@@ -2769,7 +2769,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGraphicsWidget_Adaptor *)cls)->emitter_QGraphicsWidget_destroyed_1302 (arg1);
 }
 
@@ -3697,7 +3697,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGraphicsWidget_Adaptor *)cls)->fp_QGraphicsWidget_receivers_c1731 (arg1));
 }
 
@@ -3896,7 +3896,7 @@ static void _call_fp_setGraphicsItem_1919 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsItem *arg1 = args.read<QGraphicsItem * > (heap);
+  QGraphicsItem *arg1 = gsi::arg_reader<QGraphicsItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget_Adaptor *)cls)->fp_QGraphicsWidget_setGraphicsItem_1919 (arg1);
 }
@@ -3915,7 +3915,7 @@ static void _call_fp_setOwnedByLayout_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGraphicsWidget_Adaptor *)cls)->fp_QGraphicsWidget_setOwnedByLayout_864 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGridLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGridLayout.cc
@@ -85,12 +85,12 @@ static void _call_f_addItem_7018 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayoutItem *arg1 = args.read<QLayoutItem * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(1);
-  int arg5 = args ? args.read<int > (heap) : (int)(1);
-  QFlags<Qt::AlignmentFlag> arg6 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  QLayoutItem *arg1 = gsi::arg_reader<QLayoutItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
+  QFlags<Qt::AlignmentFlag> arg6 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->addItem (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -116,11 +116,11 @@ static void _call_f_addLayout_5301 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  QFlags<Qt::AlignmentFlag> arg4 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->addLayout (arg1, arg2, arg3, arg4);
 }
@@ -150,13 +150,13 @@ static void _call_f_addLayout_6619 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  QFlags<Qt::AlignmentFlag> arg6 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg6 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->addLayout (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -176,7 +176,7 @@ static void _call_f_addWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->addWidget (arg1);
 }
@@ -202,10 +202,10 @@ static void _call_f_addWidget_5275 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  QFlags<Qt::AlignmentFlag> arg4 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->addWidget (arg1, arg2, arg3, arg4);
 }
@@ -235,12 +235,12 @@ static void _call_f_addWidget_6593 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  QFlags<Qt::AlignmentFlag> arg6 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg6 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->addWidget (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -262,8 +262,8 @@ static void _call_f_cellRect_c1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRect > ((QRect)((QGridLayout *)cls)->cellRect (arg1, arg2));
 }
 
@@ -297,7 +297,7 @@ static void _call_f_columnMinimumWidth_c767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QGridLayout *)cls)->columnMinimumWidth (arg1));
 }
 
@@ -316,7 +316,7 @@ static void _call_f_columnStretch_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QGridLayout *)cls)->columnStretch (arg1));
 }
 
@@ -373,11 +373,11 @@ static void _call_f_getItemPosition_4147 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
-  int *arg5 = args.read<int * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
+  int *arg5 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->getItemPosition (arg1, arg2, arg3, arg4, arg5);
 }
@@ -412,7 +412,7 @@ static void _call_f_heightForWidth_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QGridLayout *)cls)->heightForWidth (arg1));
 }
 
@@ -462,7 +462,7 @@ static void _call_f_itemAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QGridLayout *)cls)->itemAt (arg1));
 }
 
@@ -483,8 +483,8 @@ static void _call_f_itemAtPosition_c1426 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QGridLayout *)cls)->itemAtPosition (arg1, arg2));
 }
 
@@ -518,7 +518,7 @@ static void _call_f_minimumHeightForWidth_c767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QGridLayout *)cls)->minimumHeightForWidth (arg1));
 }
 
@@ -582,7 +582,7 @@ static void _call_f_rowMinimumHeight_c767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QGridLayout *)cls)->rowMinimumHeight (arg1));
 }
 
@@ -601,7 +601,7 @@ static void _call_f_rowStretch_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QGridLayout *)cls)->rowStretch (arg1));
 }
 
@@ -622,8 +622,8 @@ static void _call_f_setColumnMinimumWidth_1426 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setColumnMinimumWidth (arg1, arg2);
 }
@@ -645,8 +645,8 @@ static void _call_f_setColumnStretch_1426 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setColumnStretch (arg1, arg2);
 }
@@ -668,8 +668,8 @@ static void _call_f_setDefaultPositioning_2572 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setDefaultPositioning (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref());
 }
@@ -689,7 +689,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setGeometry (arg1);
 }
@@ -709,7 +709,7 @@ static void _call_f_setHorizontalSpacing_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setHorizontalSpacing (arg1);
 }
@@ -729,7 +729,7 @@ static void _call_f_setOriginCorner_1366 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Corner>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Corner>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setOriginCorner (qt_gsi::QtToCppAdaptor<Qt::Corner>(arg1).cref());
 }
@@ -751,8 +751,8 @@ static void _call_f_setRowMinimumHeight_1426 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setRowMinimumHeight (arg1, arg2);
 }
@@ -774,8 +774,8 @@ static void _call_f_setRowStretch_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setRowStretch (arg1, arg2);
 }
@@ -795,7 +795,7 @@ static void _call_f_setSpacing_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setSpacing (arg1);
 }
@@ -815,7 +815,7 @@ static void _call_f_setVerticalSpacing_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout *)cls)->setVerticalSpacing (arg1);
 }
@@ -865,7 +865,7 @@ static void _call_f_takeAt_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QGridLayout *)cls)->takeAt (arg1));
 }
 
@@ -901,8 +901,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGridLayout::tr (arg1, arg2));
 }
 
@@ -925,9 +925,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGridLayout::tr (arg1, arg2, arg3));
 }
 
@@ -948,8 +948,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGridLayout::trUtf8 (arg1, arg2));
 }
 
@@ -972,9 +972,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGridLayout::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1515,7 +1515,7 @@ static void _call_ctor_QGridLayout_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QGridLayout_Adaptor *> (new QGridLayout_Adaptor (arg1));
 }
 
@@ -1547,7 +1547,7 @@ static void _call_fp_addChildLayout_1341 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout_Adaptor *)cls)->fp_QGridLayout_addChildLayout_1341 (arg1);
@@ -1567,7 +1567,7 @@ static void _call_fp_addChildWidget_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout_Adaptor *)cls)->fp_QGridLayout_addChildWidget_1315 (arg1);
 }
@@ -1610,7 +1610,7 @@ static void _call_fp_alignmentRect_c1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QGridLayout_Adaptor *)cls)->fp_QGridLayout_alignmentRect_c1792 (arg1));
 }
 
@@ -1695,7 +1695,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGridLayout_Adaptor *)cls)->emitter_QGridLayout_destroyed_1302 (arg1);
 }
 
@@ -2031,7 +2031,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGridLayout_Adaptor *)cls)->fp_QGridLayout_receivers_c1731 (arg1));
 }
 
@@ -2191,7 +2191,7 @@ static void _call_fp_widgetEvent_1217 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGridLayout_Adaptor *)cls)->fp_QGridLayout_widgetEvent_1217 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQGroupBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQGroupBox.cc
@@ -187,7 +187,7 @@ static void _call_f_setAlignment_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGroupBox *)cls)->setAlignment (arg1);
 }
@@ -207,7 +207,7 @@ static void _call_f_setCheckable_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGroupBox *)cls)->setCheckable (arg1);
 }
@@ -227,7 +227,7 @@ static void _call_f_setChecked_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGroupBox *)cls)->setChecked (arg1);
 }
@@ -247,7 +247,7 @@ static void _call_f_setFlat_864 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGroupBox *)cls)->setFlat (arg1);
 }
@@ -267,7 +267,7 @@ static void _call_f_setTitle_2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGroupBox *)cls)->setTitle (arg1);
 }
@@ -304,8 +304,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGroupBox::tr (arg1, arg2));
 }
 
@@ -328,9 +328,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGroupBox::tr (arg1, arg2, arg3));
 }
 
@@ -351,8 +351,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QGroupBox::trUtf8 (arg1, arg2));
 }
 
@@ -375,9 +375,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QGroupBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1273,7 +1273,7 @@ static void _call_ctor_QGroupBox_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QGroupBox_Adaptor *> (new QGroupBox_Adaptor (arg1));
 }
 
@@ -1293,8 +1293,8 @@ static void _call_ctor_QGroupBox_Adaptor_3232 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QGroupBox_Adaptor *> (new QGroupBox_Adaptor (arg1, arg2));
 }
 
@@ -1384,7 +1384,7 @@ static void _call_emitter_clicked_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ((QGroupBox_Adaptor *)cls)->emitter_QGroupBox_clicked_864 (arg1);
 }
 
@@ -1454,9 +1454,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGroupBox_Adaptor *)cls)->fp_QGroupBox_create_2208 (arg1, arg2, arg3);
 }
@@ -1475,7 +1475,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QGroupBox_Adaptor *)cls)->emitter_QGroupBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1519,8 +1519,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGroupBox_Adaptor *)cls)->fp_QGroupBox_destroy_1620 (arg1, arg2);
 }
@@ -1539,7 +1539,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QGroupBox_Adaptor *)cls)->emitter_QGroupBox_destroyed_1302 (arg1);
 }
 
@@ -1944,7 +1944,7 @@ static void _call_fp_initStyleOption_c2687 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionGroupBox *arg1 = args.read<QStyleOptionGroupBox * > (heap);
+  QStyleOptionGroupBox *arg1 = gsi::arg_reader<QStyleOptionGroupBox * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QGroupBox_Adaptor *)cls)->fp_QGroupBox_initStyleOption_c2687 (arg1);
 }
@@ -2331,7 +2331,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QGroupBox_Adaptor *)cls)->fp_QGroupBox_receivers_c1731 (arg1));
 }
 
@@ -2541,7 +2541,7 @@ static void _call_emitter_toggled_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QGroupBox_Adaptor *)cls)->emitter_QGroupBox_toggled_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQHBoxLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQHBoxLayout.cc
@@ -77,8 +77,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QHBoxLayout::tr (arg1, arg2));
 }
 
@@ -101,9 +101,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QHBoxLayout::tr (arg1, arg2, arg3));
 }
 
@@ -124,8 +124,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QHBoxLayout::trUtf8 (arg1, arg2));
 }
 
@@ -148,9 +148,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QHBoxLayout::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -670,7 +670,7 @@ static void _call_ctor_QHBoxLayout_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QHBoxLayout_Adaptor *> (new QHBoxLayout_Adaptor (arg1));
 }
 
@@ -688,7 +688,7 @@ static void _call_fp_addChildLayout_1341 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHBoxLayout_Adaptor *)cls)->fp_QHBoxLayout_addChildLayout_1341 (arg1);
@@ -708,7 +708,7 @@ static void _call_fp_addChildWidget_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHBoxLayout_Adaptor *)cls)->fp_QHBoxLayout_addChildWidget_1315 (arg1);
 }
@@ -751,7 +751,7 @@ static void _call_fp_alignmentRect_c1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QHBoxLayout_Adaptor *)cls)->fp_QHBoxLayout_alignmentRect_c1792 (arg1));
 }
 
@@ -836,7 +836,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QHBoxLayout_Adaptor *)cls)->emitter_QHBoxLayout_destroyed_1302 (arg1);
 }
 
@@ -1032,8 +1032,8 @@ static void _call_fp_insertItem_2399 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QLayoutItem *arg2 = args.read<QLayoutItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QLayoutItem *arg2 = gsi::arg_reader<QLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHBoxLayout_Adaptor *)cls)->fp_QHBoxLayout_insertItem_2399 (arg1, arg2);
 }
@@ -1194,7 +1194,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QHBoxLayout_Adaptor *)cls)->fp_QHBoxLayout_receivers_c1731 (arg1));
 }
 
@@ -1354,7 +1354,7 @@ static void _call_fp_widgetEvent_1217 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHBoxLayout_Adaptor *)cls)->fp_QHBoxLayout_widgetEvent_1217 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQHeaderView.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQHeaderView.cc
@@ -199,9 +199,9 @@ static void _call_f_headerDataChanged_3231 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->headerDataChanged (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref(), arg2, arg3);
 }
@@ -236,7 +236,7 @@ static void _call_f_hideSection_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->hideSection (arg1);
 }
@@ -301,7 +301,7 @@ static void _call_f_isSectionHidden_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QHeaderView *)cls)->isSectionHidden (arg1));
 }
 
@@ -350,7 +350,7 @@ static void _call_f_logicalIndex_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->logicalIndex (arg1));
 }
 
@@ -369,7 +369,7 @@ static void _call_f_logicalIndexAt_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->logicalIndexAt (arg1));
 }
 
@@ -390,8 +390,8 @@ static void _call_f_logicalIndexAt_c1426 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->logicalIndexAt (arg1, arg2));
 }
 
@@ -410,7 +410,7 @@ static void _call_f_logicalIndexAt_c1916 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->logicalIndexAt (arg1));
 }
 
@@ -446,8 +446,8 @@ static void _call_f_moveSection_1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->moveSection (arg1, arg2);
 }
@@ -513,7 +513,7 @@ static void _call_f_resizeMode_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<qt_gsi::Converter<QHeaderView::ResizeMode>::target_type > ((qt_gsi::Converter<QHeaderView::ResizeMode>::target_type)qt_gsi::CppToQtAdaptor<QHeaderView::ResizeMode>(((QHeaderView *)cls)->resizeMode (arg1)));
 }
 
@@ -534,8 +534,8 @@ static void _call_f_resizeSection_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->resizeSection (arg1, arg2);
 }
@@ -555,7 +555,7 @@ static void _call_f_resizeSections_2644 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & > (heap);
+  const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->resizeSections (qt_gsi::QtToCppAdaptor<QHeaderView::ResizeMode>(arg1).cref());
 }
@@ -575,7 +575,7 @@ static void _call_f_restoreState_2309 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<bool > ((bool)((QHeaderView *)cls)->restoreState (arg1));
 }
 
@@ -609,7 +609,7 @@ static void _call_f_sectionPosition_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->sectionPosition (arg1));
 }
 
@@ -628,7 +628,7 @@ static void _call_f_sectionSize_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->sectionSize (arg1));
 }
 
@@ -647,7 +647,7 @@ static void _call_f_sectionSizeHint_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->sectionSizeHint (arg1));
 }
 
@@ -666,7 +666,7 @@ static void _call_f_sectionViewportPosition_c767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->sectionViewportPosition (arg1));
 }
 
@@ -715,7 +715,7 @@ static void _call_f_setCascadingSectionResizes_864 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setCascadingSectionResizes (arg1);
 }
@@ -735,7 +735,7 @@ static void _call_f_setClickable_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setClickable (arg1);
 }
@@ -755,7 +755,7 @@ static void _call_f_setDefaultAlignment_2750 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setDefaultAlignment (arg1);
 }
@@ -775,7 +775,7 @@ static void _call_f_setDefaultSectionSize_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setDefaultSectionSize (arg1);
 }
@@ -795,7 +795,7 @@ static void _call_f_setHighlightSections_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setHighlightSections (arg1);
 }
@@ -815,7 +815,7 @@ static void _call_f_setMinimumSectionSize_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setMinimumSectionSize (arg1);
 }
@@ -835,7 +835,7 @@ static void _call_f_setModel_2419 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setModel (arg1);
 }
@@ -855,7 +855,7 @@ static void _call_f_setMovable_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setMovable (arg1);
 }
@@ -875,7 +875,7 @@ static void _call_f_setOffset_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setOffset (arg1);
 }
@@ -911,7 +911,7 @@ static void _call_f_setOffsetToSectionPosition_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setOffsetToSectionPosition (arg1);
 }
@@ -931,7 +931,7 @@ static void _call_f_setResizeMode_2644 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & > (heap);
+  const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setResizeMode (qt_gsi::QtToCppAdaptor<QHeaderView::ResizeMode>(arg1).cref());
 }
@@ -953,8 +953,8 @@ static void _call_f_setResizeMode_3303 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & arg2 = args.read<const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setResizeMode (arg1, qt_gsi::QtToCppAdaptor<QHeaderView::ResizeMode>(arg2).cref());
 }
@@ -976,8 +976,8 @@ static void _call_f_setSectionHidden_1523 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setSectionHidden (arg1, arg2);
 }
@@ -999,8 +999,8 @@ static void _call_f_setSortIndicator_2340 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setSortIndicator (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -1020,7 +1020,7 @@ static void _call_f_setSortIndicatorShown_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setSortIndicatorShown (arg1);
 }
@@ -1040,7 +1040,7 @@ static void _call_f_setStretchLastSection_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->setStretchLastSection (arg1);
 }
@@ -1060,7 +1060,7 @@ static void _call_f_showSection_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->showSection (arg1);
 }
@@ -1157,8 +1157,8 @@ static void _call_f_swapSections_1426 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView *)cls)->swapSections (arg1, arg2);
 }
@@ -1178,7 +1178,7 @@ static void _call_f_visualIndex_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->visualIndex (arg1));
 }
 
@@ -1197,7 +1197,7 @@ static void _call_f_visualIndexAt_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QHeaderView *)cls)->visualIndexAt (arg1));
 }
 
@@ -1218,8 +1218,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QHeaderView::tr (arg1, arg2));
 }
 
@@ -1242,9 +1242,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QHeaderView::tr (arg1, arg2, arg3));
 }
 
@@ -1265,8 +1265,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QHeaderView::trUtf8 (arg1, arg2));
 }
 
@@ -1289,9 +1289,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QHeaderView::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -3133,8 +3133,8 @@ static void _call_ctor_QHeaderView_Adaptor_3120 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QHeaderView_Adaptor *> (new QHeaderView_Adaptor (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref(), arg2));
 }
 
@@ -3176,7 +3176,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_activated_2395 (arg1);
 }
 
@@ -3242,7 +3242,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_clicked_2395 (arg1);
 }
 
@@ -3363,9 +3363,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_create_2208 (arg1, arg2, arg3);
 }
@@ -3411,7 +3411,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_customContextMenuRequested_1916 (arg1);
 }
 
@@ -3482,8 +3482,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_destroy_1620 (arg1, arg2);
 }
@@ -3502,7 +3502,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_destroyed_1302 (arg1);
 }
 
@@ -3593,7 +3593,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_doubleClicked_2395 (arg1);
 }
 
@@ -3683,7 +3683,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_drawFrame_1426 (arg1);
 }
@@ -3841,7 +3841,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_entered_2395 (arg1);
 }
 
@@ -4211,7 +4211,7 @@ static void _call_fp_initStyleOption_c2450 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionHeader *arg1 = args.read<QStyleOptionHeader * > (heap);
+  QStyleOptionHeader *arg1 = gsi::arg_reader<QStyleOptionHeader * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_initStyleOption_c2450 (arg1);
 }
@@ -4262,8 +4262,8 @@ static void _call_fp_initializeSections_1426 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_initializeSections_1426 (arg1, arg2);
 }
@@ -4753,7 +4753,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_pressed_2395 (arg1);
 }
 
@@ -4771,7 +4771,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QHeaderView_Adaptor *)cls)->fp_QHeaderView_receivers_c1731 (arg1));
 }
 
@@ -4967,8 +4967,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -5016,8 +5016,8 @@ static void _call_emitter_sectionAutoResize_3303 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & arg2 = args.read<const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QHeaderView::ResizeMode>::target_type & >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sectionAutoResize_3303 (arg1, arg2);
 }
 
@@ -5035,7 +5035,7 @@ static void _call_emitter_sectionClicked_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sectionClicked_767 (arg1);
 }
 
@@ -5055,8 +5055,8 @@ static void _call_emitter_sectionCountChanged_1426 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sectionCountChanged_1426 (arg1, arg2);
 }
 
@@ -5074,7 +5074,7 @@ static void _call_emitter_sectionDoubleClicked_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sectionDoubleClicked_767 (arg1);
 }
 
@@ -5092,7 +5092,7 @@ static void _call_emitter_sectionEntered_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sectionEntered_767 (arg1);
 }
 
@@ -5110,7 +5110,7 @@ static void _call_emitter_sectionHandleDoubleClicked_767 (const qt_gsi::GenericM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sectionHandleDoubleClicked_767 (arg1);
 }
 
@@ -5132,9 +5132,9 @@ static void _call_emitter_sectionMoved_2085 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sectionMoved_2085 (arg1, arg2, arg3);
 }
 
@@ -5152,7 +5152,7 @@ static void _call_emitter_sectionPressed_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sectionPressed_767 (arg1);
 }
 
@@ -5174,9 +5174,9 @@ static void _call_emitter_sectionResized_2085 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sectionResized_2085 (arg1, arg2, arg3);
 }
 
@@ -5221,9 +5221,9 @@ static void _call_fp_sectionsAboutToBeRemoved_3713 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_sectionsAboutToBeRemoved_3713 (arg1, arg2, arg3);
 }
@@ -5246,9 +5246,9 @@ static void _call_fp_sectionsInserted_3713 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_sectionsInserted_3713 (arg1, arg2, arg3);
 }
@@ -5373,7 +5373,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_setDirtyRegion_2006 (arg1);
 }
@@ -5392,7 +5392,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -5510,7 +5510,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_setState_2776 (arg1);
 }
@@ -5529,7 +5529,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_setVerticalStepsPerItem_767 (arg1);
 }
@@ -5554,10 +5554,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -5576,7 +5576,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_setViewportMargins_2115 (arg1);
 }
@@ -5619,7 +5619,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_setupViewport_1315 (arg1);
 }
@@ -5729,8 +5729,8 @@ static void _call_emitter_sortIndicatorChanged_2340 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
   ((QHeaderView_Adaptor *)cls)->emitter_QHeaderView_sortIndicatorChanged_2340 (arg1, arg2);
 }
 
@@ -5963,7 +5963,7 @@ static void _call_fp_updateSection_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHeaderView_Adaptor *)cls)->fp_QHeaderView_updateSection_767 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQHelpEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQHelpEvent.cc
@@ -186,9 +186,9 @@ static void _call_ctor_QHelpEvent_Adaptor_5181 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QHelpEvent_Adaptor *> (new QHelpEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQHoverEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQHoverEvent.cc
@@ -122,9 +122,9 @@ static void _call_ctor_QHoverEvent_Adaptor_5181 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QHoverEvent_Adaptor *> (new QHoverEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQIcon.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQIcon.cc
@@ -71,7 +71,7 @@ static void _call_ctor_QIcon_2017 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QIcon *> (new QIcon (arg1));
 }
 
@@ -90,7 +90,7 @@ static void _call_ctor_QIcon_1787 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   ret.write<QIcon *> (new QIcon (arg1));
 }
 
@@ -109,7 +109,7 @@ static void _call_ctor_QIcon_2025 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QIcon *> (new QIcon (arg1));
 }
 
@@ -128,7 +128,7 @@ static void _call_ctor_QIcon_1694 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIconEngine *arg1 = args.read<QIconEngine * > (heap);
+  QIconEngine *arg1 = gsi::arg_reader<QIconEngine * >() (args, heap);
   ret.write<QIcon *> (new QIcon (arg1));
 }
 
@@ -147,7 +147,7 @@ static void _call_ctor_QIcon_1830 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIconEngineV2 *arg1 = args.read<QIconEngineV2 * > (heap);
+  QIconEngineV2 *arg1 = gsi::arg_reader<QIconEngineV2 * >() (args, heap);
   ret.write<QIcon *> (new QIcon (arg1));
 }
 
@@ -170,9 +170,9 @@ static void _call_f_actualSize_c4543 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   ret.write<QSize > ((QSize)((QIcon *)cls)->actualSize (arg1, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg2).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg3).cref()));
 }
 
@@ -197,10 +197,10 @@ static void _call_f_addFile_6460 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QSize &arg2 = args ? args.read<const QSize & > (heap) : (const QSize &)(QSize());
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QSize &arg2 = args ? gsi::arg_reader<const QSize & >() (args, heap) : gsi::arg_maker<const QSize & >() (QSize(), heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIcon *)cls)->addFile (arg1, arg2, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg3).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg4).cref());
 }
@@ -224,9 +224,9 @@ static void _call_f_addPixmap_4755 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIcon *)cls)->addPixmap (arg1, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg2).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg3).cref());
 }
@@ -248,8 +248,8 @@ static void _call_f_availableSizes_c2846 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   ret.write<QList<QSize> > ((QList<QSize>)((QIcon *)cls)->availableSizes (qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg1).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg2).cref()));
 }
 
@@ -329,7 +329,7 @@ static void _call_f_operator_eq__1787 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   ret.write<QIcon & > ((QIcon &)((QIcon *)cls)->operator= (arg1));
 }
 
@@ -356,11 +356,11 @@ static void _call_f_paint_c8490 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  QFlags<Qt::AlignmentFlag> arg3 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(Qt::AlignCenter);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg3 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (Qt::AlignCenter, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIcon *)cls)->paint (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg4).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg5).cref());
 }
@@ -394,14 +394,14 @@ static void _call_f_paint_c9442 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  QFlags<Qt::AlignmentFlag> arg6 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(Qt::AlignCenter);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg7 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg8 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg6 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (Qt::AlignCenter, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg7 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg8 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIcon *)cls)->paint (arg1, arg2, arg3, arg4, arg5, arg6, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg7).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg8).cref());
 }
@@ -425,9 +425,9 @@ static void _call_f_pixmap_c4543 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   ret.write<QPixmap > ((QPixmap)((QIcon *)cls)->pixmap (arg1, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg2).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg3).cref()));
 }
 
@@ -452,10 +452,10 @@ static void _call_f_pixmap_c4164 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   ret.write<QPixmap > ((QPixmap)((QIcon *)cls)->pixmap (arg1, arg2, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg3).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg4).cref()));
 }
 
@@ -478,9 +478,9 @@ static void _call_f_pixmap_c3505 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   ret.write<QPixmap > ((QPixmap)((QIcon *)cls)->pixmap (arg1, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg2).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg3).cref()));
 }
 
@@ -516,8 +516,8 @@ static void _call_f_fromTheme_3704 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QIcon &arg2 = args ? args.read<const QIcon & > (heap) : (const QIcon &)(QIcon());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QIcon &arg2 = args ? gsi::arg_reader<const QIcon & >() (args, heap) : gsi::arg_maker<const QIcon & >() (QIcon(), heap);
   ret.write<QIcon > ((QIcon)QIcon::fromTheme (arg1, arg2));
 }
 
@@ -536,7 +536,7 @@ static void _call_f_hasThemeIcon_2025 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QIcon::hasThemeIcon (arg1));
 }
 
@@ -555,7 +555,7 @@ static void _call_f_setThemeName_2025 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QIcon::setThemeName (arg1);
 }
@@ -575,7 +575,7 @@ static void _call_f_setThemeSearchPaths_2437 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QIcon::setThemeSearchPaths (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQIconEngine.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQIconEngine.cc
@@ -58,9 +58,9 @@ static void _call_f_actualSize_4543 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap);
-  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap);
   ret.write<QSize > ((QSize)((QIconEngine *)cls)->actualSize (arg1, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg2).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg3).cref()));
 }
 
@@ -85,10 +85,10 @@ static void _call_f_addFile_6460 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QSize &arg2 = args.read<const QSize & > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg3 = args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap);
-  const qt_gsi::Converter<QIcon::State>::target_type & arg4 = args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QSize &arg2 = gsi::arg_reader<const QSize & >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg4 = gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIconEngine *)cls)->addFile (arg1, arg2, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg3).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg4).cref());
 }
@@ -112,9 +112,9 @@ static void _call_f_addPixmap_4755 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap);
-  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIconEngine *)cls)->addPixmap (arg1, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg2).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg3).cref());
 }
@@ -140,10 +140,10 @@ static void _call_f_paint_5848 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg3 = args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap);
-  const qt_gsi::Converter<QIcon::State>::target_type & arg4 = args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg4 = gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIconEngine *)cls)->paint (arg1, arg2, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg3).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg4).cref());
 }
@@ -167,9 +167,9 @@ static void _call_f_pixmap_4543 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap);
-  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap);
   ret.write<QPixmap > ((QPixmap)((QIconEngine *)cls)->pixmap (arg1, qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg2).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg3).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQIconEnginePlugin.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQIconEnginePlugin.cc
@@ -69,7 +69,7 @@ static void _call_f_create_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QIconEngine * > ((QIconEngine *)((QIconEnginePlugin *)cls)->create (arg1));
 }
 
@@ -105,8 +105,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QIconEnginePlugin::tr (arg1, arg2));
 }
 
@@ -129,9 +129,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QIconEnginePlugin::tr (arg1, arg2, arg3));
 }
 
@@ -152,8 +152,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QIconEnginePlugin::trUtf8 (arg1, arg2));
 }
 
@@ -176,9 +176,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QIconEnginePlugin::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -390,7 +390,7 @@ static void _call_ctor_QIconEnginePlugin_Adaptor_1302 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QIconEnginePlugin_Adaptor *> (new QIconEnginePlugin_Adaptor (arg1));
 }
 
@@ -479,7 +479,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QIconEnginePlugin_Adaptor *)cls)->emitter_QIconEnginePlugin_destroyed_1302 (arg1);
 }
 
@@ -589,7 +589,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QIconEnginePlugin_Adaptor *)cls)->fp_QIconEnginePlugin_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQIconEnginePluginV2.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQIconEnginePluginV2.cc
@@ -69,7 +69,7 @@ static void _call_f_create_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QIconEngineV2 * > ((QIconEngineV2 *)((QIconEnginePluginV2 *)cls)->create (arg1));
 }
 
@@ -105,8 +105,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QIconEnginePluginV2::tr (arg1, arg2));
 }
 
@@ -129,9 +129,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QIconEnginePluginV2::tr (arg1, arg2, arg3));
 }
 
@@ -152,8 +152,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QIconEnginePluginV2::trUtf8 (arg1, arg2));
 }
 
@@ -176,9 +176,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QIconEnginePluginV2::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -390,7 +390,7 @@ static void _call_ctor_QIconEnginePluginV2_Adaptor_1302 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QIconEnginePluginV2_Adaptor *> (new QIconEnginePluginV2_Adaptor (arg1));
 }
 
@@ -479,7 +479,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QIconEnginePluginV2_Adaptor *)cls)->emitter_QIconEnginePluginV2_destroyed_1302 (arg1);
 }
 
@@ -589,7 +589,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QIconEnginePluginV2_Adaptor *)cls)->fp_QIconEnginePluginV2_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQIconEngineV2.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQIconEngineV2.cc
@@ -57,8 +57,8 @@ static void _call_f_availableSizes_2846 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::Mode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal));
-  const qt_gsi::Converter<QIcon::State>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QIcon::State>::target_type & > (heap) : (const qt_gsi::Converter<QIcon::State>::target_type &)(qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off));
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::Mode>(heap, QIcon::Normal), heap);
+  const qt_gsi::Converter<QIcon::State>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QIcon::State>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QIcon::State>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QIcon::State>(heap, QIcon::Off), heap);
   ret.write<QList<QSize> > ((QList<QSize>)((QIconEngineV2 *)cls)->availableSizes (qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg1).cref(), qt_gsi::QtToCppAdaptor<QIcon::State>(arg2).cref()));
 }
 
@@ -107,7 +107,7 @@ static void _call_f_read_1697 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QIconEngineV2 *)cls)->read (arg1));
 }
 
@@ -128,8 +128,8 @@ static void _call_f_virtual_hook_1715 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  void *arg2 = args.read<void * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  void *arg2 = gsi::arg_reader<void * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIconEngineV2 *)cls)->virtual_hook (arg1, arg2);
 }
@@ -149,7 +149,7 @@ static void _call_f_write_c1697 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QIconEngineV2 *)cls)->write (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQImage.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQImage.cc
@@ -148,7 +148,7 @@ static void _call_f_color_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<unsigned int > ((unsigned int)((QImage *)cls)->color (arg1));
 }
 
@@ -199,8 +199,8 @@ static void _call_f_convertToFormat_c4993 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QImage::Format>::target_type & arg1 = args.read<const qt_gsi::Converter<QImage::Format>::target_type & > (heap);
-  QFlags<Qt::ImageConversionFlag> arg2 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const qt_gsi::Converter<QImage::Format>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QImage::Format>::target_type & >() (args, heap);
+  QFlags<Qt::ImageConversionFlag> arg2 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->convertToFormat (qt_gsi::QtToCppAdaptor<QImage::Format>(arg1).cref(), arg2));
 }
 
@@ -223,9 +223,9 @@ static void _call_f_convertToFormat_c7392 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QImage::Format>::target_type & arg1 = args.read<const qt_gsi::Converter<QImage::Format>::target_type & > (heap);
-  const QVector<QRgb> &arg2 = args.read<const QVector<QRgb> & > (heap);
-  QFlags<Qt::ImageConversionFlag> arg3 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const qt_gsi::Converter<QImage::Format>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QImage::Format>::target_type & >() (args, heap);
+  const QVector<QRgb> &arg2 = gsi::arg_reader<const QVector<QRgb> & >() (args, heap);
+  QFlags<Qt::ImageConversionFlag> arg3 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->convertToFormat (qt_gsi::QtToCppAdaptor<QImage::Format>(arg1).cref(), arg2, arg3));
 }
 
@@ -244,7 +244,7 @@ static void _call_f_copy_c1792 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args ? args.read<const QRect & > (heap) : (const QRect &)(QRect());
+  const QRect &arg1 = args ? gsi::arg_reader<const QRect & >() (args, heap) : gsi::arg_maker<const QRect & >() (QRect(), heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->copy (arg1));
 }
 
@@ -269,10 +269,10 @@ static void _call_f_copy_c2744 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->copy (arg1, arg2, arg3, arg4));
 }
 
@@ -291,7 +291,7 @@ static void _call_f_createAlphaMask_c3368 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::ImageConversionFlag> arg1 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  QFlags<Qt::ImageConversionFlag> arg1 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->createAlphaMask (arg1));
 }
 
@@ -310,7 +310,7 @@ static void _call_f_createHeuristicMask_c864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->createHeuristicMask (arg1));
 }
 
@@ -331,8 +331,8 @@ static void _call_f_createMaskFromColor_c3198 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
-  const qt_gsi::Converter<Qt::MaskMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::MaskMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::MaskMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::MaskMode>(heap, Qt::MaskInColor));
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
+  const qt_gsi::Converter<Qt::MaskMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::MaskMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::MaskMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::MaskMode>(heap, Qt::MaskInColor), heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->createMaskFromColor (arg1, qt_gsi::QtToCppAdaptor<Qt::MaskMode>(arg2).cref()));
 }
 
@@ -412,7 +412,7 @@ static void _call_f_fill_1772 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->fill (arg1);
 }
@@ -477,7 +477,7 @@ static void _call_f_invertPixels_2137 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QImage::InvertMode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QImage::InvertMode>::target_type & > (heap) : (const qt_gsi::Converter<QImage::InvertMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QImage::InvertMode>(heap, QImage::InvertRgb));
+  const qt_gsi::Converter<QImage::InvertMode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QImage::InvertMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QImage::InvertMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QImage::InvertMode>(heap, QImage::InvertRgb), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->invertPixels (qt_gsi::QtToCppAdaptor<QImage::InvertMode>(arg1).cref());
 }
@@ -544,8 +544,8 @@ static void _call_f_load_3070 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<bool > ((bool)((QImage *)cls)->load (arg1, arg2));
 }
 
@@ -566,8 +566,8 @@ static void _call_f_load_3648 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<bool > ((bool)((QImage *)cls)->load (arg1, arg2));
 }
 
@@ -590,9 +590,9 @@ static void _call_f_loadFromData_5018 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const unsigned char *arg1 = args.read<const unsigned char * > (heap);
-  int arg2 = args.read<int > (heap);
-  const char *arg3 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const unsigned char *arg1 = gsi::arg_reader<const unsigned char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const char *arg3 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<bool > ((bool)((QImage *)cls)->loadFromData (arg1, arg2, arg3));
 }
 
@@ -613,8 +613,8 @@ static void _call_f_loadFromData_3932 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<bool > ((bool)((QImage *)cls)->loadFromData (arg1, arg2));
 }
 
@@ -635,8 +635,8 @@ static void _call_f_mirrored_c1620 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->mirrored (arg1, arg2));
 }
 
@@ -700,7 +700,7 @@ static void _call_f_operator_excl__eq__c1877 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
   ret.write<bool > ((bool)((QImage *)cls)->operator!= (arg1));
 }
 
@@ -719,7 +719,7 @@ static void _call_f_operator_eq__1877 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
   ret.write<QImage & > ((QImage &)((QImage *)cls)->operator= (arg1));
 }
 
@@ -738,7 +738,7 @@ static void _call_f_operator_eq__eq__c1877 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
   ret.write<bool > ((bool)((QImage *)cls)->operator== (arg1));
 }
 
@@ -774,8 +774,8 @@ static void _call_f_pixel_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<unsigned int > ((unsigned int)((QImage *)cls)->pixel (arg1, arg2));
 }
 
@@ -794,7 +794,7 @@ static void _call_f_pixel_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<unsigned int > ((unsigned int)((QImage *)cls)->pixel (arg1));
 }
 
@@ -815,8 +815,8 @@ static void _call_f_pixelIndex_c1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QImage *)cls)->pixelIndex (arg1, arg2));
 }
 
@@ -835,7 +835,7 @@ static void _call_f_pixelIndex_c1916 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<int > ((int)((QImage *)cls)->pixelIndex (arg1));
 }
 
@@ -888,9 +888,9 @@ static void _call_f_save_c4307 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(-1);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<bool > ((bool)((QImage *)cls)->save (arg1, arg2, arg3));
 }
 
@@ -913,9 +913,9 @@ static void _call_f_save_c3729 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(-1);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<bool > ((bool)((QImage *)cls)->save (arg1, arg2, arg3));
 }
 
@@ -940,10 +940,10 @@ static void _call_f_scaled_c6100 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::AspectRatioMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio));
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio), heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->scaled (arg1, arg2, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg3).cref(), qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg4).cref()));
 }
 
@@ -966,9 +966,9 @@ static void _call_f_scaled_c6479 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::AspectRatioMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio));
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio), heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->scaled (arg1, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg2).cref(), qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg3).cref()));
 }
 
@@ -989,8 +989,8 @@ static void _call_f_scaledToHeight_c3292 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->scaledToHeight (arg1, qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg2).cref()));
 }
 
@@ -1011,8 +1011,8 @@ static void _call_f_scaledToWidth_c3292 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->scaledToWidth (arg1, qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg2).cref()));
 }
 
@@ -1031,7 +1031,7 @@ static void _call_f_scanLine_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<const unsigned char * > ((const unsigned char *)((QImage *)cls)->scanLine (arg1));
 }
 
@@ -1065,7 +1065,7 @@ static void _call_f_setAlphaChannel_1877 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setAlphaChannel (arg1);
 }
@@ -1087,8 +1087,8 @@ static void _call_f_setColor_2431 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  unsigned int arg2 = args.read<unsigned int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  unsigned int arg2 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setColor (arg1, arg2);
 }
@@ -1108,7 +1108,7 @@ static void _call_f_setColorCount_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setColorCount (arg1);
 }
@@ -1128,7 +1128,7 @@ static void _call_f_setColorTable_2325 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QRgb> arg1 = args.read<const QVector<QRgb> > (heap);
+  const QVector<QRgb> arg1 = gsi::arg_reader<const QVector<QRgb> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setColorTable (arg1);
 }
@@ -1148,7 +1148,7 @@ static void _call_f_setDotsPerMeterX_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setDotsPerMeterX (arg1);
 }
@@ -1168,7 +1168,7 @@ static void _call_f_setDotsPerMeterY_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setDotsPerMeterY (arg1);
 }
@@ -1188,7 +1188,7 @@ static void _call_f_setNumColors_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setNumColors (arg1);
 }
@@ -1208,7 +1208,7 @@ static void _call_f_setOffset_1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setOffset (arg1);
 }
@@ -1232,9 +1232,9 @@ static void _call_f_setPixel_3090 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  unsigned int arg3 = args.read<unsigned int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  unsigned int arg3 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setPixel (arg1, arg2, arg3);
 }
@@ -1256,8 +1256,8 @@ static void _call_f_setPixel_3580 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  unsigned int arg2 = args.read<unsigned int > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  unsigned int arg2 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setPixel (arg1, arg2);
 }
@@ -1279,8 +1279,8 @@ static void _call_f_setText_3942 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setText (arg1, arg2);
 }
@@ -1304,9 +1304,9 @@ static void _call_f_setText_5271 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImage *)cls)->setText (arg1, arg2, arg3);
 }
@@ -1343,8 +1343,8 @@ static void _call_f_text_c3354 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)((QImage *)cls)->text (arg1, arg2));
 }
 
@@ -1363,7 +1363,7 @@ static void _call_f_text_c2981 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImageTextKeyLang &arg1 = args.read<const QImageTextKeyLang & > (heap);
+  const QImageTextKeyLang &arg1 = gsi::arg_reader<const QImageTextKeyLang & >() (args, heap);
   ret.write<QString > ((QString)((QImage *)cls)->text (arg1));
 }
 
@@ -1429,8 +1429,8 @@ static void _call_f_transformed_c4548 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->transformed (arg1, qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg2).cref()));
 }
 
@@ -1451,8 +1451,8 @@ static void _call_f_transformed_c4875 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QImage > ((QImage)((QImage *)cls)->transformed (arg1, qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg2).cref()));
 }
 
@@ -1473,8 +1473,8 @@ static void _call_f_valid_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QImage *)cls)->valid (arg1, arg2));
 }
 
@@ -1493,7 +1493,7 @@ static void _call_f_valid_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<bool > ((bool)((QImage *)cls)->valid (arg1));
 }
 
@@ -1531,9 +1531,9 @@ static void _call_f_fromData_5018 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const unsigned char *arg1 = args.read<const unsigned char * > (heap);
-  int arg2 = args.read<int > (heap);
-  const char *arg3 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const unsigned char *arg1 = gsi::arg_reader<const unsigned char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const char *arg3 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QImage > ((QImage)QImage::fromData (arg1, arg2, arg3));
 }
 
@@ -1554,8 +1554,8 @@ static void _call_f_fromData_3932 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QImage > ((QImage)QImage::fromData (arg1, arg2));
 }
 
@@ -1578,9 +1578,9 @@ static void _call_f_trueMatrix_3341 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QMatrix > ((QMatrix)QImage::trueMatrix (arg1, arg2, arg3));
 }
 
@@ -1603,9 +1603,9 @@ static void _call_f_trueMatrix_3668 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTransform > ((QTransform)QImage::trueMatrix (arg1, arg2, arg3));
 }
 
@@ -1829,8 +1829,8 @@ static void _call_ctor_QImage_Adaptor_3430 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const qt_gsi::Converter<QImage::Format>::target_type & arg2 = args.read<const qt_gsi::Converter<QImage::Format>::target_type & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const qt_gsi::Converter<QImage::Format>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QImage::Format>::target_type & >() (args, heap);
   ret.write<QImage_Adaptor *> (new QImage_Adaptor (arg1, qt_gsi::QtToCppAdaptor<QImage::Format>(arg2).cref()));
 }
 
@@ -1852,9 +1852,9 @@ static void _call_ctor_QImage_Adaptor_3051 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<QImage::Format>::target_type & arg3 = args.read<const qt_gsi::Converter<QImage::Format>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QImage::Format>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QImage::Format>::target_type & >() (args, heap);
   ret.write<QImage_Adaptor *> (new QImage_Adaptor (arg1, arg2, qt_gsi::QtToCppAdaptor<QImage::Format>(arg3).cref()));
 }
 
@@ -1878,10 +1878,10 @@ static void _call_ctor_QImage_Adaptor_5679 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const unsigned char *arg1 = args.read<const unsigned char * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const qt_gsi::Converter<QImage::Format>::target_type & arg4 = args.read<const qt_gsi::Converter<QImage::Format>::target_type & > (heap);
+  const unsigned char *arg1 = gsi::arg_reader<const unsigned char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QImage::Format>::target_type & arg4 = gsi::arg_reader<const qt_gsi::Converter<QImage::Format>::target_type & >() (args, heap);
   ret.write<QImage_Adaptor *> (new QImage_Adaptor (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<QImage::Format>(arg4).cref()));
 }
 
@@ -1907,11 +1907,11 @@ static void _call_ctor_QImage_Adaptor_6338 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const unsigned char *arg1 = args.read<const unsigned char * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const qt_gsi::Converter<QImage::Format>::target_type & arg5 = args.read<const qt_gsi::Converter<QImage::Format>::target_type & > (heap);
+  const unsigned char *arg1 = gsi::arg_reader<const unsigned char * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QImage::Format>::target_type & arg5 = gsi::arg_reader<const qt_gsi::Converter<QImage::Format>::target_type & >() (args, heap);
   ret.write<QImage_Adaptor *> (new QImage_Adaptor (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<QImage::Format>(arg5).cref()));
 }
 
@@ -1931,8 +1931,8 @@ static void _call_ctor_QImage_Adaptor_3648 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QImage_Adaptor *> (new QImage_Adaptor (arg1, arg2));
 }
 
@@ -1950,7 +1950,7 @@ static void _call_ctor_QImage_Adaptor_1877 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
   ret.write<QImage_Adaptor *> (new QImage_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQImageIOHandler.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQImageIOHandler.cc
@@ -143,7 +143,7 @@ static void _call_f_jumpToImage_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QImageIOHandler *)cls)->jumpToImage (arg1));
 }
 
@@ -222,7 +222,7 @@ static void _call_f_option_c3086 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & > (heap);
+  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QImageIOHandler *)cls)->option (qt_gsi::QtToCppAdaptor<QImageIOHandler::ImageOption>(arg1).cref()));
 }
 
@@ -241,7 +241,7 @@ static void _call_f_read_1186 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QImage *arg1 = args.read<QImage * > (heap);
+  QImage *arg1 = gsi::arg_reader<QImage * >() (args, heap);
   ret.write<bool > ((bool)((QImageIOHandler *)cls)->read (arg1));
 }
 
@@ -260,7 +260,7 @@ static void _call_f_setDevice_1447 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageIOHandler *)cls)->setDevice (arg1);
 }
@@ -280,7 +280,7 @@ static void _call_f_setFormat_2309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageIOHandler *)cls)->setFormat (arg1);
 }
@@ -300,7 +300,7 @@ static void _call_f_setFormat_c2309 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageIOHandler *)cls)->setFormat (arg1);
 }
@@ -322,8 +322,8 @@ static void _call_f_setOption_5097 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageIOHandler *)cls)->setOption (qt_gsi::QtToCppAdaptor<QImageIOHandler::ImageOption>(arg1).cref(), arg2);
 }
@@ -343,7 +343,7 @@ static void _call_f_supportsOption_c3086 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & > (heap);
+  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QImageIOHandler *)cls)->supportsOption (qt_gsi::QtToCppAdaptor<QImageIOHandler::ImageOption>(arg1).cref()));
 }
 
@@ -362,7 +362,7 @@ static void _call_f_write_1877 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
   ret.write<bool > ((bool)((QImageIOHandler *)cls)->write (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQImageIOPlugin.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQImageIOPlugin.cc
@@ -72,8 +72,8 @@ static void _call_f_capabilities_c3648 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const QByteArray &arg2 = args.read<const QByteArray & > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const QByteArray &arg2 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QFlags<QImageIOPlugin::Capability> > ((QFlags<QImageIOPlugin::Capability>)((QImageIOPlugin *)cls)->capabilities (arg1, arg2));
 }
 
@@ -94,8 +94,8 @@ static void _call_f_create_c3648 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const QByteArray &arg2 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const QByteArray &arg2 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QImageIOHandler * > ((QImageIOHandler *)((QImageIOPlugin *)cls)->create (arg1, arg2));
 }
 
@@ -131,8 +131,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QImageIOPlugin::tr (arg1, arg2));
 }
 
@@ -155,9 +155,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QImageIOPlugin::tr (arg1, arg2, arg3));
 }
 
@@ -178,8 +178,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QImageIOPlugin::trUtf8 (arg1, arg2));
 }
 
@@ -202,9 +202,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QImageIOPlugin::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -436,7 +436,7 @@ static void _call_ctor_QImageIOPlugin_Adaptor_1302 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QImageIOPlugin_Adaptor *> (new QImageIOPlugin_Adaptor (arg1));
 }
 
@@ -554,7 +554,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QImageIOPlugin_Adaptor *)cls)->emitter_QImageIOPlugin_destroyed_1302 (arg1);
 }
 
@@ -664,7 +664,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QImageIOPlugin_Adaptor *)cls)->fp_QImageIOPlugin_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQImageReader.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQImageReader.cc
@@ -72,8 +72,8 @@ static void _call_ctor_QImageReader_3648 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const QByteArray &arg2 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const QByteArray &arg2 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QImageReader *> (new QImageReader (arg1, arg2));
 }
 
@@ -94,8 +94,8 @@ static void _call_ctor_QImageReader_4226 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QByteArray &arg2 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QByteArray &arg2 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QImageReader *> (new QImageReader (arg1, arg2));
 }
 
@@ -324,7 +324,7 @@ static void _call_f_jumpToImage_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QImageReader *)cls)->jumpToImage (arg1));
 }
 
@@ -418,7 +418,7 @@ static void _call_f_read_1186 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QImage *arg1 = args.read<QImage * > (heap);
+  QImage *arg1 = gsi::arg_reader<QImage * >() (args, heap);
   ret.write<bool > ((bool)((QImageReader *)cls)->read (arg1));
 }
 
@@ -467,7 +467,7 @@ static void _call_f_setAutoDetectImageFormat_864 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setAutoDetectImageFormat (arg1);
 }
@@ -487,7 +487,7 @@ static void _call_f_setBackgroundColor_1905 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setBackgroundColor (arg1);
 }
@@ -507,7 +507,7 @@ static void _call_f_setClipRect_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setClipRect (arg1);
 }
@@ -527,7 +527,7 @@ static void _call_f_setDecideFormatFromContent_864 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setDecideFormatFromContent (arg1);
 }
@@ -547,7 +547,7 @@ static void _call_f_setDevice_1447 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setDevice (arg1);
 }
@@ -567,7 +567,7 @@ static void _call_f_setFileName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setFileName (arg1);
 }
@@ -587,7 +587,7 @@ static void _call_f_setFormat_2309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setFormat (arg1);
 }
@@ -607,7 +607,7 @@ static void _call_f_setQuality_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setQuality (arg1);
 }
@@ -627,7 +627,7 @@ static void _call_f_setScaledClipRect_1792 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setScaledClipRect (arg1);
 }
@@ -647,7 +647,7 @@ static void _call_f_setScaledSize_1805 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageReader *)cls)->setScaledSize (arg1);
 }
@@ -697,7 +697,7 @@ static void _call_f_supportsOption_c3086 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & > (heap);
+  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QImageReader *)cls)->supportsOption (qt_gsi::QtToCppAdaptor<QImageIOHandler::ImageOption>(arg1).cref()));
 }
 
@@ -716,7 +716,7 @@ static void _call_f_text_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QImageReader *)cls)->text (arg1));
 }
 
@@ -750,7 +750,7 @@ static void _call_f_imageFormat_2025 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)QImageReader::imageFormat (arg1));
 }
 
@@ -769,7 +769,7 @@ static void _call_f_imageFormat_1447 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   ret.write<QByteArray > ((QByteArray)QImageReader::imageFormat (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQImageTextKeyLang.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQImageTextKeyLang.cc
@@ -52,8 +52,8 @@ static void _call_ctor_QImageTextKeyLang_3354 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QImageTextKeyLang *> (new QImageTextKeyLang (arg1, arg2));
 }
 
@@ -87,7 +87,7 @@ static void _call_f_operator_excl__eq__c2981 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImageTextKeyLang &arg1 = args.read<const QImageTextKeyLang & > (heap);
+  const QImageTextKeyLang &arg1 = gsi::arg_reader<const QImageTextKeyLang & >() (args, heap);
   ret.write<bool > ((bool)((QImageTextKeyLang *)cls)->operator!= (arg1));
 }
 
@@ -106,7 +106,7 @@ static void _call_f_operator_lt__c2981 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImageTextKeyLang &arg1 = args.read<const QImageTextKeyLang & > (heap);
+  const QImageTextKeyLang &arg1 = gsi::arg_reader<const QImageTextKeyLang & >() (args, heap);
   ret.write<bool > ((bool)((QImageTextKeyLang *)cls)->operator< (arg1));
 }
 
@@ -125,7 +125,7 @@ static void _call_f_operator_eq__eq__c2981 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImageTextKeyLang &arg1 = args.read<const QImageTextKeyLang & > (heap);
+  const QImageTextKeyLang &arg1 = gsi::arg_reader<const QImageTextKeyLang & >() (args, heap);
   ret.write<bool > ((bool)((QImageTextKeyLang *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQImageWriter.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQImageWriter.cc
@@ -69,8 +69,8 @@ static void _call_ctor_QImageWriter_3648 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const QByteArray &arg2 = args.read<const QByteArray & > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const QByteArray &arg2 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QImageWriter *> (new QImageWriter (arg1, arg2));
 }
 
@@ -91,8 +91,8 @@ static void _call_ctor_QImageWriter_4226 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QByteArray &arg2 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QByteArray &arg2 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QImageWriter *> (new QImageWriter (arg1, arg2));
 }
 
@@ -261,7 +261,7 @@ static void _call_f_setCompression_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageWriter *)cls)->setCompression (arg1);
 }
@@ -281,7 +281,7 @@ static void _call_f_setDescription_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageWriter *)cls)->setDescription (arg1);
 }
@@ -301,7 +301,7 @@ static void _call_f_setDevice_1447 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageWriter *)cls)->setDevice (arg1);
 }
@@ -321,7 +321,7 @@ static void _call_f_setFileName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageWriter *)cls)->setFileName (arg1);
 }
@@ -341,7 +341,7 @@ static void _call_f_setFormat_2309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageWriter *)cls)->setFormat (arg1);
 }
@@ -361,7 +361,7 @@ static void _call_f_setGamma_970 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  float arg1 = args.read<float > (heap);
+  float arg1 = gsi::arg_reader<float >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageWriter *)cls)->setGamma (arg1);
 }
@@ -381,7 +381,7 @@ static void _call_f_setQuality_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageWriter *)cls)->setQuality (arg1);
 }
@@ -403,8 +403,8 @@ static void _call_f_setText_3942 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QImageWriter *)cls)->setText (arg1, arg2);
 }
@@ -424,7 +424,7 @@ static void _call_f_supportsOption_c3086 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & > (heap);
+  const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QImageIOHandler::ImageOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QImageWriter *)cls)->supportsOption (qt_gsi::QtToCppAdaptor<QImageIOHandler::ImageOption>(arg1).cref()));
 }
 
@@ -443,7 +443,7 @@ static void _call_f_write_1877 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
   ret.write<bool > ((bool)((QImageWriter *)cls)->write (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQInputContext.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQInputContext.cc
@@ -88,7 +88,7 @@ static void _call_f_filterEvent_1912 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QEvent *arg1 = args.read<const QEvent * > (heap);
+  const QEvent *arg1 = gsi::arg_reader<const QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QInputContext *)cls)->filterEvent (arg1));
 }
 
@@ -184,8 +184,8 @@ static void _call_f_mouseHandler_2397 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QMouseEvent *arg2 = args.read<QMouseEvent * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QMouseEvent *arg2 = gsi::arg_reader<QMouseEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputContext *)cls)->mouseHandler (arg1, arg2);
 }
@@ -221,7 +221,7 @@ static void _call_f_sendEvent_3045 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QInputMethodEvent &arg1 = args.read<const QInputMethodEvent & > (heap);
+  const QInputMethodEvent &arg1 = gsi::arg_reader<const QInputMethodEvent & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputContext *)cls)->sendEvent (arg1);
 }
@@ -241,7 +241,7 @@ static void _call_f_setFocusWidget_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputContext *)cls)->setFocusWidget (arg1);
 }
@@ -261,7 +261,7 @@ static void _call_f_standardFormat_c3336 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QInputContext::StandardFormat>::target_type & arg1 = args.read<const qt_gsi::Converter<QInputContext::StandardFormat>::target_type & > (heap);
+  const qt_gsi::Converter<QInputContext::StandardFormat>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QInputContext::StandardFormat>::target_type & >() (args, heap);
   ret.write<QTextFormat > ((QTextFormat)((QInputContext *)cls)->standardFormat (qt_gsi::QtToCppAdaptor<QInputContext::StandardFormat>(arg1).cref()));
 }
 
@@ -296,7 +296,7 @@ static void _call_f_widgetDestroyed_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputContext *)cls)->widgetDestroyed (arg1);
 }
@@ -318,8 +318,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QInputContext::tr (arg1, arg2));
 }
 
@@ -342,9 +342,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QInputContext::tr (arg1, arg2, arg3));
 }
 
@@ -365,8 +365,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QInputContext::trUtf8 (arg1, arg2));
 }
 
@@ -389,9 +389,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QInputContext::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -758,7 +758,7 @@ static void _call_ctor_QInputContext_Adaptor_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QInputContext_Adaptor *> (new QInputContext_Adaptor (arg1));
 }
 
@@ -843,7 +843,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QInputContext_Adaptor *)cls)->emitter_QInputContext_destroyed_1302 (arg1);
 }
 
@@ -1060,7 +1060,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QInputContext_Adaptor *)cls)->fp_QInputContext_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQInputContextFactory.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQInputContextFactory.cc
@@ -69,8 +69,8 @@ static void _call_f_create_3219 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QInputContext * > ((QInputContext *)QInputContextFactory::create (arg1, arg2));
 }
 
@@ -89,7 +89,7 @@ static void _call_f_description_2025 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QInputContextFactory::description (arg1));
 }
 
@@ -108,7 +108,7 @@ static void _call_f_displayName_2025 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)QInputContextFactory::displayName (arg1));
 }
 
@@ -142,7 +142,7 @@ static void _call_f_languages_2025 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStringList > ((QStringList)QInputContextFactory::languages (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQInputContextPlugin.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQInputContextPlugin.cc
@@ -69,7 +69,7 @@ static void _call_f_create_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QInputContext * > ((QInputContext *)((QInputContextPlugin *)cls)->create (arg1));
 }
 
@@ -88,7 +88,7 @@ static void _call_f_description_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QInputContextPlugin *)cls)->description (arg1));
 }
 
@@ -107,7 +107,7 @@ static void _call_f_displayName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QInputContextPlugin *)cls)->displayName (arg1));
 }
 
@@ -141,7 +141,7 @@ static void _call_f_languages_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStringList > ((QStringList)((QInputContextPlugin *)cls)->languages (arg1));
 }
 
@@ -162,8 +162,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QInputContextPlugin::tr (arg1, arg2));
 }
 
@@ -186,9 +186,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QInputContextPlugin::tr (arg1, arg2, arg3));
 }
 
@@ -209,8 +209,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QInputContextPlugin::trUtf8 (arg1, arg2));
 }
 
@@ -233,9 +233,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QInputContextPlugin::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -501,7 +501,7 @@ static void _call_ctor_QInputContextPlugin_Adaptor_1302 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QInputContextPlugin_Adaptor *> (new QInputContextPlugin_Adaptor (arg1));
 }
 
@@ -613,7 +613,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QInputContextPlugin_Adaptor *)cls)->emitter_QInputContextPlugin_destroyed_1302 (arg1);
 }
 
@@ -769,7 +769,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QInputContextPlugin_Adaptor *)cls)->fp_QInputContextPlugin_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQInputDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQInputDialog.cc
@@ -141,7 +141,7 @@ static void _call_f_done_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->done (arg1);
 }
@@ -374,8 +374,8 @@ static void _call_f_open_2925 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->open (arg1, arg2);
 }
@@ -410,7 +410,7 @@ static void _call_f_setCancelButtonText_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setCancelButtonText (arg1);
 }
@@ -430,7 +430,7 @@ static void _call_f_setComboBoxEditable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setComboBoxEditable (arg1);
 }
@@ -450,7 +450,7 @@ static void _call_f_setComboBoxItems_2437 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setComboBoxItems (arg1);
 }
@@ -470,7 +470,7 @@ static void _call_f_setDoubleDecimals_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setDoubleDecimals (arg1);
 }
@@ -490,7 +490,7 @@ static void _call_f_setDoubleMaximum_1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setDoubleMaximum (arg1);
 }
@@ -510,7 +510,7 @@ static void _call_f_setDoubleMinimum_1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setDoubleMinimum (arg1);
 }
@@ -532,8 +532,8 @@ static void _call_f_setDoubleRange_2034 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setDoubleRange (arg1, arg2);
 }
@@ -553,7 +553,7 @@ static void _call_f_setDoubleValue_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setDoubleValue (arg1);
 }
@@ -573,7 +573,7 @@ static void _call_f_setInputMode_2670 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QInputDialog::InputMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QInputDialog::InputMode>::target_type & > (heap);
+  const qt_gsi::Converter<QInputDialog::InputMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QInputDialog::InputMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setInputMode (qt_gsi::QtToCppAdaptor<QInputDialog::InputMode>(arg1).cref());
 }
@@ -593,7 +593,7 @@ static void _call_f_setIntMaximum_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setIntMaximum (arg1);
 }
@@ -613,7 +613,7 @@ static void _call_f_setIntMinimum_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setIntMinimum (arg1);
 }
@@ -635,8 +635,8 @@ static void _call_f_setIntRange_1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setIntRange (arg1, arg2);
 }
@@ -656,7 +656,7 @@ static void _call_f_setIntStep_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setIntStep (arg1);
 }
@@ -676,7 +676,7 @@ static void _call_f_setIntValue_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setIntValue (arg1);
 }
@@ -696,7 +696,7 @@ static void _call_f_setLabelText_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setLabelText (arg1);
 }
@@ -716,7 +716,7 @@ static void _call_f_setOkButtonText_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setOkButtonText (arg1);
 }
@@ -738,8 +738,8 @@ static void _call_f_setOption_4262 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QInputDialog::InputDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QInputDialog::InputDialogOption>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QInputDialog::InputDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QInputDialog::InputDialogOption>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setOption (qt_gsi::QtToCppAdaptor<QInputDialog::InputDialogOption>(arg1).cref(), arg2);
 }
@@ -759,7 +759,7 @@ static void _call_f_setOptions_4202 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QInputDialog::InputDialogOption> arg1 = args.read<QFlags<QInputDialog::InputDialogOption> > (heap);
+  QFlags<QInputDialog::InputDialogOption> arg1 = gsi::arg_reader<QFlags<QInputDialog::InputDialogOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setOptions (arg1);
 }
@@ -779,7 +779,7 @@ static void _call_f_setTextEchoMode_2187 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & > (heap);
+  const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setTextEchoMode (qt_gsi::QtToCppAdaptor<QLineEdit::EchoMode>(arg1).cref());
 }
@@ -799,7 +799,7 @@ static void _call_f_setTextValue_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setTextValue (arg1);
 }
@@ -819,7 +819,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog *)cls)->setVisible (arg1);
 }
@@ -854,7 +854,7 @@ static void _call_f_testOption_c3506 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QInputDialog::InputDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QInputDialog::InputDialogOption>::target_type & > (heap);
+  const qt_gsi::Converter<QInputDialog::InputDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QInputDialog::InputDialogOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QInputDialog *)cls)->testOption (qt_gsi::QtToCppAdaptor<QInputDialog::InputDialogOption>(arg1).cref()));
 }
 
@@ -919,15 +919,15 @@ static void _call_f_getDouble_12026 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  double arg4 = args ? args.read<double > (heap) : (double)(0);
-  double arg5 = args ? args.read<double > (heap) : (double)(-2147483647);
-  double arg6 = args ? args.read<double > (heap) : (double)(2147483647);
-  int arg7 = args ? args.read<int > (heap) : (int)(1);
-  bool *arg8 = args ? args.read<bool * > (heap) : (bool *)(0);
-  QFlags<Qt::WindowType> arg9 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  double arg4 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (0, heap);
+  double arg5 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (-2147483647, heap);
+  double arg6 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (2147483647, heap);
+  int arg7 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
+  bool *arg8 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  QFlags<Qt::WindowType> arg9 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<double > ((double)QInputDialog::getDouble (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
 }
 
@@ -962,15 +962,15 @@ static void _call_f_getInt_11114 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
-  int arg5 = args ? args.read<int > (heap) : (int)(-2147483647);
-  int arg6 = args ? args.read<int > (heap) : (int)(2147483647);
-  int arg7 = args ? args.read<int > (heap) : (int)(1);
-  bool *arg8 = args ? args.read<bool * > (heap) : (bool *)(0);
-  QFlags<Qt::WindowType> arg9 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-2147483647, heap);
+  int arg6 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (2147483647, heap);
+  int arg7 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
+  bool *arg8 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  QFlags<Qt::WindowType> arg9 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<int > ((int)QInputDialog::getInt (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
 }
 
@@ -1005,15 +1005,15 @@ static void _call_f_getInteger_11114 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
-  int arg5 = args ? args.read<int > (heap) : (int)(-2147483647);
-  int arg6 = args ? args.read<int > (heap) : (int)(2147483647);
-  int arg7 = args ? args.read<int > (heap) : (int)(1);
-  bool *arg8 = args ? args.read<bool * > (heap) : (bool *)(0);
-  QFlags<Qt::WindowType> arg9 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-2147483647, heap);
+  int arg6 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (2147483647, heap);
+  int arg7 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
+  bool *arg8 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  QFlags<Qt::WindowType> arg9 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<int > ((int)QInputDialog::getInteger (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
 }
 
@@ -1046,14 +1046,14 @@ static void _call_f_getItem_12222 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QStringList &arg4 = args.read<const QStringList & > (heap);
-  int arg5 = args ? args.read<int > (heap) : (int)(0);
-  bool arg6 = args ? args.read<bool > (heap) : (bool)(true);
-  bool *arg7 = args ? args.read<bool * > (heap) : (bool *)(0);
-  QFlags<Qt::WindowType> arg8 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QStringList &arg4 = gsi::arg_reader<const QStringList & >() (args, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  bool arg6 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool *arg7 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  QFlags<Qt::WindowType> arg8 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QString > ((QString)QInputDialog::getItem (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
 }
 
@@ -1084,13 +1084,13 @@ static void _call_f_getText_12474 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & > (heap) : (const qt_gsi::Converter<QLineEdit::EchoMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLineEdit::EchoMode>(heap, QLineEdit::Normal));
-  const QString &arg5 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  bool *arg6 = args ? args.read<bool * > (heap) : (bool *)(0);
-  QFlags<Qt::WindowType> arg7 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLineEdit::EchoMode>(heap, QLineEdit::Normal), heap);
+  const QString &arg5 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  bool *arg6 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
+  QFlags<Qt::WindowType> arg7 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QString > ((QString)QInputDialog::getText (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<QLineEdit::EchoMode>(arg4).cref(), arg5, arg6, arg7));
 }
 
@@ -1111,8 +1111,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QInputDialog::tr (arg1, arg2));
 }
 
@@ -1135,9 +1135,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QInputDialog::tr (arg1, arg2, arg3));
 }
 
@@ -1158,8 +1158,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QInputDialog::trUtf8 (arg1, arg2));
 }
 
@@ -1182,9 +1182,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QInputDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2211,8 +2211,8 @@ static void _call_ctor_QInputDialog_Adaptor_3702 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QInputDialog_Adaptor *> (new QInputDialog_Adaptor (arg1, arg2));
 }
 
@@ -2288,7 +2288,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog_Adaptor *)cls)->fp_QInputDialog_adjustPosition_1315 (arg1);
 }
@@ -2407,9 +2407,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog_Adaptor *)cls)->fp_QInputDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -2428,7 +2428,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QInputDialog_Adaptor *)cls)->emitter_QInputDialog_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2472,8 +2472,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputDialog_Adaptor *)cls)->fp_QInputDialog_destroy_1620 (arg1, arg2);
 }
@@ -2492,7 +2492,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QInputDialog_Adaptor *)cls)->emitter_QInputDialog_destroyed_1302 (arg1);
 }
 
@@ -2558,7 +2558,7 @@ static void _call_emitter_doubleValueChanged_1071 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ((QInputDialog_Adaptor *)cls)->emitter_QInputDialog_doubleValueChanged_1071 (arg1);
 }
 
@@ -2576,7 +2576,7 @@ static void _call_emitter_doubleValueSelected_1071 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ((QInputDialog_Adaptor *)cls)->emitter_QInputDialog_doubleValueSelected_1071 (arg1);
 }
 
@@ -2787,7 +2787,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QInputDialog_Adaptor *)cls)->emitter_QInputDialog_finished_767 (arg1);
 }
 
@@ -3022,7 +3022,7 @@ static void _call_emitter_intValueChanged_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QInputDialog_Adaptor *)cls)->emitter_QInputDialog_intValueChanged_767 (arg1);
 }
 
@@ -3040,7 +3040,7 @@ static void _call_emitter_intValueSelected_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QInputDialog_Adaptor *)cls)->emitter_QInputDialog_intValueSelected_767 (arg1);
 }
 
@@ -3379,7 +3379,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QInputDialog_Adaptor *)cls)->fp_QInputDialog_receivers_c1731 (arg1));
 }
 
@@ -3599,7 +3599,7 @@ static void _call_emitter_textValueChanged_2025 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QInputDialog_Adaptor *)cls)->emitter_QInputDialog_textValueChanged_2025 (arg1);
 }
 
@@ -3617,7 +3617,7 @@ static void _call_emitter_textValueSelected_2025 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QInputDialog_Adaptor *)cls)->emitter_QInputDialog_textValueSelected_2025 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQInputEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQInputEvent.cc
@@ -65,7 +65,7 @@ static void _call_f_setModifiers_3077 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::KeyboardModifier> arg1 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  QFlags<Qt::KeyboardModifier> arg1 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputEvent *)cls)->setModifiers (arg1);
 }
@@ -130,8 +130,8 @@ static void _call_ctor_QInputEvent_Adaptor_4534 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  QFlags<Qt::KeyboardModifier> arg2 = args ? args.read<QFlags<Qt::KeyboardModifier> > (heap) : (QFlags<Qt::KeyboardModifier>)(Qt::NoModifier);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg2 = args ? gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap) : gsi::arg_maker<QFlags<Qt::KeyboardModifier> >() (Qt::NoModifier, heap);
   ret.write<QInputEvent_Adaptor *> (new QInputEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQInputMethodEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQInputMethodEvent.cc
@@ -67,8 +67,8 @@ static void _call_ctor_QInputMethodEvent_6641 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QList<QInputMethodEvent::Attribute> &arg2 = args.read<const QList<QInputMethodEvent::Attribute> & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QList<QInputMethodEvent::Attribute> &arg2 = gsi::arg_reader<const QList<QInputMethodEvent::Attribute> & >() (args, heap);
   ret.write<QInputMethodEvent *> (new QInputMethodEvent (arg1, arg2));
 }
 
@@ -87,7 +87,7 @@ static void _call_ctor_QInputMethodEvent_3045 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QInputMethodEvent &arg1 = args.read<const QInputMethodEvent & > (heap);
+  const QInputMethodEvent &arg1 = gsi::arg_reader<const QInputMethodEvent & >() (args, heap);
   ret.write<QInputMethodEvent *> (new QInputMethodEvent (arg1));
 }
 
@@ -185,9 +185,9 @@ static void _call_f_setCommitString_3343 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QInputMethodEvent *)cls)->setCommitString (arg1, arg2, arg3);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQInputMethodEvent_Attribute.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQInputMethodEvent_Attribute.cc
@@ -56,10 +56,10 @@ static void _call_ctor_QInputMethodEvent_Attribute_6102 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QInputMethodEvent::AttributeType>::target_type & arg1 = args.read<const qt_gsi::Converter<QInputMethodEvent::AttributeType>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  QVariant arg4 = args.read<QVariant > (heap);
+  const qt_gsi::Converter<QInputMethodEvent::AttributeType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QInputMethodEvent::AttributeType>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  QVariant arg4 = gsi::arg_reader<QVariant >() (args, heap);
   ret.write<QInputMethodEvent::Attribute *> (new QInputMethodEvent::Attribute (qt_gsi::QtToCppAdaptor<QInputMethodEvent::AttributeType>(arg1).cref(), arg2, arg3, arg4));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQIntValidator.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQIntValidator.cc
@@ -84,7 +84,7 @@ static void _call_f_setBottom_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIntValidator *)cls)->setBottom (arg1);
 }
@@ -106,8 +106,8 @@ static void _call_f_setRange_1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIntValidator *)cls)->setRange (arg1, arg2);
 }
@@ -127,7 +127,7 @@ static void _call_f_setTop_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QIntValidator *)cls)->setTop (arg1);
 }
@@ -164,8 +164,8 @@ static void _call_f_validate_c2171 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
-  int &arg2 = args.read<int & > (heap);
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
+  int &arg2 = gsi::arg_reader<int & >() (args, heap);
   ret.write<qt_gsi::Converter<QValidator::State>::target_type > ((qt_gsi::Converter<QValidator::State>::target_type)qt_gsi::CppToQtAdaptor<QValidator::State>(((QIntValidator *)cls)->validate (arg1, arg2)));
 }
 
@@ -186,8 +186,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QIntValidator::tr (arg1, arg2));
 }
 
@@ -210,9 +210,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QIntValidator::tr (arg1, arg2, arg3));
 }
 
@@ -233,8 +233,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QIntValidator::trUtf8 (arg1, arg2));
 }
 
@@ -257,9 +257,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QIntValidator::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -496,7 +496,7 @@ static void _call_ctor_QIntValidator_Adaptor_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QIntValidator_Adaptor *> (new QIntValidator_Adaptor (arg1));
 }
 
@@ -518,9 +518,9 @@ static void _call_ctor_QIntValidator_Adaptor_2620 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  QObject *arg3 = args.read<QObject * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QObject *arg3 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QIntValidator_Adaptor *> (new QIntValidator_Adaptor (arg1, arg2, arg3));
 }
 
@@ -586,7 +586,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QIntValidator_Adaptor *)cls)->emitter_QIntValidator_destroyed_1302 (arg1);
 }
 
@@ -701,7 +701,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QIntValidator_Adaptor *)cls)->fp_QIntValidator_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQItemDelegate.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQItemDelegate.cc
@@ -86,9 +86,9 @@ static void _call_f_createEditor_c6860 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QItemDelegate *)cls)->createEditor (arg1, arg2, arg3));
 }
 
@@ -141,9 +141,9 @@ static void _call_f_paint_c6971 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemDelegate *)cls)->paint (arg1, arg2, arg3);
 }
@@ -163,7 +163,7 @@ static void _call_f_setClipping_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemDelegate *)cls)->setClipping (arg1);
 }
@@ -185,8 +185,8 @@ static void _call_f_setEditorData_c3602 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemDelegate *)cls)->setEditorData (arg1, arg2);
 }
@@ -206,7 +206,7 @@ static void _call_f_setItemEditorFactory_2445 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QItemEditorFactory *arg1 = args.read<QItemEditorFactory * > (heap);
+  QItemEditorFactory *arg1 = gsi::arg_reader<QItemEditorFactory * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemDelegate *)cls)->setItemEditorFactory (arg1);
 }
@@ -230,9 +230,9 @@ static void _call_f_setModelData_c5913 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QAbstractItemModel *arg2 = args.read<QAbstractItemModel * > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QAbstractItemModel *arg2 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemDelegate *)cls)->setModelData (arg1, arg2, arg3);
 }
@@ -254,8 +254,8 @@ static void _call_f_sizeHint_c5653 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QSize > ((QSize)((QItemDelegate *)cls)->sizeHint (arg1, arg2));
 }
 
@@ -278,9 +278,9 @@ static void _call_f_updateEditorGeometry_c6860 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemDelegate *)cls)->updateEditorGeometry (arg1, arg2, arg3);
 }
@@ -302,8 +302,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QItemDelegate::tr (arg1, arg2));
 }
 
@@ -326,9 +326,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QItemDelegate::tr (arg1, arg2, arg3));
 }
 
@@ -349,8 +349,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QItemDelegate::trUtf8 (arg1, arg2));
 }
 
@@ -373,9 +373,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QItemDelegate::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -799,7 +799,7 @@ static void _call_ctor_QItemDelegate_Adaptor_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QItemDelegate_Adaptor *> (new QItemDelegate_Adaptor (arg1));
 }
 
@@ -821,9 +821,9 @@ static void _call_fp_check_c7061 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
   ret.write<QRect > ((QRect)((QItemDelegate_Adaptor *)cls)->fp_QItemDelegate_check_c7061 (arg1, arg2, arg3));
 }
 
@@ -867,8 +867,8 @@ static void _call_emitter_closeEditor_4926 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemDelegate::EndEditHint>(heap, QAbstractItemDelegate::NoHint));
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemDelegate::EndEditHint>(heap, QAbstractItemDelegate::NoHint), heap);
   ((QItemDelegate_Adaptor *)cls)->emitter_QItemDelegate_closeEditor_4926 (arg1, arg2);
 }
 
@@ -886,7 +886,7 @@ static void _call_emitter_commitData_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ((QItemDelegate_Adaptor *)cls)->emitter_QItemDelegate_commitData_1315 (arg1);
 }
 
@@ -959,8 +959,8 @@ static void _call_fp_decoration_c5377 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   ret.write<QPixmap > ((QPixmap)((QItemDelegate_Adaptor *)cls)->fp_QItemDelegate_decoration_c5377 (arg1, arg2));
 }
 
@@ -978,7 +978,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QItemDelegate_Adaptor *)cls)->emitter_QItemDelegate_destroyed_1302 (arg1);
 }
 
@@ -1028,11 +1028,11 @@ static void _call_fp_doLayout_c7101 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
-  QRect *arg2 = args.read<QRect * > (heap);
-  QRect *arg3 = args.read<QRect * > (heap);
-  QRect *arg4 = args.read<QRect * > (heap);
-  bool arg5 = args.read<bool > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  QRect *arg2 = gsi::arg_reader<QRect * >() (args, heap);
+  QRect *arg3 = gsi::arg_reader<QRect * >() (args, heap);
+  QRect *arg4 = gsi::arg_reader<QRect * >() (args, heap);
+  bool arg5 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemDelegate_Adaptor *)cls)->fp_QItemDelegate_doLayout_c7101 (arg1, arg2, arg3, arg4, arg5);
 }
@@ -1055,9 +1055,9 @@ static void _call_fp_drawBackground_c6971 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemDelegate_Adaptor *)cls)->fp_QItemDelegate_drawBackground_c6971 (arg1, arg2, arg3);
 }
@@ -1316,7 +1316,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QItemDelegate_Adaptor *)cls)->fp_QItemDelegate_receivers_c1731 (arg1));
 }
 
@@ -1338,9 +1338,9 @@ static void _call_fp_rect_c6312 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
-  int arg3 = args.read<int > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRect > ((QRect)((QItemDelegate_Adaptor *)cls)->fp_QItemDelegate_rect_c6312 (arg1, arg2, arg3));
 }
 
@@ -1362,9 +1362,9 @@ static void _call_fp_selected_c4778 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
-  const QPalette &arg2 = args.read<const QPalette & > (heap);
-  bool arg3 = args.read<bool > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QPalette &arg2 = gsi::arg_reader<const QPalette & >() (args, heap);
+  bool arg3 = gsi::arg_reader<bool >() (args, heap);
   ret.write<QPixmap * > ((QPixmap *)((QItemDelegate_Adaptor *)cls)->fp_QItemDelegate_selected_c4778 (arg1, arg2, arg3));
 }
 
@@ -1455,8 +1455,8 @@ static void _call_fp_setOptions_c5653 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
   ret.write<QStyleOptionViewItem > ((QStyleOptionViewItem)((QItemDelegate_Adaptor *)cls)->fp_QItemDelegate_setOptions_c5653 (arg1, arg2));
 }
 
@@ -1500,7 +1500,7 @@ static void _call_emitter_sizeHintChanged_2395 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QItemDelegate_Adaptor *)cls)->emitter_QItemDelegate_sizeHintChanged_2395 (arg1);
 }
 
@@ -1524,10 +1524,10 @@ static void _call_fp_textRectangle_c6720 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  const QFont &arg3 = args.read<const QFont & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QFont &arg3 = gsi::arg_reader<const QFont & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QRect > ((QRect)((QItemDelegate_Adaptor *)cls)->fp_QItemDelegate_textRectangle_c6720 (arg1, arg2, arg3, arg4));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQItemEditorCreatorBase.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQItemEditorCreatorBase.cc
@@ -51,7 +51,7 @@ static void _call_f_createWidget_c1315 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QItemEditorCreatorBase *)cls)->createWidget (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQItemEditorFactory.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQItemEditorFactory.cc
@@ -54,8 +54,8 @@ static void _call_f_createEditor_c2983 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QVariant::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QVariant::Type>::target_type & > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  const qt_gsi::Converter<QVariant::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QVariant::Type>::target_type & >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QItemEditorFactory *)cls)->createEditor (qt_gsi::QtToCppAdaptor<QVariant::Type>(arg1).cref(), arg2));
 }
 
@@ -76,8 +76,8 @@ static void _call_f_registerEditor_4484 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QVariant::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QVariant::Type>::target_type & > (heap);
-  QItemEditorCreatorBase *arg2 = args.read<QItemEditorCreatorBase * > (heap);
+  const qt_gsi::Converter<QVariant::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QVariant::Type>::target_type & >() (args, heap);
+  QItemEditorCreatorBase *arg2 = gsi::arg_reader<QItemEditorCreatorBase * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemEditorFactory *)cls)->registerEditor (qt_gsi::QtToCppAdaptor<QVariant::Type>(arg1).cref(), arg2);
 }
@@ -97,7 +97,7 @@ static void _call_f_valuePropertyName_c1776 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QVariant::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QVariant::Type>::target_type & > (heap);
+  const qt_gsi::Converter<QVariant::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QVariant::Type>::target_type & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QItemEditorFactory *)cls)->valuePropertyName (qt_gsi::QtToCppAdaptor<QVariant::Type>(arg1).cref()));
 }
 
@@ -131,7 +131,7 @@ static void _call_f_setDefaultFactory_2445 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QItemEditorFactory *arg1 = args.read<QItemEditorFactory * > (heap);
+  QItemEditorFactory *arg1 = gsi::arg_reader<QItemEditorFactory * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QItemEditorFactory::setDefaultFactory (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQItemSelection.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQItemSelection.cc
@@ -69,8 +69,8 @@ static void _call_ctor_QItemSelection_4682 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QItemSelection *> (new QItemSelection (arg1, arg2));
 }
 
@@ -89,7 +89,7 @@ static void _call_f_contains_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelection *)cls)->contains (arg1));
 }
 
@@ -125,8 +125,8 @@ static void _call_f_merge_7090 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelection &arg1 = args.read<const QItemSelection & > (heap);
-  QFlags<QItemSelectionModel::SelectionFlag> arg2 = args.read<QFlags<QItemSelectionModel::SelectionFlag> > (heap);
+  const QItemSelection &arg1 = gsi::arg_reader<const QItemSelection & >() (args, heap);
+  QFlags<QItemSelectionModel::SelectionFlag> arg2 = gsi::arg_reader<QFlags<QItemSelectionModel::SelectionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemSelection *)cls)->merge (arg1, arg2);
 }
@@ -148,8 +148,8 @@ static void _call_f_select_4682 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemSelection *)cls)->select (arg1, arg2);
 }
@@ -173,9 +173,9 @@ static void _call_f_split_8260 (const qt_gsi::GenericStaticMethod * /*decl*/, gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelectionRange &arg1 = args.read<const QItemSelectionRange & > (heap);
-  const QItemSelectionRange &arg2 = args.read<const QItemSelectionRange & > (heap);
-  QItemSelection *arg3 = args.read<QItemSelection * > (heap);
+  const QItemSelectionRange &arg1 = gsi::arg_reader<const QItemSelectionRange & >() (args, heap);
+  const QItemSelectionRange &arg2 = gsi::arg_reader<const QItemSelectionRange & >() (args, heap);
+  QItemSelection *arg3 = gsi::arg_reader<QItemSelection * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QItemSelection::split (arg1, arg2, arg3);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQItemSelectionModel.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQItemSelectionModel.cc
@@ -105,8 +105,8 @@ static void _call_f_columnIntersectsSelection_c3054 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionModel *)cls)->columnIntersectsSelection (arg1, arg2));
 }
 
@@ -157,8 +157,8 @@ static void _call_f_isColumnSelected_c3054 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionModel *)cls)->isColumnSelected (arg1, arg2));
 }
 
@@ -179,8 +179,8 @@ static void _call_f_isRowSelected_c3054 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionModel *)cls)->isRowSelected (arg1, arg2));
 }
 
@@ -199,7 +199,7 @@ static void _call_f_isSelected_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionModel *)cls)->isSelected (arg1));
 }
 
@@ -251,8 +251,8 @@ static void _call_f_rowIntersectsSelection_c3054 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionModel *)cls)->rowIntersectsSelection (arg1, arg2));
 }
 
@@ -273,8 +273,8 @@ static void _call_f_select_6758 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  QFlags<QItemSelectionModel::SelectionFlag> arg2 = args.read<QFlags<QItemSelectionModel::SelectionFlag> > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QFlags<QItemSelectionModel::SelectionFlag> arg2 = gsi::arg_reader<QFlags<QItemSelectionModel::SelectionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemSelectionModel *)cls)->select (arg1, arg2);
 }
@@ -296,8 +296,8 @@ static void _call_f_select_7090 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelection &arg1 = args.read<const QItemSelection & > (heap);
-  QFlags<QItemSelectionModel::SelectionFlag> arg2 = args.read<QFlags<QItemSelectionModel::SelectionFlag> > (heap);
+  const QItemSelection &arg1 = gsi::arg_reader<const QItemSelection & >() (args, heap);
+  QFlags<QItemSelectionModel::SelectionFlag> arg2 = gsi::arg_reader<QFlags<QItemSelectionModel::SelectionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemSelectionModel *)cls)->select (arg1, arg2);
 }
@@ -317,7 +317,7 @@ static void _call_f_selectedColumns_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QList<QModelIndex> > ((QList<QModelIndex>)((QItemSelectionModel *)cls)->selectedColumns (arg1));
 }
 
@@ -351,7 +351,7 @@ static void _call_f_selectedRows_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QList<QModelIndex> > ((QList<QModelIndex>)((QItemSelectionModel *)cls)->selectedRows (arg1));
 }
 
@@ -387,8 +387,8 @@ static void _call_f_setCurrentIndex_6758 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  QFlags<QItemSelectionModel::SelectionFlag> arg2 = args.read<QFlags<QItemSelectionModel::SelectionFlag> > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QFlags<QItemSelectionModel::SelectionFlag> arg2 = gsi::arg_reader<QFlags<QItemSelectionModel::SelectionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemSelectionModel *)cls)->setCurrentIndex (arg1, arg2);
 }
@@ -410,8 +410,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QItemSelectionModel::tr (arg1, arg2));
 }
 
@@ -434,9 +434,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QItemSelectionModel::tr (arg1, arg2, arg3));
 }
 
@@ -457,8 +457,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QItemSelectionModel::trUtf8 (arg1, arg2));
 }
 
@@ -481,9 +481,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QItemSelectionModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -775,7 +775,7 @@ static void _call_ctor_QItemSelectionModel_Adaptor_2419 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   ret.write<QItemSelectionModel_Adaptor *> (new QItemSelectionModel_Adaptor (arg1));
 }
 
@@ -795,8 +795,8 @@ static void _call_ctor_QItemSelectionModel_Adaptor_3613 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QItemSelectionModel_Adaptor *> (new QItemSelectionModel_Adaptor (arg1, arg2));
 }
 
@@ -860,8 +860,8 @@ static void _call_emitter_currentChanged_4682 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QItemSelectionModel_Adaptor *)cls)->emitter_QItemSelectionModel_currentChanged_4682 (arg1, arg2);
 }
 
@@ -881,8 +881,8 @@ static void _call_emitter_currentColumnChanged_4682 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QItemSelectionModel_Adaptor *)cls)->emitter_QItemSelectionModel_currentColumnChanged_4682 (arg1, arg2);
 }
 
@@ -902,8 +902,8 @@ static void _call_emitter_currentRowChanged_4682 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QItemSelectionModel_Adaptor *)cls)->emitter_QItemSelectionModel_currentRowChanged_4682 (arg1, arg2);
 }
 
@@ -945,7 +945,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QItemSelectionModel_Adaptor *)cls)->emitter_QItemSelectionModel_destroyed_1302 (arg1);
 }
 
@@ -989,8 +989,8 @@ static void _call_fp_emitSelectionChanged_5346 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelection &arg1 = args.read<const QItemSelection & > (heap);
-  const QItemSelection &arg2 = args.read<const QItemSelection & > (heap);
+  const QItemSelection &arg1 = gsi::arg_reader<const QItemSelection & >() (args, heap);
+  const QItemSelection &arg2 = gsi::arg_reader<const QItemSelection & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QItemSelectionModel_Adaptor *)cls)->fp_QItemSelectionModel_emitSelectionChanged_5346 (arg1, arg2);
 }
@@ -1058,7 +1058,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QItemSelectionModel_Adaptor *)cls)->fp_QItemSelectionModel_receivers_c1731 (arg1));
 }
 
@@ -1152,8 +1152,8 @@ static void _call_emitter_selectionChanged_5346 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelection &arg1 = args.read<const QItemSelection & > (heap);
-  const QItemSelection &arg2 = args.read<const QItemSelection & > (heap);
+  const QItemSelection &arg1 = gsi::arg_reader<const QItemSelection & >() (args, heap);
+  const QItemSelection &arg2 = gsi::arg_reader<const QItemSelection & >() (args, heap);
   ((QItemSelectionModel_Adaptor *)cls)->emitter_QItemSelectionModel_selectionChanged_5346 (arg1, arg2);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQItemSelectionRange.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQItemSelectionRange.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QItemSelectionRange_3220 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelectionRange &arg1 = args.read<const QItemSelectionRange & > (heap);
+  const QItemSelectionRange &arg1 = gsi::arg_reader<const QItemSelectionRange & >() (args, heap);
   ret.write<QItemSelectionRange *> (new QItemSelectionRange (arg1));
 }
 
@@ -88,8 +88,8 @@ static void _call_ctor_QItemSelectionRange_4682 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QItemSelectionRange *> (new QItemSelectionRange (arg1, arg2));
 }
 
@@ -108,7 +108,7 @@ static void _call_ctor_QItemSelectionRange_2395 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QItemSelectionRange *> (new QItemSelectionRange (arg1));
 }
 
@@ -157,7 +157,7 @@ static void _call_f_contains_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionRange *)cls)->contains (arg1));
 }
 
@@ -180,9 +180,9 @@ static void _call_f_contains_c3713 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionRange *)cls)->contains (arg1, arg2, arg3));
 }
 
@@ -231,7 +231,7 @@ static void _call_f_intersect_c3220 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelectionRange &arg1 = args.read<const QItemSelectionRange & > (heap);
+  const QItemSelectionRange &arg1 = gsi::arg_reader<const QItemSelectionRange & >() (args, heap);
   ret.write<QItemSelectionRange > ((QItemSelectionRange)((QItemSelectionRange *)cls)->intersect (arg1));
 }
 
@@ -250,7 +250,7 @@ static void _call_f_intersected_c3220 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelectionRange &arg1 = args.read<const QItemSelectionRange & > (heap);
+  const QItemSelectionRange &arg1 = gsi::arg_reader<const QItemSelectionRange & >() (args, heap);
   ret.write<QItemSelectionRange > ((QItemSelectionRange)((QItemSelectionRange *)cls)->intersected (arg1));
 }
 
@@ -269,7 +269,7 @@ static void _call_f_intersects_c3220 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelectionRange &arg1 = args.read<const QItemSelectionRange & > (heap);
+  const QItemSelectionRange &arg1 = gsi::arg_reader<const QItemSelectionRange & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionRange *)cls)->intersects (arg1));
 }
 
@@ -333,7 +333,7 @@ static void _call_f_operator_excl__eq__c3220 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelectionRange &arg1 = args.read<const QItemSelectionRange & > (heap);
+  const QItemSelectionRange &arg1 = gsi::arg_reader<const QItemSelectionRange & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionRange *)cls)->operator!= (arg1));
 }
 
@@ -352,7 +352,7 @@ static void _call_f_operator_eq__eq__c3220 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelectionRange &arg1 = args.read<const QItemSelectionRange & > (heap);
+  const QItemSelectionRange &arg1 = gsi::arg_reader<const QItemSelectionRange & >() (args, heap);
   ret.write<bool > ((bool)((QItemSelectionRange *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQKeyEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQKeyEvent.cc
@@ -110,7 +110,7 @@ static void _call_f_matches_c2869 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & arg1 = args.read<const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & > (heap);
+  const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QKeyEvent *)cls)->matches (qt_gsi::QtToCppAdaptor<QKeySequence::StandardKey>(arg1).cref()));
 }
 
@@ -220,15 +220,15 @@ static void _call_f_createExtendedKeyEvent_13204 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  QFlags<Qt::KeyboardModifier> arg3 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
-  quint32 arg4 = args.read<quint32 > (heap);
-  quint32 arg5 = args.read<quint32 > (heap);
-  quint32 arg6 = args.read<quint32 > (heap);
-  const QString &arg7 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  bool arg8 = args ? args.read<bool > (heap) : (bool)(false);
-  unsigned short int arg9 = args ? args.read<unsigned short int > (heap) : (unsigned short int)(1);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg3 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
+  quint32 arg4 = gsi::arg_reader<quint32 >() (args, heap);
+  quint32 arg5 = gsi::arg_reader<quint32 >() (args, heap);
+  quint32 arg6 = gsi::arg_reader<quint32 >() (args, heap);
+  const QString &arg7 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  bool arg8 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
+  unsigned short int arg9 = args ? gsi::arg_reader<unsigned short int >() (args, heap) : gsi::arg_maker<unsigned short int >() (1, heap);
   ret.write<QKeyEvent * > ((QKeyEvent *)QKeyEvent::createExtendedKeyEvent (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
 }
 
@@ -321,12 +321,12 @@ static void _call_ctor_QKeyEvent_Adaptor_10234 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  QFlags<Qt::KeyboardModifier> arg3 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  bool arg5 = args ? args.read<bool > (heap) : (bool)(false);
-  unsigned short int arg6 = args ? args.read<unsigned short int > (heap) : (unsigned short int)(1);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg3 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  bool arg5 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
+  unsigned short int arg6 = args ? gsi::arg_reader<unsigned short int >() (args, heap) : gsi::arg_maker<unsigned short int >() (1, heap);
   ret.write<QKeyEvent_Adaptor *> (new QKeyEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2, arg3, arg4, arg5, arg6));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQKeySequence.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQKeySequence.cc
@@ -65,7 +65,7 @@ static void _call_ctor_QKeySequence_2025 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QKeySequence *> (new QKeySequence (arg1));
 }
 
@@ -90,10 +90,10 @@ static void _call_ctor_QKeySequence_2744 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QKeySequence *> (new QKeySequence (arg1, arg2, arg3, arg4));
 }
 
@@ -112,7 +112,7 @@ static void _call_ctor_QKeySequence_2516 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   ret.write<QKeySequence *> (new QKeySequence (arg1));
 }
 
@@ -131,7 +131,7 @@ static void _call_ctor_QKeySequence_2869 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & arg1 = args.read<const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & > (heap);
+  const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & >() (args, heap);
   ret.write<QKeySequence *> (new QKeySequence (qt_gsi::QtToCppAdaptor<QKeySequence::StandardKey>(arg1).cref()));
 }
 
@@ -195,7 +195,7 @@ static void _call_f_matches_c2516 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   ret.write<qt_gsi::Converter<QKeySequence::SequenceMatch>::target_type > ((qt_gsi::Converter<QKeySequence::SequenceMatch>::target_type)qt_gsi::CppToQtAdaptor<QKeySequence::SequenceMatch>(((QKeySequence *)cls)->matches (arg1)));
 }
 
@@ -214,7 +214,7 @@ static void _call_f_operator_excl__eq__c2516 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   ret.write<bool > ((bool)((QKeySequence *)cls)->operator!= (arg1));
 }
 
@@ -233,7 +233,7 @@ static void _call_f_operator_lt__c2516 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   ret.write<bool > ((bool)((QKeySequence *)cls)->operator< (arg1));
 }
 
@@ -252,7 +252,7 @@ static void _call_f_operator_lt__eq__c2516 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   ret.write<bool > ((bool)((QKeySequence *)cls)->operator<= (arg1));
 }
 
@@ -271,7 +271,7 @@ static void _call_f_operator_eq__2516 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   ret.write<QKeySequence & > ((QKeySequence &)((QKeySequence *)cls)->operator= (arg1));
 }
 
@@ -290,7 +290,7 @@ static void _call_f_operator_eq__eq__c2516 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   ret.write<bool > ((bool)((QKeySequence *)cls)->operator== (arg1));
 }
 
@@ -309,7 +309,7 @@ static void _call_f_operator_gt__c2516 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   ret.write<bool > ((bool)((QKeySequence *)cls)->operator> (arg1));
 }
 
@@ -328,7 +328,7 @@ static void _call_f_operator_gt__eq__c2516 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   ret.write<bool > ((bool)((QKeySequence *)cls)->operator>= (arg1));
 }
 
@@ -347,7 +347,7 @@ static void _call_f_operator_index__c1772 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   ret.write<int > ((int)((QKeySequence *)cls)->operator[] (arg1));
 }
 
@@ -366,7 +366,7 @@ static void _call_f_toString_c3197 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & > (heap) : (const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QKeySequence::SequenceFormat>(heap, QKeySequence::PortableText));
+  const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QKeySequence::SequenceFormat>(heap, QKeySequence::PortableText), heap);
   ret.write<QString > ((QString)((QKeySequence *)cls)->toString (qt_gsi::QtToCppAdaptor<QKeySequence::SequenceFormat>(arg1).cref()));
 }
 
@@ -387,8 +387,8 @@ static void _call_f_fromString_5114 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & > (heap) : (const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QKeySequence::SequenceFormat>(heap, QKeySequence::PortableText));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QKeySequence::SequenceFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QKeySequence::SequenceFormat>(heap, QKeySequence::PortableText), heap);
   ret.write<QKeySequence > ((QKeySequence)QKeySequence::fromString (arg1, qt_gsi::QtToCppAdaptor<QKeySequence::SequenceFormat>(arg2).cref()));
 }
 
@@ -407,7 +407,7 @@ static void _call_f_keyBindings_2869 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & arg1 = args.read<const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & > (heap);
+  const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QKeySequence::StandardKey>::target_type & >() (args, heap);
   ret.write<QList<QKeySequence> > ((QList<QKeySequence>)QKeySequence::keyBindings (qt_gsi::QtToCppAdaptor<QKeySequence::StandardKey>(arg1).cref()));
 }
 
@@ -426,7 +426,7 @@ static void _call_f_mnemonic_2025 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QKeySequence > ((QKeySequence)QKeySequence::mnemonic (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQLCDNumber.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQLCDNumber.cc
@@ -111,7 +111,7 @@ static void _call_f_checkOverflow_c1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<bool > ((bool)((QLCDNumber *)cls)->checkOverflow (arg1));
 }
 
@@ -130,7 +130,7 @@ static void _call_f_checkOverflow_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QLCDNumber *)cls)->checkOverflow (arg1));
 }
 
@@ -164,7 +164,7 @@ static void _call_f_display_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber *)cls)->display (arg1);
 }
@@ -184,7 +184,7 @@ static void _call_f_display_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber *)cls)->display (arg1);
 }
@@ -204,7 +204,7 @@ static void _call_f_display_1071 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber *)cls)->display (arg1);
 }
@@ -316,7 +316,7 @@ static void _call_f_setDigitCount_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber *)cls)->setDigitCount (arg1);
 }
@@ -352,7 +352,7 @@ static void _call_f_setMode_1850 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLCDNumber::Mode>::target_type & arg1 = args.read<const qt_gsi::Converter<QLCDNumber::Mode>::target_type & > (heap);
+  const qt_gsi::Converter<QLCDNumber::Mode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLCDNumber::Mode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber *)cls)->setMode (qt_gsi::QtToCppAdaptor<QLCDNumber::Mode>(arg1).cref());
 }
@@ -372,7 +372,7 @@ static void _call_f_setNumDigits_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber *)cls)->setNumDigits (arg1);
 }
@@ -408,7 +408,7 @@ static void _call_f_setSegmentStyle_2713 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLCDNumber::SegmentStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<QLCDNumber::SegmentStyle>::target_type & > (heap);
+  const qt_gsi::Converter<QLCDNumber::SegmentStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLCDNumber::SegmentStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber *)cls)->setSegmentStyle (qt_gsi::QtToCppAdaptor<QLCDNumber::SegmentStyle>(arg1).cref());
 }
@@ -428,7 +428,7 @@ static void _call_f_setSmallDecimalPoint_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber *)cls)->setSmallDecimalPoint (arg1);
 }
@@ -495,8 +495,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLCDNumber::tr (arg1, arg2));
 }
 
@@ -519,9 +519,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLCDNumber::tr (arg1, arg2, arg3));
 }
 
@@ -542,8 +542,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLCDNumber::trUtf8 (arg1, arg2));
 }
 
@@ -566,9 +566,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLCDNumber::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1468,7 +1468,7 @@ static void _call_ctor_QLCDNumber_Adaptor_1315 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QLCDNumber_Adaptor *> (new QLCDNumber_Adaptor (arg1));
 }
 
@@ -1488,8 +1488,8 @@ static void _call_ctor_QLCDNumber_Adaptor_2979 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QLCDNumber_Adaptor *> (new QLCDNumber_Adaptor (arg1, arg2));
 }
 
@@ -1631,9 +1631,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber_Adaptor *)cls)->fp_QLCDNumber_create_2208 (arg1, arg2, arg3);
 }
@@ -1652,7 +1652,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QLCDNumber_Adaptor *)cls)->emitter_QLCDNumber_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1696,8 +1696,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber_Adaptor *)cls)->fp_QLCDNumber_destroy_1620 (arg1, arg2);
 }
@@ -1716,7 +1716,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QLCDNumber_Adaptor *)cls)->emitter_QLCDNumber_destroyed_1302 (arg1);
 }
 
@@ -1830,7 +1830,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLCDNumber_Adaptor *)cls)->fp_QLCDNumber_drawFrame_1426 (arg1);
 }
@@ -2522,7 +2522,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QLCDNumber_Adaptor *)cls)->fp_QLCDNumber_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQLabel.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQLabel.cc
@@ -175,7 +175,7 @@ static void _call_f_heightForWidth_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QLabel *)cls)->heightForWidth (arg1));
 }
 
@@ -299,7 +299,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setAlignment (arg1);
 }
@@ -319,7 +319,7 @@ static void _call_f_setBuddy_1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setBuddy (arg1);
 }
@@ -339,7 +339,7 @@ static void _call_f_setIndent_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setIndent (arg1);
 }
@@ -359,7 +359,7 @@ static void _call_f_setMargin_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setMargin (arg1);
 }
@@ -379,7 +379,7 @@ static void _call_f_setMovie_1215 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMovie *arg1 = args.read<QMovie * > (heap);
+  QMovie *arg1 = gsi::arg_reader<QMovie * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setMovie (arg1);
 }
@@ -399,7 +399,7 @@ static void _call_f_setNum_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setNum (arg1);
 }
@@ -419,7 +419,7 @@ static void _call_f_setNum_1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setNum (arg1);
 }
@@ -439,7 +439,7 @@ static void _call_f_setOpenExternalLinks_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setOpenExternalLinks (arg1);
 }
@@ -459,7 +459,7 @@ static void _call_f_setPicture_2126 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPicture &arg1 = args.read<const QPicture & > (heap);
+  const QPicture &arg1 = gsi::arg_reader<const QPicture & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setPicture (arg1);
 }
@@ -479,7 +479,7 @@ static void _call_f_setPixmap_2017 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setPixmap (arg1);
 }
@@ -499,7 +499,7 @@ static void _call_f_setScaledContents_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setScaledContents (arg1);
 }
@@ -519,7 +519,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setText (arg1);
 }
@@ -539,7 +539,7 @@ static void _call_f_setTextFormat_1787 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TextFormat>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TextFormat>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TextFormat>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextFormat>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setTextFormat (qt_gsi::QtToCppAdaptor<Qt::TextFormat>(arg1).cref());
 }
@@ -559,7 +559,7 @@ static void _call_f_setTextInteractionFlags_3396 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::TextInteractionFlag> arg1 = args.read<QFlags<Qt::TextInteractionFlag> > (heap);
+  QFlags<Qt::TextInteractionFlag> arg1 = gsi::arg_reader<QFlags<Qt::TextInteractionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setTextInteractionFlags (arg1);
 }
@@ -579,7 +579,7 @@ static void _call_f_setWordWrap_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel *)cls)->setWordWrap (arg1);
 }
@@ -676,8 +676,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLabel::tr (arg1, arg2));
 }
 
@@ -700,9 +700,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLabel::tr (arg1, arg2, arg3));
 }
 
@@ -723,8 +723,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLabel::trUtf8 (arg1, arg2));
 }
 
@@ -747,9 +747,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLabel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1680,8 +1680,8 @@ static void _call_ctor_QLabel_Adaptor_3702 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QLabel_Adaptor *> (new QLabel_Adaptor (arg1, arg2));
 }
 
@@ -1703,9 +1703,9 @@ static void _call_ctor_QLabel_Adaptor_5619 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg3 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg3 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QLabel_Adaptor *> (new QLabel_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1847,9 +1847,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel_Adaptor *)cls)->fp_QLabel_create_2208 (arg1, arg2, arg3);
 }
@@ -1868,7 +1868,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QLabel_Adaptor *)cls)->emitter_QLabel_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1912,8 +1912,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel_Adaptor *)cls)->fp_QLabel_destroy_1620 (arg1, arg2);
 }
@@ -1932,7 +1932,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QLabel_Adaptor *)cls)->emitter_QLabel_destroyed_1302 (arg1);
 }
 
@@ -2046,7 +2046,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLabel_Adaptor *)cls)->fp_QLabel_drawFrame_1426 (arg1);
 }
@@ -2495,7 +2495,7 @@ static void _call_emitter_linkActivated_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QLabel_Adaptor *)cls)->emitter_QLabel_linkActivated_2025 (arg1);
 }
 
@@ -2513,7 +2513,7 @@ static void _call_emitter_linkHovered_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QLabel_Adaptor *)cls)->emitter_QLabel_linkHovered_2025 (arg1);
 }
 
@@ -2760,7 +2760,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QLabel_Adaptor *)cls)->fp_QLabel_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQLayout.cc
@@ -89,7 +89,7 @@ static void _call_f_addItem_1740 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayoutItem *arg1 = args.read<QLayoutItem * > (heap);
+  QLayoutItem *arg1 = gsi::arg_reader<QLayoutItem * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->addItem (arg1);
@@ -110,7 +110,7 @@ static void _call_f_addWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->addWidget (arg1);
 }
@@ -211,10 +211,10 @@ static void _call_f_getContentsMargins_c3488 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->getContentsMargins (arg1, arg2, arg3, arg4);
 }
@@ -234,7 +234,7 @@ static void _call_f_indexOf_c1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QLayout *)cls)->indexOf (arg1));
 }
 
@@ -299,7 +299,7 @@ static void _call_f_itemAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QLayout *)cls)->itemAt (arg1));
 }
 
@@ -408,7 +408,7 @@ static void _call_f_removeItem_1740 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayoutItem *arg1 = args.read<QLayoutItem * > (heap);
+  QLayoutItem *arg1 = gsi::arg_reader<QLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->removeItem (arg1);
 }
@@ -428,7 +428,7 @@ static void _call_f_removeWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->removeWidget (arg1);
 }
@@ -450,8 +450,8 @@ static void _call_f_setAlignment_3957 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QFlags<Qt::AlignmentFlag> arg2 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg2 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   ret.write<bool > ((bool)((QLayout *)cls)->setAlignment (arg1, arg2));
 }
 
@@ -472,8 +472,8 @@ static void _call_f_setAlignment_3983 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
-  QFlags<Qt::AlignmentFlag> arg2 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg2 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   ret.write<bool > ((bool)((QLayout *)cls)->setAlignment (arg1, arg2));
 }
 
@@ -492,7 +492,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->setAlignment (arg1);
 }
@@ -518,10 +518,10 @@ static void _call_f_setContentsMargins_2744 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->setContentsMargins (arg1, arg2, arg3, arg4);
 }
@@ -541,7 +541,7 @@ static void _call_f_setContentsMargins_2115 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->setContentsMargins (arg1);
 }
@@ -561,7 +561,7 @@ static void _call_f_setEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->setEnabled (arg1);
 }
@@ -581,7 +581,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->setGeometry (arg1);
 }
@@ -601,7 +601,7 @@ static void _call_f_setMargin_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->setMargin (arg1);
 }
@@ -621,7 +621,7 @@ static void _call_f_setMenuBar_1315 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->setMenuBar (arg1);
 }
@@ -641,7 +641,7 @@ static void _call_f_setSizeConstraint_2743 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLayout::SizeConstraint>::target_type & arg1 = args.read<const qt_gsi::Converter<QLayout::SizeConstraint>::target_type & > (heap);
+  const qt_gsi::Converter<QLayout::SizeConstraint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLayout::SizeConstraint>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->setSizeConstraint (qt_gsi::QtToCppAdaptor<QLayout::SizeConstraint>(arg1).cref());
 }
@@ -661,7 +661,7 @@ static void _call_f_setSpacing_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout *)cls)->setSpacing (arg1);
 }
@@ -711,7 +711,7 @@ static void _call_f_takeAt_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QLayout *)cls)->takeAt (arg1));
 }
 
@@ -730,7 +730,7 @@ static void _call_f_totalHeightForWidth_c767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QLayout *)cls)->totalHeightForWidth (arg1));
 }
 
@@ -812,8 +812,8 @@ static void _call_f_closestAcceptableSize_3707 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
-  const QSize &arg2 = args.read<const QSize & > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
+  const QSize &arg2 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QSize > ((QSize)QLayout::closestAcceptableSize (arg1, arg2));
 }
 
@@ -834,8 +834,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLayout::tr (arg1, arg2));
 }
 
@@ -858,9 +858,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLayout::tr (arg1, arg2, arg3));
 }
 
@@ -881,8 +881,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLayout::trUtf8 (arg1, arg2));
 }
 
@@ -905,9 +905,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLayout::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1502,7 +1502,7 @@ static void _call_ctor_QLayout_Adaptor_1315 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QLayout_Adaptor *> (new QLayout_Adaptor (arg1));
 }
 
@@ -1534,7 +1534,7 @@ static void _call_fp_addChildLayout_1341 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout_Adaptor *)cls)->fp_QLayout_addChildLayout_1341 (arg1);
@@ -1554,7 +1554,7 @@ static void _call_fp_addChildWidget_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout_Adaptor *)cls)->fp_QLayout_addChildWidget_1315 (arg1);
 }
@@ -1597,7 +1597,7 @@ static void _call_fp_alignmentRect_c1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QLayout_Adaptor *)cls)->fp_QLayout_alignmentRect_c1792 (arg1));
 }
 
@@ -1682,7 +1682,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QLayout_Adaptor *)cls)->emitter_QLayout_destroyed_1302 (arg1);
 }
 
@@ -2018,7 +2018,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QLayout_Adaptor *)cls)->fp_QLayout_receivers_c1731 (arg1));
 }
 
@@ -2178,7 +2178,7 @@ static void _call_fp_widgetEvent_1217 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayout_Adaptor *)cls)->fp_QLayout_widgetEvent_1217 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQLayoutItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQLayoutItem.cc
@@ -130,7 +130,7 @@ static void _call_f_heightForWidth_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QLayoutItem *)cls)->heightForWidth (arg1));
 }
 
@@ -210,7 +210,7 @@ static void _call_f_minimumHeightForWidth_c767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QLayoutItem *)cls)->minimumHeightForWidth (arg1));
 }
 
@@ -244,7 +244,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayoutItem *)cls)->setAlignment (arg1);
 }
@@ -264,7 +264,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLayoutItem *)cls)->setGeometry (arg1);
 }
@@ -609,7 +609,7 @@ static void _call_ctor_QLayoutItem_Adaptor_2750 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args ? args.read<QFlags<Qt::AlignmentFlag> > (heap) : (QFlags<Qt::AlignmentFlag>)(0);
+  QFlags<Qt::AlignmentFlag> arg1 = args ? gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::AlignmentFlag> >() (0, heap);
   ret.write<QLayoutItem_Adaptor *> (new QLayoutItem_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQLineEdit.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQLineEdit.cc
@@ -210,8 +210,8 @@ static void _call_f_cursorBackward_1523 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(1);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->cursorBackward (arg1, arg2);
 }
@@ -233,8 +233,8 @@ static void _call_f_cursorForward_1523 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(1);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->cursorForward (arg1, arg2);
 }
@@ -269,7 +269,7 @@ static void _call_f_cursorPositionAt_1916 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<int > ((int)((QLineEdit *)cls)->cursorPositionAt (arg1));
 }
 
@@ -288,7 +288,7 @@ static void _call_f_cursorWordBackward_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->cursorWordBackward (arg1);
 }
@@ -308,7 +308,7 @@ static void _call_f_cursorWordForward_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->cursorWordForward (arg1);
 }
@@ -421,7 +421,7 @@ static void _call_f_end_864 (const qt_gsi::GenericMethod * /*decl*/, void *cls, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->end (arg1);
 }
@@ -441,7 +441,7 @@ static void _call_f_event_1217 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QLineEdit *)cls)->event (arg1));
 }
 
@@ -466,10 +466,10 @@ static void _call_f_getTextMargins_c3488 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->getTextMargins (arg1, arg2, arg3, arg4);
 }
@@ -534,7 +534,7 @@ static void _call_f_home_864 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->home (arg1);
 }
@@ -569,7 +569,7 @@ static void _call_f_inputMethodQuery_c2420 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QLineEdit *)cls)->inputMethodQuery (qt_gsi::QtToCppAdaptor<Qt::InputMethodQuery>(arg1).cref()));
 }
 
@@ -588,7 +588,7 @@ static void _call_f_insert_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->insert (arg1);
 }
@@ -776,7 +776,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setAlignment (arg1);
 }
@@ -796,7 +796,7 @@ static void _call_f_setCompleter_1642 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QCompleter *arg1 = args.read<QCompleter * > (heap);
+  QCompleter *arg1 = gsi::arg_reader<QCompleter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setCompleter (arg1);
 }
@@ -816,7 +816,7 @@ static void _call_f_setCursorPosition_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setCursorPosition (arg1);
 }
@@ -836,7 +836,7 @@ static void _call_f_setDragEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setDragEnabled (arg1);
 }
@@ -856,7 +856,7 @@ static void _call_f_setEchoMode_2187 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & > (heap);
+  const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QLineEdit::EchoMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setEchoMode (qt_gsi::QtToCppAdaptor<QLineEdit::EchoMode>(arg1).cref());
 }
@@ -876,7 +876,7 @@ static void _call_f_setFrame_864 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setFrame (arg1);
 }
@@ -896,7 +896,7 @@ static void _call_f_setInputMask_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setInputMask (arg1);
 }
@@ -916,7 +916,7 @@ static void _call_f_setMaxLength_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setMaxLength (arg1);
 }
@@ -936,7 +936,7 @@ static void _call_f_setModified_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setModified (arg1);
 }
@@ -956,7 +956,7 @@ static void _call_f_setReadOnly_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setReadOnly (arg1);
 }
@@ -978,8 +978,8 @@ static void _call_f_setSelection_1426 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setSelection (arg1, arg2);
 }
@@ -999,7 +999,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setText (arg1);
 }
@@ -1025,10 +1025,10 @@ static void _call_f_setTextMargins_2744 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setTextMargins (arg1, arg2, arg3, arg4);
 }
@@ -1048,7 +1048,7 @@ static void _call_f_setTextMargins_2115 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setTextMargins (arg1);
 }
@@ -1068,7 +1068,7 @@ static void _call_f_setValidator_2332 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QValidator *arg1 = args.read<const QValidator * > (heap);
+  const QValidator *arg1 = gsi::arg_reader<const QValidator * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit *)cls)->setValidator (arg1);
 }
@@ -1166,8 +1166,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLineEdit::tr (arg1, arg2));
 }
 
@@ -1190,9 +1190,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLineEdit::tr (arg1, arg2, arg3));
 }
 
@@ -1213,8 +1213,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLineEdit::trUtf8 (arg1, arg2));
 }
 
@@ -1237,9 +1237,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLineEdit::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2216,7 +2216,7 @@ static void _call_ctor_QLineEdit_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QLineEdit_Adaptor *> (new QLineEdit_Adaptor (arg1));
 }
 
@@ -2236,8 +2236,8 @@ static void _call_ctor_QLineEdit_Adaptor_3232 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QLineEdit_Adaptor *> (new QLineEdit_Adaptor (arg1, arg2));
 }
 
@@ -2379,9 +2379,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit_Adaptor *)cls)->fp_QLineEdit_create_2208 (arg1, arg2, arg3);
 }
@@ -2402,8 +2402,8 @@ static void _call_emitter_cursorPositionChanged_1426 (const qt_gsi::GenericMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QLineEdit_Adaptor *)cls)->emitter_QLineEdit_cursorPositionChanged_1426 (arg1, arg2);
 }
 
@@ -2435,7 +2435,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QLineEdit_Adaptor *)cls)->emitter_QLineEdit_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2479,8 +2479,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit_Adaptor *)cls)->fp_QLineEdit_destroy_1620 (arg1, arg2);
 }
@@ -2499,7 +2499,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QLineEdit_Adaptor *)cls)->emitter_QLineEdit_destroyed_1302 (arg1);
 }
 
@@ -2918,7 +2918,7 @@ static void _call_fp_initStyleOption_c2356 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionFrame *arg1 = args.read<QStyleOptionFrame * > (heap);
+  QStyleOptionFrame *arg1 = gsi::arg_reader<QStyleOptionFrame * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLineEdit_Adaptor *)cls)->fp_QLineEdit_initStyleOption_c2356 (arg1);
 }
@@ -3305,7 +3305,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QLineEdit_Adaptor *)cls)->fp_QLineEdit_receivers_c1731 (arg1));
 }
 
@@ -3519,7 +3519,7 @@ static void _call_emitter_textChanged_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QLineEdit_Adaptor *)cls)->emitter_QLineEdit_textChanged_2025 (arg1);
 }
 
@@ -3537,7 +3537,7 @@ static void _call_emitter_textEdited_2025 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QLineEdit_Adaptor *)cls)->emitter_QLineEdit_textEdited_2025 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQLinearGradient.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQLinearGradient.cc
@@ -70,8 +70,8 @@ static void _call_ctor_QLinearGradient_3864 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QLinearGradient *> (new QLinearGradient (arg1, arg2));
 }
 
@@ -96,10 +96,10 @@ static void _call_ctor_QLinearGradient_3960 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QLinearGradient *> (new QLinearGradient (arg1, arg2, arg3, arg4));
 }
 
@@ -133,7 +133,7 @@ static void _call_f_setFinalStop_1986 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLinearGradient *)cls)->setFinalStop (arg1);
 }
@@ -155,8 +155,8 @@ static void _call_f_setFinalStop_2034 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLinearGradient *)cls)->setFinalStop (arg1, arg2);
 }
@@ -176,7 +176,7 @@ static void _call_f_setStart_1986 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLinearGradient *)cls)->setStart (arg1);
 }
@@ -198,8 +198,8 @@ static void _call_f_setStart_2034 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLinearGradient *)cls)->setStart (arg1, arg2);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQListView.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQListView.cc
@@ -195,7 +195,7 @@ static void _call_f_indexAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QListView *)cls)->indexAt (arg1));
 }
 
@@ -214,7 +214,7 @@ static void _call_f_isRowHidden_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QListView *)cls)->isRowHidden (arg1));
 }
 
@@ -341,8 +341,8 @@ static void _call_f_scrollTo_5576 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible));
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->scrollTo (arg1, qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollHint>(arg2).cref());
 }
@@ -362,7 +362,7 @@ static void _call_f_setBatchSize_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setBatchSize (arg1);
 }
@@ -382,7 +382,7 @@ static void _call_f_setFlow_1864 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QListView::Flow>::target_type & arg1 = args.read<const qt_gsi::Converter<QListView::Flow>::target_type & > (heap);
+  const qt_gsi::Converter<QListView::Flow>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QListView::Flow>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setFlow (qt_gsi::QtToCppAdaptor<QListView::Flow>(arg1).cref());
 }
@@ -402,7 +402,7 @@ static void _call_f_setGridSize_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setGridSize (arg1);
 }
@@ -422,7 +422,7 @@ static void _call_f_setLayoutMode_2483 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QListView::LayoutMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QListView::LayoutMode>::target_type & > (heap);
+  const qt_gsi::Converter<QListView::LayoutMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QListView::LayoutMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setLayoutMode (qt_gsi::QtToCppAdaptor<QListView::LayoutMode>(arg1).cref());
 }
@@ -442,7 +442,7 @@ static void _call_f_setModelColumn_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setModelColumn (arg1);
 }
@@ -462,7 +462,7 @@ static void _call_f_setMovement_2299 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QListView::Movement>::target_type & arg1 = args.read<const qt_gsi::Converter<QListView::Movement>::target_type & > (heap);
+  const qt_gsi::Converter<QListView::Movement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QListView::Movement>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setMovement (qt_gsi::QtToCppAdaptor<QListView::Movement>(arg1).cref());
 }
@@ -482,7 +482,7 @@ static void _call_f_setResizeMode_2471 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QListView::ResizeMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QListView::ResizeMode>::target_type & > (heap);
+  const qt_gsi::Converter<QListView::ResizeMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QListView::ResizeMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setResizeMode (qt_gsi::QtToCppAdaptor<QListView::ResizeMode>(arg1).cref());
 }
@@ -502,7 +502,7 @@ static void _call_f_setRootIndex_2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setRootIndex (arg1);
 }
@@ -524,8 +524,8 @@ static void _call_f_setRowHidden_1523 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setRowHidden (arg1, arg2);
 }
@@ -545,7 +545,7 @@ static void _call_f_setSelectionRectVisible_864 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setSelectionRectVisible (arg1);
 }
@@ -565,7 +565,7 @@ static void _call_f_setSpacing_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setSpacing (arg1);
 }
@@ -585,7 +585,7 @@ static void _call_f_setUniformItemSizes_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setUniformItemSizes (arg1);
 }
@@ -605,7 +605,7 @@ static void _call_f_setViewMode_2256 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QListView::ViewMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QListView::ViewMode>::target_type & > (heap);
+  const qt_gsi::Converter<QListView::ViewMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QListView::ViewMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setViewMode (qt_gsi::QtToCppAdaptor<QListView::ViewMode>(arg1).cref());
 }
@@ -625,7 +625,7 @@ static void _call_f_setWordWrap_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setWordWrap (arg1);
 }
@@ -645,7 +645,7 @@ static void _call_f_setWrapping_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView *)cls)->setWrapping (arg1);
 }
@@ -710,7 +710,7 @@ static void _call_f_visualRect_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QRect > ((QRect)((QListView *)cls)->visualRect (arg1));
 }
 
@@ -746,8 +746,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QListView::tr (arg1, arg2));
 }
 
@@ -770,9 +770,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QListView::tr (arg1, arg2, arg3));
 }
 
@@ -793,8 +793,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QListView::trUtf8 (arg1, arg2));
 }
 
@@ -817,9 +817,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QListView::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2522,7 +2522,7 @@ static void _call_ctor_QListView_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QListView_Adaptor *> (new QListView_Adaptor (arg1));
 }
 
@@ -2564,7 +2564,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListView_Adaptor *)cls)->emitter_QListView_activated_2395 (arg1);
 }
 
@@ -2630,7 +2630,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListView_Adaptor *)cls)->emitter_QListView_clicked_2395 (arg1);
 }
 
@@ -2765,9 +2765,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_create_2208 (arg1, arg2, arg3);
 }
@@ -2813,7 +2813,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QListView_Adaptor *)cls)->emitter_QListView_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2884,8 +2884,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_destroy_1620 (arg1, arg2);
 }
@@ -2904,7 +2904,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QListView_Adaptor *)cls)->emitter_QListView_destroyed_1302 (arg1);
 }
 
@@ -2995,7 +2995,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListView_Adaptor *)cls)->emitter_QListView_doubleClicked_2395 (arg1);
 }
 
@@ -3085,7 +3085,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_drawFrame_1426 (arg1);
 }
@@ -3243,7 +3243,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListView_Adaptor *)cls)->emitter_QListView_entered_2395 (arg1);
 }
 
@@ -3599,7 +3599,7 @@ static void _call_emitter_indexesMoved_3010 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   ((QListView_Adaptor *)cls)->emitter_QListView_indexesMoved_3010 (arg1);
 }
 
@@ -3664,7 +3664,7 @@ static void _call_fp_internalDrag_2456 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DropAction> arg1 = args.read<QFlags<Qt::DropAction> > (heap);
+  QFlags<Qt::DropAction> arg1 = gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_internalDrag_2456 (arg1);
 }
@@ -3683,7 +3683,7 @@ static void _call_fp_internalDrop_1622 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDropEvent *arg1 = args.read<QDropEvent * > (heap);
+  QDropEvent *arg1 = gsi::arg_reader<QDropEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_internalDrop_1622 (arg1);
 }
@@ -4096,7 +4096,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListView_Adaptor *)cls)->emitter_QListView_pressed_2395 (arg1);
 }
 
@@ -4114,7 +4114,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QListView_Adaptor *)cls)->fp_QListView_receivers_c1731 (arg1));
 }
 
@@ -4132,7 +4132,7 @@ static void _call_fp_rectForIndex_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QRect > ((QRect)((QListView_Adaptor *)cls)->fp_QListView_rectForIndex_c2395 (arg1));
 }
 
@@ -4187,8 +4187,8 @@ static void _call_fp_resizeContents_1426 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_resizeContents_1426 (arg1, arg2);
 }
@@ -4335,8 +4335,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -4488,7 +4488,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_setDirtyRegion_2006 (arg1);
 }
@@ -4507,7 +4507,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -4552,8 +4552,8 @@ static void _call_fp_setPositionForIndex_4203 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_setPositionForIndex_4203 (arg1, arg2);
 }
@@ -4647,7 +4647,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_setState_2776 (arg1);
 }
@@ -4666,7 +4666,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_setVerticalStepsPerItem_767 (arg1);
 }
@@ -4691,10 +4691,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -4713,7 +4713,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_setViewportMargins_2115 (arg1);
 }
@@ -4756,7 +4756,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListView_Adaptor *)cls)->fp_QListView_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQListWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQListWidget.cc
@@ -120,7 +120,7 @@ static void _call_f_addItem_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->addItem (arg1);
 }
@@ -140,7 +140,7 @@ static void _call_f_addItem_2126 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->addItem (arg1);
@@ -161,7 +161,7 @@ static void _call_f_addItems_2437 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->addItems (arg1);
 }
@@ -197,7 +197,7 @@ static void _call_f_closePersistentEditor_2126 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->closePersistentEditor (arg1);
 }
@@ -262,7 +262,7 @@ static void _call_f_dropEvent_1622 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDropEvent *arg1 = args.read<QDropEvent * > (heap);
+  QDropEvent *arg1 = gsi::arg_reader<QDropEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->dropEvent (arg1);
 }
@@ -282,7 +282,7 @@ static void _call_f_editItem_2126 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->editItem (arg1);
 }
@@ -304,8 +304,8 @@ static void _call_f_findItems_c4233 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<Qt::MatchFlag> arg2 = args.read<QFlags<Qt::MatchFlag> > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<Qt::MatchFlag> arg2 = gsi::arg_reader<QFlags<Qt::MatchFlag> >() (args, heap);
   ret.write<QList<QListWidgetItem*> > ((QList<QListWidgetItem*>)((QListWidget *)cls)->findItems (arg1, arg2));
 }
 
@@ -326,8 +326,8 @@ static void _call_f_insertItem_2785 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QListWidgetItem *arg2 = args.read<QListWidgetItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QListWidgetItem *arg2 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   qt_gsi::qt_keep (arg2);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->insertItem (arg1, arg2);
@@ -350,8 +350,8 @@ static void _call_f_insertItem_2684 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->insertItem (arg1, arg2);
 }
@@ -373,8 +373,8 @@ static void _call_f_insertItems_3096 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->insertItems (arg1, arg2);
 }
@@ -394,7 +394,7 @@ static void _call_f_isItemHidden_c2821 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem *arg1 = args.read<const QListWidgetItem * > (heap);
+  const QListWidgetItem *arg1 = gsi::arg_reader<const QListWidgetItem * >() (args, heap);
   ret.write<bool > ((bool)((QListWidget *)cls)->isItemHidden (arg1));
 }
 
@@ -413,7 +413,7 @@ static void _call_f_isItemSelected_c2821 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem *arg1 = args.read<const QListWidgetItem * > (heap);
+  const QListWidgetItem *arg1 = gsi::arg_reader<const QListWidgetItem * >() (args, heap);
   ret.write<bool > ((bool)((QListWidget *)cls)->isItemSelected (arg1));
 }
 
@@ -447,7 +447,7 @@ static void _call_f_item_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QListWidgetItem * > ((QListWidgetItem *)((QListWidget *)cls)->item (arg1));
 }
 
@@ -466,7 +466,7 @@ static void _call_f_itemAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QListWidgetItem * > ((QListWidgetItem *)((QListWidget *)cls)->itemAt (arg1));
 }
 
@@ -487,8 +487,8 @@ static void _call_f_itemAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QListWidgetItem * > ((QListWidgetItem *)((QListWidget *)cls)->itemAt (arg1, arg2));
 }
 
@@ -507,7 +507,7 @@ static void _call_f_itemWidget_c2126 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QListWidget *)cls)->itemWidget (arg1));
 }
 
@@ -526,7 +526,7 @@ static void _call_f_openPersistentEditor_2126 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->openPersistentEditor (arg1);
 }
@@ -546,7 +546,7 @@ static void _call_f_removeItemWidget_2126 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->removeItemWidget (arg1);
 }
@@ -566,7 +566,7 @@ static void _call_f_row_c2821 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem *arg1 = args.read<const QListWidgetItem * > (heap);
+  const QListWidgetItem *arg1 = gsi::arg_reader<const QListWidgetItem * >() (args, heap);
   ret.write<int > ((int)((QListWidget *)cls)->row (arg1));
 }
 
@@ -587,8 +587,8 @@ static void _call_f_scrollToItem_6002 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem *arg1 = args.read<const QListWidgetItem * > (heap);
-  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible));
+  const QListWidgetItem *arg1 = gsi::arg_reader<const QListWidgetItem * >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->scrollToItem (arg1, qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollHint>(arg2).cref());
 }
@@ -623,7 +623,7 @@ static void _call_f_setCurrentItem_2126 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->setCurrentItem (arg1);
 }
@@ -645,8 +645,8 @@ static void _call_f_setCurrentItem_6489 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
-  QFlags<QItemSelectionModel::SelectionFlag> arg2 = args.read<QFlags<QItemSelectionModel::SelectionFlag> > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
+  QFlags<QItemSelectionModel::SelectionFlag> arg2 = gsi::arg_reader<QFlags<QItemSelectionModel::SelectionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->setCurrentItem (arg1, arg2);
 }
@@ -666,7 +666,7 @@ static void _call_f_setCurrentRow_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->setCurrentRow (arg1);
 }
@@ -688,8 +688,8 @@ static void _call_f_setCurrentRow_5130 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QFlags<QItemSelectionModel::SelectionFlag> arg2 = args.read<QFlags<QItemSelectionModel::SelectionFlag> > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QFlags<QItemSelectionModel::SelectionFlag> arg2 = gsi::arg_reader<QFlags<QItemSelectionModel::SelectionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->setCurrentRow (arg1, arg2);
 }
@@ -711,8 +711,8 @@ static void _call_f_setItemHidden_3577 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem *arg1 = args.read<const QListWidgetItem * > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QListWidgetItem *arg1 = gsi::arg_reader<const QListWidgetItem * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->setItemHidden (arg1, arg2);
 }
@@ -734,8 +734,8 @@ static void _call_f_setItemSelected_3577 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem *arg1 = args.read<const QListWidgetItem * > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QListWidgetItem *arg1 = gsi::arg_reader<const QListWidgetItem * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->setItemSelected (arg1, arg2);
 }
@@ -757,8 +757,8 @@ static void _call_f_setItemWidget_3333 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->setItemWidget (arg1, arg2);
 }
@@ -778,7 +778,7 @@ static void _call_f_setSortingEnabled_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->setSortingEnabled (arg1);
 }
@@ -798,7 +798,7 @@ static void _call_f_sortItems_1681 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SortOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder));
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget *)cls)->sortItems (qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg1).cref());
 }
@@ -818,7 +818,7 @@ static void _call_f_takeItem_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QListWidgetItem * > ((QListWidgetItem *)((QListWidget *)cls)->takeItem (arg1));
 }
 
@@ -837,7 +837,7 @@ static void _call_f_visualItemRect_c2821 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem *arg1 = args.read<const QListWidgetItem * > (heap);
+  const QListWidgetItem *arg1 = gsi::arg_reader<const QListWidgetItem * >() (args, heap);
   ret.write<QRect > ((QRect)((QListWidget *)cls)->visualItemRect (arg1));
 }
 
@@ -858,8 +858,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QListWidget::tr (arg1, arg2));
 }
 
@@ -882,9 +882,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QListWidget::tr (arg1, arg2, arg3));
 }
 
@@ -905,8 +905,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QListWidget::trUtf8 (arg1, arg2));
 }
 
@@ -929,9 +929,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QListWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2769,7 +2769,7 @@ static void _call_ctor_QListWidget_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QListWidget_Adaptor *> (new QListWidget_Adaptor (arg1));
 }
 
@@ -2811,7 +2811,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_activated_2395 (arg1);
 }
 
@@ -2877,7 +2877,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_clicked_2395 (arg1);
 }
 
@@ -3012,9 +3012,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -3062,8 +3062,8 @@ static void _call_emitter_currentItemChanged_4144 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
-  QListWidgetItem *arg2 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
+  QListWidgetItem *arg2 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_currentItemChanged_4144 (arg1, arg2);
 }
 
@@ -3081,7 +3081,7 @@ static void _call_emitter_currentRowChanged_767 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_currentRowChanged_767 (arg1);
 }
 
@@ -3099,7 +3099,7 @@ static void _call_emitter_currentTextChanged_2025 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_currentTextChanged_2025 (arg1);
 }
 
@@ -3117,7 +3117,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -3188,8 +3188,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_destroy_1620 (arg1, arg2);
 }
@@ -3208,7 +3208,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_destroyed_1302 (arg1);
 }
 
@@ -3299,7 +3299,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_doubleClicked_2395 (arg1);
 }
 
@@ -3389,7 +3389,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_drawFrame_1426 (arg1);
 }
@@ -3576,7 +3576,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_entered_2395 (arg1);
 }
 
@@ -3932,7 +3932,7 @@ static void _call_fp_indexFromItem_c2126 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QListWidget_Adaptor *)cls)->fp_QListWidget_indexFromItem_c2126 (arg1));
 }
 
@@ -3950,7 +3950,7 @@ static void _call_emitter_indexesMoved_3010 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_indexesMoved_3010 (arg1);
 }
 
@@ -4015,7 +4015,7 @@ static void _call_fp_internalDrag_2456 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DropAction> arg1 = args.read<QFlags<Qt::DropAction> > (heap);
+  QFlags<Qt::DropAction> arg1 = gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_internalDrag_2456 (arg1);
 }
@@ -4034,7 +4034,7 @@ static void _call_fp_internalDrop_1622 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDropEvent *arg1 = args.read<QDropEvent * > (heap);
+  QDropEvent *arg1 = gsi::arg_reader<QDropEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_internalDrop_1622 (arg1);
 }
@@ -4076,7 +4076,7 @@ static void _call_emitter_itemActivated_2126 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_itemActivated_2126 (arg1);
 }
 
@@ -4094,7 +4094,7 @@ static void _call_emitter_itemChanged_2126 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_itemChanged_2126 (arg1);
 }
 
@@ -4112,7 +4112,7 @@ static void _call_emitter_itemClicked_2126 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_itemClicked_2126 (arg1);
 }
 
@@ -4130,7 +4130,7 @@ static void _call_emitter_itemDoubleClicked_2126 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_itemDoubleClicked_2126 (arg1);
 }
 
@@ -4148,7 +4148,7 @@ static void _call_emitter_itemEntered_2126 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_itemEntered_2126 (arg1);
 }
 
@@ -4166,7 +4166,7 @@ static void _call_fp_itemFromIndex_c2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QListWidgetItem * > ((QListWidgetItem *)((QListWidget_Adaptor *)cls)->fp_QListWidget_itemFromIndex_c2395 (arg1));
 }
 
@@ -4184,7 +4184,7 @@ static void _call_emitter_itemPressed_2126 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidgetItem *arg1 = args.read<QListWidgetItem * > (heap);
+  QListWidgetItem *arg1 = gsi::arg_reader<QListWidgetItem * >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_itemPressed_2126 (arg1);
 }
 
@@ -4216,7 +4216,7 @@ static void _call_fp_items_c2168 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
   ret.write<QList<QListWidgetItem*> > ((QList<QListWidgetItem*>)((QListWidget_Adaptor *)cls)->fp_QListWidget_items_c2168 (arg1));
 }
 
@@ -4647,7 +4647,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QListWidget_Adaptor *)cls)->emitter_QListWidget_pressed_2395 (arg1);
 }
 
@@ -4665,7 +4665,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QListWidget_Adaptor *)cls)->fp_QListWidget_receivers_c1731 (arg1));
 }
 
@@ -4683,7 +4683,7 @@ static void _call_fp_rectForIndex_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QRect > ((QRect)((QListWidget_Adaptor *)cls)->fp_QListWidget_rectForIndex_c2395 (arg1));
 }
 
@@ -4738,8 +4738,8 @@ static void _call_fp_resizeContents_1426 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_resizeContents_1426 (arg1, arg2);
 }
@@ -4886,8 +4886,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -5039,7 +5039,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_setDirtyRegion_2006 (arg1);
 }
@@ -5058,7 +5058,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -5079,8 +5079,8 @@ static void _call_fp_setPositionForIndex_4203 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_setPositionForIndex_4203 (arg1, arg2);
 }
@@ -5174,7 +5174,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_setState_2776 (arg1);
 }
@@ -5193,7 +5193,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_setVerticalStepsPerItem_767 (arg1);
 }
@@ -5218,10 +5218,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -5240,7 +5240,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_setViewportMargins_2115 (arg1);
 }
@@ -5283,7 +5283,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidget_Adaptor *)cls)->fp_QListWidget_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQListWidgetItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQListWidgetItem.cc
@@ -117,7 +117,7 @@ static void _call_f_data_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QListWidgetItem *)cls)->data (arg1));
 }
 
@@ -241,7 +241,7 @@ static void _call_f_operator_lt__c2817 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem &arg1 = args.read<const QListWidgetItem & > (heap);
+  const QListWidgetItem &arg1 = gsi::arg_reader<const QListWidgetItem & >() (args, heap);
   ret.write<bool > ((bool)((QListWidgetItem *)cls)->operator< (arg1));
 }
 
@@ -260,7 +260,7 @@ static void _call_f_operator_eq__2817 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem &arg1 = args.read<const QListWidgetItem & > (heap);
+  const QListWidgetItem &arg1 = gsi::arg_reader<const QListWidgetItem & >() (args, heap);
   ret.write<QListWidgetItem & > ((QListWidgetItem &)((QListWidgetItem *)cls)->operator= (arg1));
 }
 
@@ -279,7 +279,7 @@ static void _call_f_read_1697 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->read (arg1);
 }
@@ -299,7 +299,7 @@ static void _call_f_setBackground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setBackground (arg1);
 }
@@ -319,7 +319,7 @@ static void _call_f_setBackgroundColor_1905 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setBackgroundColor (arg1);
 }
@@ -339,7 +339,7 @@ static void _call_f_setCheckState_1740 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CheckState>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CheckState>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CheckState>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CheckState>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setCheckState (qt_gsi::QtToCppAdaptor<Qt::CheckState>(arg1).cref());
 }
@@ -361,8 +361,8 @@ static void _call_f_setData_2778 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setData (arg1, arg2);
 }
@@ -382,7 +382,7 @@ static void _call_f_setFlags_2222 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::ItemFlag> arg1 = args.read<QFlags<Qt::ItemFlag> > (heap);
+  QFlags<Qt::ItemFlag> arg1 = gsi::arg_reader<QFlags<Qt::ItemFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setFlags (arg1);
 }
@@ -402,7 +402,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setFont (arg1);
 }
@@ -422,7 +422,7 @@ static void _call_f_setForeground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setForeground (arg1);
 }
@@ -442,7 +442,7 @@ static void _call_f_setHidden_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setHidden (arg1);
 }
@@ -462,7 +462,7 @@ static void _call_f_setIcon_1787 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setIcon (arg1);
 }
@@ -482,7 +482,7 @@ static void _call_f_setSelected_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setSelected (arg1);
 }
@@ -502,7 +502,7 @@ static void _call_f_setSizeHint_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setSizeHint (arg1);
 }
@@ -522,7 +522,7 @@ static void _call_f_setStatusTip_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setStatusTip (arg1);
 }
@@ -542,7 +542,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setText (arg1);
 }
@@ -562,7 +562,7 @@ static void _call_f_setTextAlignment_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setTextAlignment (arg1);
 }
@@ -582,7 +582,7 @@ static void _call_f_setTextColor_1905 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setTextColor (arg1);
 }
@@ -602,7 +602,7 @@ static void _call_f_setToolTip_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setToolTip (arg1);
 }
@@ -622,7 +622,7 @@ static void _call_f_setWhatsThis_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->setWhatsThis (arg1);
 }
@@ -762,7 +762,7 @@ static void _call_f_write_c1697 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QListWidgetItem *)cls)->write (arg1);
 }
@@ -1023,8 +1023,8 @@ static void _call_ctor_QListWidgetItem_Adaptor_2386 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QListWidget *arg1 = args ? args.read<QListWidget * > (heap) : (QListWidget *)(0);
-  int arg2 = args ? args.read<int > (heap) : (int)(QListWidgetItem::Type);
+  QListWidget *arg1 = args ? gsi::arg_reader<QListWidget * >() (args, heap) : gsi::arg_maker<QListWidget * >() (0, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QListWidgetItem::Type, heap);
   QListWidgetItem_Adaptor *obj = new QListWidgetItem_Adaptor (arg1, arg2);
   if (arg1) {
     qt_gsi::qt_keep (obj);
@@ -1050,9 +1050,9 @@ static void _call_ctor_QListWidgetItem_Adaptor_4303 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QListWidget *arg2 = args ? args.read<QListWidget * > (heap) : (QListWidget *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(QListWidgetItem::Type);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QListWidget *arg2 = args ? gsi::arg_reader<QListWidget * >() (args, heap) : gsi::arg_maker<QListWidget * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QListWidgetItem::Type, heap);
   ret.write<QListWidgetItem_Adaptor *> (new QListWidgetItem_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1076,10 +1076,10 @@ static void _call_ctor_QListWidgetItem_Adaptor_5982 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QListWidget *arg3 = args ? args.read<QListWidget * > (heap) : (QListWidget *)(0);
-  int arg4 = args ? args.read<int > (heap) : (int)(QListWidgetItem::Type);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QListWidget *arg3 = args ? gsi::arg_reader<QListWidget * >() (args, heap) : gsi::arg_maker<QListWidget * >() (0, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QListWidgetItem::Type, heap);
   ret.write<QListWidgetItem_Adaptor *> (new QListWidgetItem_Adaptor (arg1, arg2, arg3, arg4));
 }
 
@@ -1097,7 +1097,7 @@ static void _call_ctor_QListWidgetItem_Adaptor_2817 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QListWidgetItem &arg1 = args.read<const QListWidgetItem & > (heap);
+  const QListWidgetItem &arg1 = gsi::arg_reader<const QListWidgetItem & >() (args, heap);
   ret.write<QListWidgetItem_Adaptor *> (new QListWidgetItem_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMainWindow.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMainWindow.cc
@@ -118,8 +118,8 @@ static void _call_f_addDockWidget_3715 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & > (heap);
-  QDockWidget *arg2 = args.read<QDockWidget * > (heap);
+  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & >() (args, heap);
+  QDockWidget *arg2 = gsi::arg_reader<QDockWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->addDockWidget (qt_gsi::QtToCppAdaptor<Qt::DockWidgetArea>(arg1).cref(), arg2);
 }
@@ -143,9 +143,9 @@ static void _call_f_addDockWidget_5520 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & > (heap);
-  QDockWidget *arg2 = args.read<QDockWidget * > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & >() (args, heap);
+  QDockWidget *arg2 = gsi::arg_reader<QDockWidget * >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->addDockWidget (qt_gsi::QtToCppAdaptor<Qt::DockWidgetArea>(arg1).cref(), arg2, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg3).cref());
 }
@@ -167,8 +167,8 @@ static void _call_f_addToolBar_3103 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ToolBarArea>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ToolBarArea>::target_type & > (heap);
-  QToolBar *arg2 = args.read<QToolBar * > (heap);
+  const qt_gsi::Converter<Qt::ToolBarArea>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ToolBarArea>::target_type & >() (args, heap);
+  QToolBar *arg2 = gsi::arg_reader<QToolBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->addToolBar (qt_gsi::QtToCppAdaptor<Qt::ToolBarArea>(arg1).cref(), arg2);
 }
@@ -188,7 +188,7 @@ static void _call_f_addToolBar_1394 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QToolBar *arg1 = args.read<QToolBar * > (heap);
+  QToolBar *arg1 = gsi::arg_reader<QToolBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->addToolBar (arg1);
 }
@@ -208,7 +208,7 @@ static void _call_f_addToolBar_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QToolBar * > ((QToolBar *)((QMainWindow *)cls)->addToolBar (arg1));
 }
 
@@ -227,7 +227,7 @@ static void _call_f_addToolBarBreak_1817 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ToolBarArea>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::ToolBarArea>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ToolBarArea>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ToolBarArea>(heap, Qt::TopToolBarArea));
+  const qt_gsi::Converter<Qt::ToolBarArea>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ToolBarArea>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ToolBarArea>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ToolBarArea>(heap, Qt::TopToolBarArea), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->addToolBarBreak (qt_gsi::QtToCppAdaptor<Qt::ToolBarArea>(arg1).cref());
 }
@@ -262,7 +262,7 @@ static void _call_f_corner_c1366 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Corner>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Corner>::target_type & >() (args, heap);
   ret.write<qt_gsi::Converter<Qt::DockWidgetArea>::target_type > ((qt_gsi::Converter<Qt::DockWidgetArea>::target_type)qt_gsi::CppToQtAdaptor<Qt::DockWidgetArea>(((QMainWindow *)cls)->corner (qt_gsi::QtToCppAdaptor<Qt::Corner>(arg1).cref())));
 }
 
@@ -311,7 +311,7 @@ static void _call_f_dockWidgetArea_c1700 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDockWidget *arg1 = args.read<QDockWidget * > (heap);
+  QDockWidget *arg1 = gsi::arg_reader<QDockWidget * >() (args, heap);
   ret.write<qt_gsi::Converter<Qt::DockWidgetArea>::target_type > ((qt_gsi::Converter<Qt::DockWidgetArea>::target_type)qt_gsi::CppToQtAdaptor<Qt::DockWidgetArea>(((QMainWindow *)cls)->dockWidgetArea (arg1)));
 }
 
@@ -362,8 +362,8 @@ static void _call_f_insertToolBar_2680 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QToolBar *arg1 = args.read<QToolBar * > (heap);
-  QToolBar *arg2 = args.read<QToolBar * > (heap);
+  QToolBar *arg1 = gsi::arg_reader<QToolBar * >() (args, heap);
+  QToolBar *arg2 = gsi::arg_reader<QToolBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->insertToolBar (arg1, arg2);
 }
@@ -383,7 +383,7 @@ static void _call_f_insertToolBarBreak_1394 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QToolBar *arg1 = args.read<QToolBar * > (heap);
+  QToolBar *arg1 = gsi::arg_reader<QToolBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->insertToolBarBreak (arg1);
 }
@@ -433,7 +433,7 @@ static void _call_f_isSeparator_c1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<bool > ((bool)((QMainWindow *)cls)->isSeparator (arg1));
 }
 
@@ -482,7 +482,7 @@ static void _call_f_removeDockWidget_1700 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDockWidget *arg1 = args.read<QDockWidget * > (heap);
+  QDockWidget *arg1 = gsi::arg_reader<QDockWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->removeDockWidget (arg1);
 }
@@ -502,7 +502,7 @@ static void _call_f_removeToolBar_1394 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QToolBar *arg1 = args.read<QToolBar * > (heap);
+  QToolBar *arg1 = gsi::arg_reader<QToolBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->removeToolBar (arg1);
 }
@@ -522,7 +522,7 @@ static void _call_f_removeToolBarBreak_1394 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QToolBar *arg1 = args.read<QToolBar * > (heap);
+  QToolBar *arg1 = gsi::arg_reader<QToolBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->removeToolBarBreak (arg1);
 }
@@ -542,7 +542,7 @@ static void _call_f_restoreDockWidget_1700 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDockWidget *arg1 = args.read<QDockWidget * > (heap);
+  QDockWidget *arg1 = gsi::arg_reader<QDockWidget * >() (args, heap);
   ret.write<bool > ((bool)((QMainWindow *)cls)->restoreDockWidget (arg1));
 }
 
@@ -563,8 +563,8 @@ static void _call_f_restoreState_2968 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<bool > ((bool)((QMainWindow *)cls)->restoreState (arg1, arg2));
 }
 
@@ -583,7 +583,7 @@ static void _call_f_saveState_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QByteArray > ((QByteArray)((QMainWindow *)cls)->saveState (arg1));
 }
 
@@ -602,7 +602,7 @@ static void _call_f_setAnimated_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setAnimated (arg1);
 }
@@ -622,7 +622,7 @@ static void _call_f_setCentralWidget_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setCentralWidget (arg1);
 }
@@ -644,8 +644,8 @@ static void _call_f_setCorner_3381 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Corner>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Corner>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setCorner (qt_gsi::QtToCppAdaptor<Qt::Corner>(arg1).cref(), qt_gsi::QtToCppAdaptor<Qt::DockWidgetArea>(arg2).cref());
 }
@@ -665,7 +665,7 @@ static void _call_f_setDockNestingEnabled_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setDockNestingEnabled (arg1);
 }
@@ -685,7 +685,7 @@ static void _call_f_setDockOptions_3368 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QMainWindow::DockOption> arg1 = args.read<QFlags<QMainWindow::DockOption> > (heap);
+  QFlags<QMainWindow::DockOption> arg1 = gsi::arg_reader<QFlags<QMainWindow::DockOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setDockOptions (arg1);
 }
@@ -705,7 +705,7 @@ static void _call_f_setDocumentMode_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setDocumentMode (arg1);
 }
@@ -725,7 +725,7 @@ static void _call_f_setIconSize_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setIconSize (arg1);
 }
@@ -745,7 +745,7 @@ static void _call_f_setMenuBar_1385 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMenuBar *arg1 = args.read<QMenuBar * > (heap);
+  QMenuBar *arg1 = gsi::arg_reader<QMenuBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setMenuBar (arg1);
 }
@@ -765,7 +765,7 @@ static void _call_f_setMenuWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setMenuWidget (arg1);
 }
@@ -785,7 +785,7 @@ static void _call_f_setStatusBar_1624 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStatusBar *arg1 = args.read<QStatusBar * > (heap);
+  QStatusBar *arg1 = gsi::arg_reader<QStatusBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setStatusBar (arg1);
 }
@@ -807,8 +807,8 @@ static void _call_f_setTabPosition_5367 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DockWidgetArea> arg1 = args.read<QFlags<Qt::DockWidgetArea> > (heap);
-  const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & arg2 = args.read<const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & > (heap);
+  QFlags<Qt::DockWidgetArea> arg1 = gsi::arg_reader<QFlags<Qt::DockWidgetArea> >() (args, heap);
+  const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setTabPosition (arg1, qt_gsi::QtToCppAdaptor<QTabWidget::TabPosition>(arg2).cref());
 }
@@ -828,7 +828,7 @@ static void _call_f_setTabShape_2300 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTabWidget::TabShape>::target_type & arg1 = args.read<const qt_gsi::Converter<QTabWidget::TabShape>::target_type & > (heap);
+  const qt_gsi::Converter<QTabWidget::TabShape>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTabWidget::TabShape>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setTabShape (qt_gsi::QtToCppAdaptor<QTabWidget::TabShape>(arg1).cref());
 }
@@ -848,7 +848,7 @@ static void _call_f_setToolButtonStyle_2328 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setToolButtonStyle (qt_gsi::QtToCppAdaptor<Qt::ToolButtonStyle>(arg1).cref());
 }
@@ -868,7 +868,7 @@ static void _call_f_setUnifiedTitleAndToolBarOnMac_864 (const qt_gsi::GenericMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->setUnifiedTitleAndToolBarOnMac (arg1);
 }
@@ -892,9 +892,9 @@ static void _call_f_splitDockWidget_5097 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDockWidget *arg1 = args.read<QDockWidget * > (heap);
-  QDockWidget *arg2 = args.read<QDockWidget * > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  QDockWidget *arg1 = gsi::arg_reader<QDockWidget * >() (args, heap);
+  QDockWidget *arg2 = gsi::arg_reader<QDockWidget * >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->splitDockWidget (arg1, arg2, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg3).cref());
 }
@@ -929,7 +929,7 @@ static void _call_f_tabPosition_c2123 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::DockWidgetArea>::target_type & >() (args, heap);
   ret.write<qt_gsi::Converter<QTabWidget::TabPosition>::target_type > ((qt_gsi::Converter<QTabWidget::TabPosition>::target_type)qt_gsi::CppToQtAdaptor<QTabWidget::TabPosition>(((QMainWindow *)cls)->tabPosition (qt_gsi::QtToCppAdaptor<Qt::DockWidgetArea>(arg1).cref())));
 }
 
@@ -963,7 +963,7 @@ static void _call_f_tabifiedDockWidgets_c1700 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDockWidget *arg1 = args.read<QDockWidget * > (heap);
+  QDockWidget *arg1 = gsi::arg_reader<QDockWidget * >() (args, heap);
   ret.write<QList<QDockWidget*> > ((QList<QDockWidget*>)((QMainWindow *)cls)->tabifiedDockWidgets (arg1));
 }
 
@@ -984,8 +984,8 @@ static void _call_f_tabifyDockWidget_3292 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDockWidget *arg1 = args.read<QDockWidget * > (heap);
-  QDockWidget *arg2 = args.read<QDockWidget * > (heap);
+  QDockWidget *arg1 = gsi::arg_reader<QDockWidget * >() (args, heap);
+  QDockWidget *arg2 = gsi::arg_reader<QDockWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow *)cls)->tabifyDockWidget (arg1, arg2);
 }
@@ -1005,7 +1005,7 @@ static void _call_f_toolBarArea_c1394 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QToolBar *arg1 = args.read<QToolBar * > (heap);
+  QToolBar *arg1 = gsi::arg_reader<QToolBar * >() (args, heap);
   ret.write<qt_gsi::Converter<Qt::ToolBarArea>::target_type > ((qt_gsi::Converter<Qt::ToolBarArea>::target_type)qt_gsi::CppToQtAdaptor<Qt::ToolBarArea>(((QMainWindow *)cls)->toolBarArea (arg1)));
 }
 
@@ -1024,7 +1024,7 @@ static void _call_f_toolBarBreak_c1394 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QToolBar *arg1 = args.read<QToolBar * > (heap);
+  QToolBar *arg1 = gsi::arg_reader<QToolBar * >() (args, heap);
   ret.write<bool > ((bool)((QMainWindow *)cls)->toolBarBreak (arg1));
 }
 
@@ -1075,8 +1075,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMainWindow::tr (arg1, arg2));
 }
 
@@ -1099,9 +1099,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMainWindow::tr (arg1, arg2, arg3));
 }
 
@@ -1122,8 +1122,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMainWindow::trUtf8 (arg1, arg2));
 }
 
@@ -1146,9 +1146,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMainWindow::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2090,8 +2090,8 @@ static void _call_ctor_QMainWindow_Adaptor_3702 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QMainWindow_Adaptor *> (new QMainWindow_Adaptor (arg1, arg2));
 }
 
@@ -2233,9 +2233,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow_Adaptor *)cls)->fp_QMainWindow_create_2208 (arg1, arg2, arg3);
 }
@@ -2273,7 +2273,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QMainWindow_Adaptor *)cls)->emitter_QMainWindow_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2317,8 +2317,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMainWindow_Adaptor *)cls)->fp_QMainWindow_destroy_1620 (arg1, arg2);
 }
@@ -2337,7 +2337,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QMainWindow_Adaptor *)cls)->emitter_QMainWindow_destroyed_1302 (arg1);
 }
 
@@ -2742,7 +2742,7 @@ static void _call_emitter_iconSizeChanged_1805 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ((QMainWindow_Adaptor *)cls)->emitter_QMainWindow_iconSizeChanged_1805 (arg1);
 }
 
@@ -3128,7 +3128,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMainWindow_Adaptor *)cls)->fp_QMainWindow_receivers_c1731 (arg1));
 }
 
@@ -3338,7 +3338,7 @@ static void _call_emitter_toolButtonStyleChanged_2328 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & >() (args, heap);
   ((QMainWindow_Adaptor *)cls)->emitter_QMainWindow_toolButtonStyleChanged_2328 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMatrix.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMatrix.cc
@@ -60,7 +60,7 @@ static void _call_ctor_QMatrix_2229 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Initialization>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Initialization>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Initialization>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Initialization>::target_type & >() (args, heap);
   ret.write<QMatrix *> (new QMatrix (qt_gsi::QtToCppAdaptor<Qt::Initialization>(arg1).cref()));
 }
 
@@ -104,12 +104,12 @@ static void _call_ctor_QMatrix_5886 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
   ret.write<QMatrix *> (new QMatrix (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -128,7 +128,7 @@ static void _call_ctor_QMatrix_2023 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   ret.write<QMatrix *> (new QMatrix (arg1));
 }
 
@@ -207,7 +207,7 @@ static void _call_f_inverted_c1050 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool *arg1 = args ? args.read<bool * > (heap) : (bool *)(0);
+  bool *arg1 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<QMatrix > ((QMatrix)((QMatrix *)cls)->inverted (arg1));
 }
 
@@ -322,10 +322,10 @@ static void _call_f_map_c3116 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix *)cls)->map (arg1, arg2, arg3, arg4);
 }
@@ -351,10 +351,10 @@ static void _call_f_map_c4332 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix *)cls)->map (arg1, arg2, arg3, arg4);
 }
@@ -374,7 +374,7 @@ static void _call_f_map_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QMatrix *)cls)->map (arg1));
 }
 
@@ -393,7 +393,7 @@ static void _call_f_map_c1986 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QMatrix *)cls)->map (arg1));
 }
 
@@ -412,7 +412,7 @@ static void _call_f_map_c1786 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLine &arg1 = args.read<const QLine & > (heap);
+  const QLine &arg1 = gsi::arg_reader<const QLine & >() (args, heap);
   ret.write<QLine > ((QLine)((QMatrix *)cls)->map (arg1));
 }
 
@@ -431,7 +431,7 @@ static void _call_f_map_c1856 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
   ret.write<QLineF > ((QLineF)((QMatrix *)cls)->map (arg1));
 }
 
@@ -450,7 +450,7 @@ static void _call_f_map_c2208 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QMatrix *)cls)->map (arg1));
 }
 
@@ -469,7 +469,7 @@ static void _call_f_map_c2138 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QMatrix *)cls)->map (arg1));
 }
 
@@ -488,7 +488,7 @@ static void _call_f_map_c2006 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QMatrix *)cls)->map (arg1));
 }
 
@@ -507,7 +507,7 @@ static void _call_f_map_c2514 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QMatrix *)cls)->map (arg1));
 }
 
@@ -526,7 +526,7 @@ static void _call_f_mapRect_c1792 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QMatrix *)cls)->mapRect (arg1));
 }
 
@@ -545,7 +545,7 @@ static void _call_f_mapRect_c1862 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QMatrix *)cls)->mapRect (arg1));
 }
 
@@ -564,7 +564,7 @@ static void _call_f_mapToPolygon_c1792 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QMatrix *)cls)->mapToPolygon (arg1));
 }
 
@@ -583,7 +583,7 @@ static void _call_f_operator_excl__eq__c2023 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   ret.write<bool > ((bool)((QMatrix *)cls)->operator!= (arg1));
 }
 
@@ -602,7 +602,7 @@ static void _call_f_operator_star__c2023 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   ret.write<QMatrix > ((QMatrix)((QMatrix *)cls)->operator* (arg1));
 }
 
@@ -621,7 +621,7 @@ static void _call_f_operator_star__eq__2023 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   ret.write<QMatrix & > ((QMatrix &)((QMatrix *)cls)->operator*= (arg1));
 }
 
@@ -640,7 +640,7 @@ static void _call_f_operator_eq__2023 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   ret.write<QMatrix & > ((QMatrix &)((QMatrix *)cls)->operator= (arg1));
 }
 
@@ -659,7 +659,7 @@ static void _call_f_operator_eq__eq__c2023 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   ret.write<bool > ((bool)((QMatrix *)cls)->operator== (arg1));
 }
 
@@ -694,7 +694,7 @@ static void _call_f_rotate_1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QMatrix & > ((QMatrix &)((QMatrix *)cls)->rotate (arg1));
 }
 
@@ -715,8 +715,8 @@ static void _call_f_scale_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QMatrix & > ((QMatrix &)((QMatrix *)cls)->scale (arg1, arg2));
 }
 
@@ -745,12 +745,12 @@ static void _call_f_setMatrix_5886 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix *)cls)->setMatrix (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -772,8 +772,8 @@ static void _call_f_shear_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QMatrix & > ((QMatrix &)((QMatrix *)cls)->shear (arg1, arg2));
 }
 
@@ -794,8 +794,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QMatrix & > ((QMatrix &)((QMatrix *)cls)->translate (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMatrix4x4.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMatrix4x4.cc
@@ -74,7 +74,7 @@ static void _call_ctor_QMatrix4x4_1952 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const double *arg1 = args.read<const double * > (heap);
+  const double *arg1 = gsi::arg_reader<const double * >() (args, heap);
   ret.write<QMatrix4x4 *> (new QMatrix4x4 (arg1));
 }
 
@@ -123,22 +123,22 @@ static void _call_ctor_QMatrix4x4_15516 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
-  double arg7 = args.read<double > (heap);
-  double arg8 = args.read<double > (heap);
-  double arg9 = args.read<double > (heap);
-  double arg10 = args.read<double > (heap);
-  double arg11 = args.read<double > (heap);
-  double arg12 = args.read<double > (heap);
-  double arg13 = args.read<double > (heap);
-  double arg14 = args.read<double > (heap);
-  double arg15 = args.read<double > (heap);
-  double arg16 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
+  double arg7 = gsi::arg_reader<double >() (args, heap);
+  double arg8 = gsi::arg_reader<double >() (args, heap);
+  double arg9 = gsi::arg_reader<double >() (args, heap);
+  double arg10 = gsi::arg_reader<double >() (args, heap);
+  double arg11 = gsi::arg_reader<double >() (args, heap);
+  double arg12 = gsi::arg_reader<double >() (args, heap);
+  double arg13 = gsi::arg_reader<double >() (args, heap);
+  double arg14 = gsi::arg_reader<double >() (args, heap);
+  double arg15 = gsi::arg_reader<double >() (args, heap);
+  double arg16 = gsi::arg_reader<double >() (args, heap);
   ret.write<QMatrix4x4 *> (new QMatrix4x4 (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16));
 }
 
@@ -161,9 +161,9 @@ static void _call_ctor_QMatrix4x4_3270 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const double *arg1 = args.read<const double * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const double *arg1 = gsi::arg_reader<const double * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QMatrix4x4 *> (new QMatrix4x4 (arg1, arg2, arg3));
 }
 
@@ -182,7 +182,7 @@ static void _call_ctor_QMatrix4x4_2350 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QMatrix4x4 *> (new QMatrix4x4 (arg1));
 }
 
@@ -201,7 +201,7 @@ static void _call_ctor_QMatrix4x4_2023 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   ret.write<QMatrix4x4 *> (new QMatrix4x4 (arg1));
 }
 
@@ -220,7 +220,7 @@ static void _call_f_column_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVector4D > ((QVector4D)((QMatrix4x4 *)cls)->column (arg1));
 }
 
@@ -254,7 +254,7 @@ static void _call_f_copyDataTo_c1257 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->copyDataTo (arg1);
 }
@@ -319,7 +319,7 @@ static void _call_f_fill_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->fill (arg1);
 }
@@ -365,12 +365,12 @@ static void _call_f_frustum_5886 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->frustum (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -390,7 +390,7 @@ static void _call_f_inverted_c1050 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool *arg1 = args ? args.read<bool * > (heap) : (bool *)(0);
+  bool *arg1 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<QMatrix4x4 > ((QMatrix4x4)((QMatrix4x4 *)cls)->inverted (arg1));
 }
 
@@ -428,9 +428,9 @@ static void _call_f_lookAt_6204 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg3 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg3 = gsi::arg_reader<const QVector3D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->lookAt (arg1, arg2, arg3);
 }
@@ -450,7 +450,7 @@ static void _call_f_map_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QMatrix4x4 *)cls)->map (arg1));
 }
 
@@ -469,7 +469,7 @@ static void _call_f_map_c1986 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QMatrix4x4 *)cls)->map (arg1));
 }
 
@@ -488,7 +488,7 @@ static void _call_f_map_c2140 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector3D > ((QVector3D)((QMatrix4x4 *)cls)->map (arg1));
 }
 
@@ -507,7 +507,7 @@ static void _call_f_map_c2141 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector4D &arg1 = args.read<const QVector4D & > (heap);
+  const QVector4D &arg1 = gsi::arg_reader<const QVector4D & >() (args, heap);
   ret.write<QVector4D > ((QVector4D)((QMatrix4x4 *)cls)->map (arg1));
 }
 
@@ -526,7 +526,7 @@ static void _call_f_mapRect_c1792 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QMatrix4x4 *)cls)->mapRect (arg1));
 }
 
@@ -545,7 +545,7 @@ static void _call_f_mapRect_c1862 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QMatrix4x4 *)cls)->mapRect (arg1));
 }
 
@@ -564,7 +564,7 @@ static void _call_f_mapVector_c2140 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector3D > ((QVector3D)((QMatrix4x4 *)cls)->mapVector (arg1));
 }
 
@@ -583,7 +583,7 @@ static void _call_f_operator_excl__eq__c2247 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix4x4 &arg1 = args.read<const QMatrix4x4 & > (heap);
+  const QMatrix4x4 &arg1 = gsi::arg_reader<const QMatrix4x4 & >() (args, heap);
   ret.write<bool > ((bool)((QMatrix4x4 *)cls)->operator!= (arg1));
 }
 
@@ -604,8 +604,8 @@ static void _call_f_operator_func__c1426 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<const double & > ((const double &)((QMatrix4x4 *)cls)->operator() (arg1, arg2));
 }
 
@@ -626,8 +626,8 @@ static void _call_f_operator_func__1426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<double & > ((double &)((QMatrix4x4 *)cls)->operator() (arg1, arg2));
 }
 
@@ -646,7 +646,7 @@ static void _call_f_operator_star__eq__2247 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix4x4 &arg1 = args.read<const QMatrix4x4 & > (heap);
+  const QMatrix4x4 &arg1 = gsi::arg_reader<const QMatrix4x4 & >() (args, heap);
   ret.write<QMatrix4x4 & > ((QMatrix4x4 &)((QMatrix4x4 *)cls)->operator*= (arg1));
 }
 
@@ -665,7 +665,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QMatrix4x4 & > ((QMatrix4x4 &)((QMatrix4x4 *)cls)->operator*= (arg1));
 }
 
@@ -684,7 +684,7 @@ static void _call_f_operator_plus__eq__2247 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix4x4 &arg1 = args.read<const QMatrix4x4 & > (heap);
+  const QMatrix4x4 &arg1 = gsi::arg_reader<const QMatrix4x4 & >() (args, heap);
   ret.write<QMatrix4x4 & > ((QMatrix4x4 &)((QMatrix4x4 *)cls)->operator+= (arg1));
 }
 
@@ -703,7 +703,7 @@ static void _call_f_operator_minus__eq__2247 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix4x4 &arg1 = args.read<const QMatrix4x4 & > (heap);
+  const QMatrix4x4 &arg1 = gsi::arg_reader<const QMatrix4x4 & >() (args, heap);
   ret.write<QMatrix4x4 & > ((QMatrix4x4 &)((QMatrix4x4 *)cls)->operator-= (arg1));
 }
 
@@ -722,7 +722,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QMatrix4x4 & > ((QMatrix4x4 &)((QMatrix4x4 *)cls)->operator/= (arg1));
 }
 
@@ -741,7 +741,7 @@ static void _call_f_operator_eq__eq__c2247 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix4x4 &arg1 = args.read<const QMatrix4x4 & > (heap);
+  const QMatrix4x4 &arg1 = gsi::arg_reader<const QMatrix4x4 & >() (args, heap);
   ret.write<bool > ((bool)((QMatrix4x4 *)cls)->operator== (arg1));
 }
 
@@ -776,7 +776,7 @@ static void _call_f_ortho_1792 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->ortho (arg1);
 }
@@ -796,7 +796,7 @@ static void _call_f_ortho_1862 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->ortho (arg1);
 }
@@ -826,12 +826,12 @@ static void _call_f_ortho_5886 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->ortho (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -857,10 +857,10 @@ static void _call_f_perspective_3960 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->perspective (arg1, arg2, arg3, arg4);
 }
@@ -882,8 +882,8 @@ static void _call_f_rotate_3103 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->rotate (arg1, arg2);
 }
@@ -909,10 +909,10 @@ static void _call_f_rotate_3960 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args ? args.read<double > (heap) : (double)(0.0f);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (0.0f, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->rotate (arg1, arg2, arg3, arg4);
 }
@@ -932,7 +932,7 @@ static void _call_f_rotate_2456 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QQuaternion &arg1 = args.read<const QQuaternion & > (heap);
+  const QQuaternion &arg1 = gsi::arg_reader<const QQuaternion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->rotate (arg1);
 }
@@ -952,7 +952,7 @@ static void _call_f_row_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVector4D > ((QVector4D)((QMatrix4x4 *)cls)->row (arg1));
 }
 
@@ -971,7 +971,7 @@ static void _call_f_scale_2140 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->scale (arg1);
 }
@@ -993,8 +993,8 @@ static void _call_f_scale_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->scale (arg1, arg2);
 }
@@ -1018,9 +1018,9 @@ static void _call_f_scale_2997 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->scale (arg1, arg2, arg3);
 }
@@ -1040,7 +1040,7 @@ static void _call_f_scale_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->scale (arg1);
 }
@@ -1062,8 +1062,8 @@ static void _call_f_setColumn_2800 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVector4D &arg2 = args.read<const QVector4D & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVector4D &arg2 = gsi::arg_reader<const QVector4D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->setColumn (arg1, arg2);
 }
@@ -1085,8 +1085,8 @@ static void _call_f_setRow_2800 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVector4D &arg2 = args.read<const QVector4D & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVector4D &arg2 = gsi::arg_reader<const QVector4D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->setRow (arg1, arg2);
 }
@@ -1152,7 +1152,7 @@ static void _call_f_toTransform_c1071 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform > ((QTransform)((QMatrix4x4 *)cls)->toTransform (arg1));
 }
 
@@ -1171,7 +1171,7 @@ static void _call_f_translate_2140 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->translate (arg1);
 }
@@ -1193,8 +1193,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->translate (arg1, arg2);
 }
@@ -1218,9 +1218,9 @@ static void _call_f_translate_2997 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMatrix4x4 *)cls)->translate (arg1, arg2, arg3);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMdiArea.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMdiArea.cc
@@ -178,8 +178,8 @@ static void _call_f_addSubWindow_3702 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QMdiSubWindow * > ((QMdiSubWindow *)((QMdiArea *)cls)->addSubWindow (arg1, arg2));
 }
 
@@ -306,7 +306,7 @@ static void _call_f_removeSubWindow_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea *)cls)->removeSubWindow (arg1);
 }
@@ -326,7 +326,7 @@ static void _call_f_setActivationOrder_2432 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type & arg1 = args.read<const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type & > (heap);
+  const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea *)cls)->setActivationOrder (qt_gsi::QtToCppAdaptor<QMdiArea::WindowOrder>(arg1).cref());
 }
@@ -346,7 +346,7 @@ static void _call_f_setActiveSubWindow_1915 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMdiSubWindow *arg1 = args.read<QMdiSubWindow * > (heap);
+  QMdiSubWindow *arg1 = gsi::arg_reader<QMdiSubWindow * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea *)cls)->setActiveSubWindow (arg1);
 }
@@ -366,7 +366,7 @@ static void _call_f_setBackground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea *)cls)->setBackground (arg1);
 }
@@ -386,7 +386,7 @@ static void _call_f_setDocumentMode_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea *)cls)->setDocumentMode (arg1);
 }
@@ -408,8 +408,8 @@ static void _call_f_setOption_3058 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMdiArea::AreaOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QMdiArea::AreaOption>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QMdiArea::AreaOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMdiArea::AreaOption>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea *)cls)->setOption (qt_gsi::QtToCppAdaptor<QMdiArea::AreaOption>(arg1).cref(), arg2);
 }
@@ -429,7 +429,7 @@ static void _call_f_setTabPosition_2656 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & arg1 = args.read<const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & > (heap);
+  const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea *)cls)->setTabPosition (qt_gsi::QtToCppAdaptor<QTabWidget::TabPosition>(arg1).cref());
 }
@@ -449,7 +449,7 @@ static void _call_f_setTabShape_2300 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTabWidget::TabShape>::target_type & arg1 = args.read<const qt_gsi::Converter<QTabWidget::TabShape>::target_type & > (heap);
+  const qt_gsi::Converter<QTabWidget::TabShape>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTabWidget::TabShape>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea *)cls)->setTabShape (qt_gsi::QtToCppAdaptor<QTabWidget::TabShape>(arg1).cref());
 }
@@ -469,7 +469,7 @@ static void _call_f_setViewMode_2092 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMdiArea::ViewMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QMdiArea::ViewMode>::target_type & > (heap);
+  const qt_gsi::Converter<QMdiArea::ViewMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMdiArea::ViewMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea *)cls)->setViewMode (qt_gsi::QtToCppAdaptor<QMdiArea::ViewMode>(arg1).cref());
 }
@@ -504,7 +504,7 @@ static void _call_f_subWindowList_c2432 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type & > (heap) : (const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<QMdiArea::WindowOrder>(heap, QMdiArea::CreationOrder));
+  const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QMdiArea::WindowOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QMdiArea::WindowOrder>(heap, QMdiArea::CreationOrder), heap);
   ret.write<QList<QMdiSubWindow *> > ((QList<QMdiSubWindow *>)((QMdiArea *)cls)->subWindowList (qt_gsi::QtToCppAdaptor<QMdiArea::WindowOrder>(arg1).cref()));
 }
 
@@ -553,7 +553,7 @@ static void _call_f_testOption_c2302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMdiArea::AreaOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QMdiArea::AreaOption>::target_type & > (heap);
+  const qt_gsi::Converter<QMdiArea::AreaOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMdiArea::AreaOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QMdiArea *)cls)->testOption (qt_gsi::QtToCppAdaptor<QMdiArea::AreaOption>(arg1).cref()));
 }
 
@@ -605,8 +605,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMdiArea::tr (arg1, arg2));
 }
 
@@ -629,9 +629,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMdiArea::tr (arg1, arg2, arg3));
 }
 
@@ -652,8 +652,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMdiArea::trUtf8 (arg1, arg2));
 }
 
@@ -676,9 +676,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMdiArea::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1619,7 +1619,7 @@ static void _call_ctor_QMdiArea_Adaptor_1315 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QMdiArea_Adaptor *> (new QMdiArea_Adaptor (arg1));
 }
 
@@ -1761,9 +1761,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea_Adaptor *)cls)->fp_QMdiArea_create_2208 (arg1, arg2, arg3);
 }
@@ -1782,7 +1782,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QMdiArea_Adaptor *)cls)->emitter_QMdiArea_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1826,8 +1826,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea_Adaptor *)cls)->fp_QMdiArea_destroy_1620 (arg1, arg2);
 }
@@ -1846,7 +1846,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QMdiArea_Adaptor *)cls)->emitter_QMdiArea_destroyed_1302 (arg1);
 }
 
@@ -1960,7 +1960,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea_Adaptor *)cls)->fp_QMdiArea_drawFrame_1426 (arg1);
 }
@@ -2638,7 +2638,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMdiArea_Adaptor *)cls)->fp_QMdiArea_receivers_c1731 (arg1));
 }
 
@@ -2742,10 +2742,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea_Adaptor *)cls)->fp_QMdiArea_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -2764,7 +2764,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea_Adaptor *)cls)->fp_QMdiArea_setViewportMargins_2115 (arg1);
 }
@@ -2807,7 +2807,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiArea_Adaptor *)cls)->fp_QMdiArea_setupViewport_1315 (arg1);
 }
@@ -2893,7 +2893,7 @@ static void _call_emitter_subWindowActivated_1915 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMdiSubWindow *arg1 = args.read<QMdiSubWindow * > (heap);
+  QMdiSubWindow *arg1 = gsi::arg_reader<QMdiSubWindow * >() (args, heap);
   ((QMdiArea_Adaptor *)cls)->emitter_QMdiArea_subWindowActivated_1915 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMdiSubWindow.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMdiSubWindow.cc
@@ -218,7 +218,7 @@ static void _call_f_setKeyboardPageStep_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiSubWindow *)cls)->setKeyboardPageStep (arg1);
 }
@@ -238,7 +238,7 @@ static void _call_f_setKeyboardSingleStep_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiSubWindow *)cls)->setKeyboardSingleStep (arg1);
 }
@@ -260,8 +260,8 @@ static void _call_f_setOption_4164 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMdiSubWindow::SubWindowOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QMdiSubWindow::SubWindowOption>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QMdiSubWindow::SubWindowOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMdiSubWindow::SubWindowOption>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiSubWindow *)cls)->setOption (qt_gsi::QtToCppAdaptor<QMdiSubWindow::SubWindowOption>(arg1).cref(), arg2);
 }
@@ -281,7 +281,7 @@ static void _call_f_setSystemMenu_1108 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMenu *arg1 = args.read<QMenu * > (heap);
+  QMenu *arg1 = gsi::arg_reader<QMenu * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiSubWindow *)cls)->setSystemMenu (arg1);
 }
@@ -301,7 +301,7 @@ static void _call_f_setWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiSubWindow *)cls)->setWidget (arg1);
 }
@@ -383,7 +383,7 @@ static void _call_f_testOption_c3408 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMdiSubWindow::SubWindowOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QMdiSubWindow::SubWindowOption>::target_type & > (heap);
+  const qt_gsi::Converter<QMdiSubWindow::SubWindowOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMdiSubWindow::SubWindowOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QMdiSubWindow *)cls)->testOption (qt_gsi::QtToCppAdaptor<QMdiSubWindow::SubWindowOption>(arg1).cref()));
 }
 
@@ -419,8 +419,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMdiSubWindow::tr (arg1, arg2));
 }
 
@@ -443,9 +443,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMdiSubWindow::tr (arg1, arg2, arg3));
 }
 
@@ -466,8 +466,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMdiSubWindow::trUtf8 (arg1, arg2));
 }
 
@@ -490,9 +490,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMdiSubWindow::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1386,8 +1386,8 @@ static void _call_ctor_QMdiSubWindow_Adaptor_3702 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QMdiSubWindow_Adaptor *> (new QMdiSubWindow_Adaptor (arg1, arg2));
 }
 
@@ -1543,9 +1543,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiSubWindow_Adaptor *)cls)->fp_QMdiSubWindow_create_2208 (arg1, arg2, arg3);
 }
@@ -1564,7 +1564,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QMdiSubWindow_Adaptor *)cls)->emitter_QMdiSubWindow_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1608,8 +1608,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMdiSubWindow_Adaptor *)cls)->fp_QMdiSubWindow_destroy_1620 (arg1, arg2);
 }
@@ -1628,7 +1628,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QMdiSubWindow_Adaptor *)cls)->emitter_QMdiSubWindow_destroyed_1302 (arg1);
 }
 
@@ -2401,7 +2401,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMdiSubWindow_Adaptor *)cls)->fp_QMdiSubWindow_receivers_c1731 (arg1));
 }
 
@@ -2676,8 +2676,8 @@ static void _call_emitter_windowStateChanged_5072 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::WindowState> arg1 = args.read<QFlags<Qt::WindowState> > (heap);
-  QFlags<Qt::WindowState> arg2 = args.read<QFlags<Qt::WindowState> > (heap);
+  QFlags<Qt::WindowState> arg1 = gsi::arg_reader<QFlags<Qt::WindowState> >() (args, heap);
+  QFlags<Qt::WindowState> arg2 = gsi::arg_reader<QFlags<Qt::WindowState> >() (args, heap);
   ((QMdiSubWindow_Adaptor *)cls)->emitter_QMdiSubWindow_windowStateChanged_5072 (arg1, arg2);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMenu.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMenu.cc
@@ -112,7 +112,7 @@ static void _call_f_actionAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenu *)cls)->actionAt (arg1));
 }
 
@@ -131,7 +131,7 @@ static void _call_f_actionGeometry_c1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ret.write<QRect > ((QRect)((QMenu *)cls)->actionGeometry (arg1));
 }
 
@@ -165,7 +165,7 @@ static void _call_f_addAction_1309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu *)cls)->addAction (arg1);
 }
@@ -185,7 +185,7 @@ static void _call_f_addAction_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenu *)cls)->addAction (arg1));
 }
 
@@ -206,8 +206,8 @@ static void _call_f_addAction_3704 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenu *)cls)->addAction (arg1, arg2));
 }
 
@@ -232,10 +232,10 @@ static void _call_f_addAction_7945 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QObject *arg2 = args.read<const QObject * > (heap);
-  const char *arg3 = args.read<const char * > (heap);
-  const QKeySequence &arg4 = args ? args.read<const QKeySequence & > (heap) : (const QKeySequence &)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QObject *arg2 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
+  const QKeySequence &arg4 = args ? gsi::arg_reader<const QKeySequence & >() (args, heap) : gsi::arg_maker<const QKeySequence & >() (0, heap);
   ret.write<QAction * > ((QAction *)((QMenu *)cls)->addAction (arg1, arg2, arg3, arg4));
 }
 
@@ -262,11 +262,11 @@ static void _call_f_addAction_9624 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QObject *arg3 = args.read<const QObject * > (heap);
-  const char *arg4 = args.read<const char * > (heap);
-  const QKeySequence &arg5 = args ? args.read<const QKeySequence & > (heap) : (const QKeySequence &)(0);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QObject *arg3 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg4 = gsi::arg_reader<const char * >() (args, heap);
+  const QKeySequence &arg5 = args ? gsi::arg_reader<const QKeySequence & >() (args, heap) : gsi::arg_maker<const QKeySequence & >() (0, heap);
   ret.write<QAction * > ((QAction *)((QMenu *)cls)->addAction (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -285,7 +285,7 @@ static void _call_f_addMenu_1108 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMenu *arg1 = args.read<QMenu * > (heap);
+  QMenu *arg1 = gsi::arg_reader<QMenu * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenu *)cls)->addMenu (arg1));
 }
 
@@ -304,7 +304,7 @@ static void _call_f_addMenu_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QMenu * > ((QMenu *)((QMenu *)cls)->addMenu (arg1));
 }
 
@@ -325,8 +325,8 @@ static void _call_f_addMenu_3704 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QMenu * > ((QMenu *)((QMenu *)cls)->addMenu (arg1, arg2));
 }
 
@@ -408,8 +408,8 @@ static void _call_f_exec_3117 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  QAction *arg2 = args ? args.read<QAction * > (heap) : (QAction *)(0);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  QAction *arg2 = args ? gsi::arg_reader<QAction * >() (args, heap) : gsi::arg_maker<QAction * >() (0, heap);
   ret.write<QAction * > ((QAction *)((QMenu *)cls)->exec (arg1, arg2));
 }
 
@@ -461,8 +461,8 @@ static void _call_f_insertMenu_2309 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
-  QMenu *arg2 = args.read<QMenu * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
+  QMenu *arg2 = gsi::arg_reader<QMenu * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenu *)cls)->insertMenu (arg1, arg2));
 }
 
@@ -481,7 +481,7 @@ static void _call_f_insertSeparator_1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenu *)cls)->insertSeparator (arg1));
 }
 
@@ -562,8 +562,8 @@ static void _call_f_popup_3117 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  QAction *arg2 = args ? args.read<QAction * > (heap) : (QAction *)(0);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  QAction *arg2 = args ? gsi::arg_reader<QAction * >() (args, heap) : gsi::arg_maker<QAction * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu *)cls)->popup (arg1, arg2);
 }
@@ -598,7 +598,7 @@ static void _call_f_setActiveAction_1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu *)cls)->setActiveAction (arg1);
 }
@@ -618,7 +618,7 @@ static void _call_f_setDefaultAction_1309 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu *)cls)->setDefaultAction (arg1);
 }
@@ -638,7 +638,7 @@ static void _call_f_setIcon_1787 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu *)cls)->setIcon (arg1);
 }
@@ -658,7 +658,7 @@ static void _call_f_setNoReplayFor_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu *)cls)->setNoReplayFor (arg1);
 }
@@ -678,7 +678,7 @@ static void _call_f_setSeparatorsCollapsible_864 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu *)cls)->setSeparatorsCollapsible (arg1);
 }
@@ -698,7 +698,7 @@ static void _call_f_setTearOffEnabled_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu *)cls)->setTearOffEnabled (arg1);
 }
@@ -718,7 +718,7 @@ static void _call_f_setTitle_2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu *)cls)->setTitle (arg1);
 }
@@ -772,9 +772,9 @@ static void _call_f_exec_4789 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QList<QAction*> arg1 = args.read<QList<QAction*> > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
-  QAction *arg3 = args ? args.read<QAction * > (heap) : (QAction *)(0);
+  QList<QAction*> arg1 = gsi::arg_reader<QList<QAction*> >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
+  QAction *arg3 = args ? gsi::arg_reader<QAction * >() (args, heap) : gsi::arg_maker<QAction * >() (0, heap);
   ret.write<QAction * > ((QAction *)QMenu::exec (arg1, arg2, arg3));
 }
 
@@ -799,10 +799,10 @@ static void _call_f_exec_5996 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QList<QAction*> arg1 = args.read<QList<QAction*> > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
-  QAction *arg3 = args.read<QAction * > (heap);
-  QWidget *arg4 = args.read<QWidget * > (heap);
+  QList<QAction*> arg1 = gsi::arg_reader<QList<QAction*> >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
+  QAction *arg3 = gsi::arg_reader<QAction * >() (args, heap);
+  QWidget *arg4 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QAction * > ((QAction *)QMenu::exec (arg1, arg2, arg3, arg4));
 }
 
@@ -823,8 +823,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMenu::tr (arg1, arg2));
 }
 
@@ -847,9 +847,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMenu::tr (arg1, arg2, arg3));
 }
 
@@ -870,8 +870,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMenu::trUtf8 (arg1, arg2));
 }
 
@@ -894,9 +894,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMenu::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1837,7 +1837,7 @@ static void _call_ctor_QMenu_Adaptor_1315 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QMenu_Adaptor *> (new QMenu_Adaptor (arg1));
 }
 
@@ -1857,8 +1857,8 @@ static void _call_ctor_QMenu_Adaptor_3232 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QMenu_Adaptor *> (new QMenu_Adaptor (arg1, arg2));
 }
 
@@ -2042,9 +2042,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu_Adaptor *)cls)->fp_QMenu_create_2208 (arg1, arg2, arg3);
 }
@@ -2063,7 +2063,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QMenu_Adaptor *)cls)->emitter_QMenu_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2107,8 +2107,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu_Adaptor *)cls)->fp_QMenu_destroy_1620 (arg1, arg2);
 }
@@ -2127,7 +2127,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QMenu_Adaptor *)cls)->emitter_QMenu_destroyed_1302 (arg1);
 }
 
@@ -2532,7 +2532,7 @@ static void _call_emitter_hovered_1309 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ((QMenu_Adaptor *)cls)->emitter_QMenu_hovered_1309 (arg1);
 }
 
@@ -2552,8 +2552,8 @@ static void _call_fp_initStyleOption_c4565 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionMenuItem *arg1 = args.read<QStyleOptionMenuItem * > (heap);
-  const QAction *arg2 = args.read<const QAction * > (heap);
+  QStyleOptionMenuItem *arg1 = gsi::arg_reader<QStyleOptionMenuItem * >() (args, heap);
+  const QAction *arg2 = gsi::arg_reader<const QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenu_Adaptor *)cls)->fp_QMenu_initStyleOption_c4565 (arg1, arg2);
 }
@@ -2940,7 +2940,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMenu_Adaptor *)cls)->fp_QMenu_receivers_c1731 (arg1));
 }
 
@@ -3150,7 +3150,7 @@ static void _call_emitter_triggered_1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ((QMenu_Adaptor *)cls)->emitter_QMenu_triggered_1309 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMenuBar.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMenuBar.cc
@@ -113,7 +113,7 @@ static void _call_f_actionAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenuBar *)cls)->actionAt (arg1));
 }
 
@@ -132,7 +132,7 @@ static void _call_f_actionGeometry_c1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ret.write<QRect > ((QRect)((QMenuBar *)cls)->actionGeometry (arg1));
 }
 
@@ -166,7 +166,7 @@ static void _call_f_addAction_1309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenuBar *)cls)->addAction (arg1);
 }
@@ -186,7 +186,7 @@ static void _call_f_addAction_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenuBar *)cls)->addAction (arg1));
 }
 
@@ -209,9 +209,9 @@ static void _call_f_addAction_5537 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QObject *arg2 = args.read<const QObject * > (heap);
-  const char *arg3 = args.read<const char * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QObject *arg2 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenuBar *)cls)->addAction (arg1, arg2, arg3));
 }
 
@@ -230,7 +230,7 @@ static void _call_f_addMenu_1108 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMenu *arg1 = args.read<QMenu * > (heap);
+  QMenu *arg1 = gsi::arg_reader<QMenu * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenuBar *)cls)->addMenu (arg1));
 }
 
@@ -249,7 +249,7 @@ static void _call_f_addMenu_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QMenu * > ((QMenu *)((QMenuBar *)cls)->addMenu (arg1));
 }
 
@@ -270,8 +270,8 @@ static void _call_f_addMenu_3704 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QMenu * > ((QMenu *)((QMenuBar *)cls)->addMenu (arg1, arg2));
 }
 
@@ -321,7 +321,7 @@ static void _call_f_cornerWidget_c1366 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::Corner>::target_type & > (heap) : (const qt_gsi::Converter<Qt::Corner>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::Corner>(heap, Qt::TopRightCorner));
+  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::Corner>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::Corner>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::Corner>(heap, Qt::TopRightCorner), heap);
   ret.write<QWidget * > ((QWidget *)((QMenuBar *)cls)->cornerWidget (qt_gsi::QtToCppAdaptor<Qt::Corner>(arg1).cref()));
 }
 
@@ -340,7 +340,7 @@ static void _call_f_heightForWidth_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QMenuBar *)cls)->heightForWidth (arg1));
 }
 
@@ -361,8 +361,8 @@ static void _call_f_insertMenu_2309 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
-  QMenu *arg2 = args.read<QMenu * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
+  QMenu *arg2 = gsi::arg_reader<QMenu * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenuBar *)cls)->insertMenu (arg1, arg2));
 }
 
@@ -381,7 +381,7 @@ static void _call_f_insertSeparator_1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QMenuBar *)cls)->insertSeparator (arg1));
 }
 
@@ -445,7 +445,7 @@ static void _call_f_setActiveAction_1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenuBar *)cls)->setActiveAction (arg1);
 }
@@ -467,8 +467,8 @@ static void _call_f_setCornerWidget_2573 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const qt_gsi::Converter<Qt::Corner>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::Corner>::target_type & > (heap) : (const qt_gsi::Converter<Qt::Corner>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::Corner>(heap, Qt::TopRightCorner));
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const qt_gsi::Converter<Qt::Corner>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::Corner>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::Corner>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::Corner>(heap, Qt::TopRightCorner), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenuBar *)cls)->setCornerWidget (arg1, qt_gsi::QtToCppAdaptor<Qt::Corner>(arg2).cref());
 }
@@ -488,7 +488,7 @@ static void _call_f_setDefaultUp_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenuBar *)cls)->setDefaultUp (arg1);
 }
@@ -508,7 +508,7 @@ static void _call_f_setNativeMenuBar_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenuBar *)cls)->setNativeMenuBar (arg1);
 }
@@ -528,7 +528,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenuBar *)cls)->setVisible (arg1);
 }
@@ -565,8 +565,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMenuBar::tr (arg1, arg2));
 }
 
@@ -589,9 +589,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMenuBar::tr (arg1, arg2, arg3));
 }
 
@@ -612,8 +612,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMenuBar::trUtf8 (arg1, arg2));
 }
 
@@ -636,9 +636,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMenuBar::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1535,7 +1535,7 @@ static void _call_ctor_QMenuBar_Adaptor_1315 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QMenuBar_Adaptor *> (new QMenuBar_Adaptor (arg1));
 }
 
@@ -1677,9 +1677,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenuBar_Adaptor *)cls)->fp_QMenuBar_create_2208 (arg1, arg2, arg3);
 }
@@ -1698,7 +1698,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QMenuBar_Adaptor *)cls)->emitter_QMenuBar_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1742,8 +1742,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenuBar_Adaptor *)cls)->fp_QMenuBar_destroy_1620 (arg1, arg2);
 }
@@ -1762,7 +1762,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QMenuBar_Adaptor *)cls)->emitter_QMenuBar_destroyed_1302 (arg1);
 }
 
@@ -2167,7 +2167,7 @@ static void _call_emitter_hovered_1309 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ((QMenuBar_Adaptor *)cls)->emitter_QMenuBar_hovered_1309 (arg1);
 }
 
@@ -2187,8 +2187,8 @@ static void _call_fp_initStyleOption_c4565 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionMenuItem *arg1 = args.read<QStyleOptionMenuItem * > (heap);
-  const QAction *arg2 = args.read<const QAction * > (heap);
+  QStyleOptionMenuItem *arg1 = gsi::arg_reader<QStyleOptionMenuItem * >() (args, heap);
+  const QAction *arg2 = gsi::arg_reader<const QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMenuBar_Adaptor *)cls)->fp_QMenuBar_initStyleOption_c4565 (arg1, arg2);
 }
@@ -2575,7 +2575,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMenuBar_Adaptor *)cls)->fp_QMenuBar_receivers_c1731 (arg1));
 }
 
@@ -2785,7 +2785,7 @@ static void _call_emitter_triggered_1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ((QMenuBar_Adaptor *)cls)->emitter_QMenuBar_triggered_1309 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMessageBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMessageBox.cc
@@ -116,8 +116,8 @@ static void _call_f_addButton_4728 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
-  const qt_gsi::Converter<QMessageBox::ButtonRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QMessageBox::ButtonRole>::target_type & > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
+  const qt_gsi::Converter<QMessageBox::ButtonRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QMessageBox::ButtonRole>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->addButton (arg1, qt_gsi::QtToCppAdaptor<QMessageBox::ButtonRole>(arg2).cref());
 }
@@ -139,8 +139,8 @@ static void _call_f_addButton_4594 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QMessageBox::ButtonRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QMessageBox::ButtonRole>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QMessageBox::ButtonRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QMessageBox::ButtonRole>::target_type & >() (args, heap);
   ret.write<QPushButton * > ((QPushButton *)((QMessageBox *)cls)->addButton (arg1, qt_gsi::QtToCppAdaptor<QMessageBox::ButtonRole>(arg2).cref()));
 }
 
@@ -159,7 +159,7 @@ static void _call_f_addButton_3092 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & > (heap);
+  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (args, heap);
   ret.write<QPushButton * > ((QPushButton *)((QMessageBox *)cls)->addButton (qt_gsi::QtToCppAdaptor<QMessageBox::StandardButton>(arg1).cref()));
 }
 
@@ -178,7 +178,7 @@ static void _call_f_button_c3092 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & > (heap);
+  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (args, heap);
   ret.write<QAbstractButton * > ((QAbstractButton *)((QMessageBox *)cls)->button (qt_gsi::QtToCppAdaptor<QMessageBox::StandardButton>(arg1).cref()));
 }
 
@@ -197,7 +197,7 @@ static void _call_f_buttonRole_c2159 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ret.write<qt_gsi::Converter<QMessageBox::ButtonRole>::target_type > ((qt_gsi::Converter<QMessageBox::ButtonRole>::target_type)qt_gsi::CppToQtAdaptor<QMessageBox::ButtonRole>(((QMessageBox *)cls)->buttonRole (arg1)));
 }
 
@@ -216,7 +216,7 @@ static void _call_f_buttonText_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QMessageBox *)cls)->buttonText (arg1));
 }
 
@@ -373,8 +373,8 @@ static void _call_f_open_2925 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->open (arg1, arg2);
 }
@@ -394,7 +394,7 @@ static void _call_f_removeButton_2159 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->removeButton (arg1);
 }
@@ -416,8 +416,8 @@ static void _call_f_setButtonText_2684 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setButtonText (arg1, arg2);
 }
@@ -437,7 +437,7 @@ static void _call_f_setDefaultButton_1755 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPushButton *arg1 = args.read<QPushButton * > (heap);
+  QPushButton *arg1 = gsi::arg_reader<QPushButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setDefaultButton (arg1);
 }
@@ -457,7 +457,7 @@ static void _call_f_setDefaultButton_3092 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & > (heap);
+  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setDefaultButton (qt_gsi::QtToCppAdaptor<QMessageBox::StandardButton>(arg1).cref());
 }
@@ -477,7 +477,7 @@ static void _call_f_setDetailedText_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setDetailedText (arg1);
 }
@@ -497,7 +497,7 @@ static void _call_f_setEscapeButton_2159 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setEscapeButton (arg1);
 }
@@ -517,7 +517,7 @@ static void _call_f_setEscapeButton_3092 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & > (heap);
+  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setEscapeButton (qt_gsi::QtToCppAdaptor<QMessageBox::StandardButton>(arg1).cref());
 }
@@ -537,7 +537,7 @@ static void _call_f_setIcon_2032 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMessageBox::Icon>::target_type & arg1 = args.read<const qt_gsi::Converter<QMessageBox::Icon>::target_type & > (heap);
+  const qt_gsi::Converter<QMessageBox::Icon>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMessageBox::Icon>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setIcon (qt_gsi::QtToCppAdaptor<QMessageBox::Icon>(arg1).cref());
 }
@@ -557,7 +557,7 @@ static void _call_f_setIconPixmap_2017 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setIconPixmap (arg1);
 }
@@ -577,7 +577,7 @@ static void _call_f_setInformativeText_2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setInformativeText (arg1);
 }
@@ -597,7 +597,7 @@ static void _call_f_setStandardButtons_3788 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QMessageBox::StandardButton> arg1 = args.read<QFlags<QMessageBox::StandardButton> > (heap);
+  QFlags<QMessageBox::StandardButton> arg1 = gsi::arg_reader<QFlags<QMessageBox::StandardButton> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setStandardButtons (arg1);
 }
@@ -617,7 +617,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setText (arg1);
 }
@@ -637,7 +637,7 @@ static void _call_f_setTextFormat_1787 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TextFormat>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TextFormat>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TextFormat>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextFormat>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setTextFormat (qt_gsi::QtToCppAdaptor<Qt::TextFormat>(arg1).cref());
 }
@@ -657,7 +657,7 @@ static void _call_f_setWindowModality_2216 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::WindowModality>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::WindowModality>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::WindowModality>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::WindowModality>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setWindowModality (qt_gsi::QtToCppAdaptor<Qt::WindowModality>(arg1).cref());
 }
@@ -677,7 +677,7 @@ static void _call_f_setWindowTitle_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox *)cls)->setWindowTitle (arg1);
 }
@@ -712,7 +712,7 @@ static void _call_f_standardButton_c2159 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ret.write<qt_gsi::Converter<QMessageBox::StandardButton>::target_type > ((qt_gsi::Converter<QMessageBox::StandardButton>::target_type)qt_gsi::CppToQtAdaptor<QMessageBox::StandardButton>(((QMessageBox *)cls)->standardButton (arg1)));
 }
 
@@ -780,9 +780,9 @@ static void _call_f_about_5149 (const qt_gsi::GenericStaticMethod * /*decl*/, gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QMessageBox::about (arg1, arg2, arg3);
 }
@@ -804,8 +804,8 @@ static void _call_f_aboutQt_3232 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QMessageBox::aboutQt (arg1, arg2);
 }
@@ -833,11 +833,11 @@ static void _call_f_critical_11813 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  QFlags<QMessageBox::StandardButton> arg4 = args ? args.read<QFlags<QMessageBox::StandardButton> > (heap) : (QFlags<QMessageBox::StandardButton>)(QMessageBox::Ok);
-  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & > (heap) : (const qt_gsi::Converter<QMessageBox::StandardButton>::target_type &)(qt_gsi::CppToQtReadAdaptor<QMessageBox::StandardButton>(heap, QMessageBox::NoButton));
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QMessageBox::StandardButton> arg4 = args ? gsi::arg_reader<QFlags<QMessageBox::StandardButton> >() (args, heap) : gsi::arg_maker<QFlags<QMessageBox::StandardButton> >() (QMessageBox::Ok, heap);
+  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QMessageBox::StandardButton>(heap, QMessageBox::NoButton), heap);
   ret.write<qt_gsi::Converter<QMessageBox::StandardButton>::target_type > ((qt_gsi::Converter<QMessageBox::StandardButton>::target_type)qt_gsi::CppToQtAdaptor<QMessageBox::StandardButton>(QMessageBox::critical (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<QMessageBox::StandardButton>(arg5).cref())));
 }
 
@@ -864,11 +864,11 @@ static void _call_f_information_11813 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  QFlags<QMessageBox::StandardButton> arg4 = args ? args.read<QFlags<QMessageBox::StandardButton> > (heap) : (QFlags<QMessageBox::StandardButton>)(QMessageBox::Ok);
-  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & > (heap) : (const qt_gsi::Converter<QMessageBox::StandardButton>::target_type &)(qt_gsi::CppToQtReadAdaptor<QMessageBox::StandardButton>(heap, QMessageBox::NoButton));
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QMessageBox::StandardButton> arg4 = args ? gsi::arg_reader<QFlags<QMessageBox::StandardButton> >() (args, heap) : gsi::arg_maker<QFlags<QMessageBox::StandardButton> >() (QMessageBox::Ok, heap);
+  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QMessageBox::StandardButton>(heap, QMessageBox::NoButton), heap);
   ret.write<qt_gsi::Converter<QMessageBox::StandardButton>::target_type > ((qt_gsi::Converter<QMessageBox::StandardButton>::target_type)qt_gsi::CppToQtAdaptor<QMessageBox::StandardButton>(QMessageBox::information (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<QMessageBox::StandardButton>(arg5).cref())));
 }
 
@@ -895,11 +895,11 @@ static void _call_f_question_11813 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  QFlags<QMessageBox::StandardButton> arg4 = args ? args.read<QFlags<QMessageBox::StandardButton> > (heap) : (QFlags<QMessageBox::StandardButton>)(QMessageBox::Ok);
-  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & > (heap) : (const qt_gsi::Converter<QMessageBox::StandardButton>::target_type &)(qt_gsi::CppToQtReadAdaptor<QMessageBox::StandardButton>(heap, QMessageBox::NoButton));
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QMessageBox::StandardButton> arg4 = args ? gsi::arg_reader<QFlags<QMessageBox::StandardButton> >() (args, heap) : gsi::arg_maker<QFlags<QMessageBox::StandardButton> >() (QMessageBox::Ok, heap);
+  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QMessageBox::StandardButton>(heap, QMessageBox::NoButton), heap);
   ret.write<qt_gsi::Converter<QMessageBox::StandardButton>::target_type > ((qt_gsi::Converter<QMessageBox::StandardButton>::target_type)qt_gsi::CppToQtAdaptor<QMessageBox::StandardButton>(QMessageBox::question (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<QMessageBox::StandardButton>(arg5).cref())));
 }
 
@@ -920,8 +920,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMessageBox::tr (arg1, arg2));
 }
 
@@ -944,9 +944,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMessageBox::tr (arg1, arg2, arg3));
 }
 
@@ -967,8 +967,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMessageBox::trUtf8 (arg1, arg2));
 }
 
@@ -991,9 +991,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMessageBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1020,11 +1020,11 @@ static void _call_f_warning_11813 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  QFlags<QMessageBox::StandardButton> arg4 = args ? args.read<QFlags<QMessageBox::StandardButton> > (heap) : (QFlags<QMessageBox::StandardButton>)(QMessageBox::Ok);
-  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & > (heap) : (const qt_gsi::Converter<QMessageBox::StandardButton>::target_type &)(qt_gsi::CppToQtReadAdaptor<QMessageBox::StandardButton>(heap, QMessageBox::NoButton));
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QMessageBox::StandardButton> arg4 = args ? gsi::arg_reader<QFlags<QMessageBox::StandardButton> >() (args, heap) : gsi::arg_maker<QFlags<QMessageBox::StandardButton> >() (QMessageBox::Ok, heap);
+  const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QMessageBox::StandardButton>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QMessageBox::StandardButton>(heap, QMessageBox::NoButton), heap);
   ret.write<qt_gsi::Converter<QMessageBox::StandardButton>::target_type > ((qt_gsi::Converter<QMessageBox::StandardButton>::target_type)qt_gsi::CppToQtAdaptor<QMessageBox::StandardButton>(QMessageBox::warning (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<QMessageBox::StandardButton>(arg5).cref())));
 }
 
@@ -2043,7 +2043,7 @@ static void _call_ctor_QMessageBox_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QMessageBox_Adaptor *> (new QMessageBox_Adaptor (arg1));
 }
 
@@ -2071,12 +2071,12 @@ static void _call_ctor_QMessageBox_Adaptor_13140 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMessageBox::Icon>::target_type & arg1 = args.read<const qt_gsi::Converter<QMessageBox::Icon>::target_type & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  QFlags<QMessageBox::StandardButton> arg4 = args ? args.read<QFlags<QMessageBox::StandardButton> > (heap) : (QFlags<QMessageBox::StandardButton>)(QMessageBox::NoButton);
-  QWidget *arg5 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg6 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
+  const qt_gsi::Converter<QMessageBox::Icon>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMessageBox::Icon>::target_type & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QMessageBox::StandardButton> arg4 = args ? gsi::arg_reader<QFlags<QMessageBox::StandardButton> >() (args, heap) : gsi::arg_maker<QFlags<QMessageBox::StandardButton> >() (QMessageBox::NoButton, heap);
+  QWidget *arg5 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg6 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint, heap);
   ret.write<QMessageBox_Adaptor *> (new QMessageBox_Adaptor (qt_gsi::QtToCppAdaptor<QMessageBox::Icon>(arg1).cref(), arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -2108,14 +2108,14 @@ static void _call_ctor_QMessageBox_Adaptor_11437 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QMessageBox::Icon>::target_type & arg3 = args.read<const qt_gsi::Converter<QMessageBox::Icon>::target_type & > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  int arg6 = args.read<int > (heap);
-  QWidget *arg7 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg8 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QMessageBox::Icon>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QMessageBox::Icon>::target_type & >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  int arg6 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg7 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg8 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint, heap);
   ret.write<QMessageBox_Adaptor *> (new QMessageBox_Adaptor (arg1, arg2, qt_gsi::QtToCppAdaptor<QMessageBox::Icon>(arg3).cref(), arg4, arg5, arg6, arg7, arg8));
 }
 
@@ -2191,7 +2191,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox_Adaptor *)cls)->fp_QMessageBox_adjustPosition_1315 (arg1);
 }
@@ -2210,7 +2210,7 @@ static void _call_emitter_buttonClicked_2159 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractButton *arg1 = args.read<QAbstractButton * > (heap);
+  QAbstractButton *arg1 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   ((QMessageBox_Adaptor *)cls)->emitter_QMessageBox_buttonClicked_2159 (arg1);
 }
 
@@ -2328,9 +2328,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox_Adaptor *)cls)->fp_QMessageBox_create_2208 (arg1, arg2, arg3);
 }
@@ -2349,7 +2349,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QMessageBox_Adaptor *)cls)->emitter_QMessageBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2393,8 +2393,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMessageBox_Adaptor *)cls)->fp_QMessageBox_destroy_1620 (arg1, arg2);
 }
@@ -2413,7 +2413,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QMessageBox_Adaptor *)cls)->emitter_QMessageBox_destroyed_1302 (arg1);
 }
 
@@ -2672,7 +2672,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QMessageBox_Adaptor *)cls)->emitter_QMessageBox_finished_767 (arg1);
 }
 
@@ -3228,7 +3228,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMessageBox_Adaptor *)cls)->fp_QMessageBox_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMimeSource.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMimeSource.cc
@@ -50,7 +50,7 @@ static void _call_f_encodedData_c1731 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QMimeSource *)cls)->encodedData (arg1));
 }
 
@@ -69,7 +69,7 @@ static void _call_f_format_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<const char * > ((const char *)((QMimeSource *)cls)->format (arg1));
 }
 
@@ -88,7 +88,7 @@ static void _call_f_provides_c1731 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<bool > ((bool)((QMimeSource *)cls)->provides (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMotifStyle.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMotifStyle.cc
@@ -88,10 +88,10 @@ static void _call_f_drawComplexControl_c9027 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMotifStyle *)cls)->drawComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -117,10 +117,10 @@ static void _call_f_drawControl_c8285 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ControlElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ControlElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMotifStyle *)cls)->drawControl (qt_gsi::QtToCppAdaptor<QStyle::ControlElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -146,10 +146,10 @@ static void _call_f_drawPrimitive_c8501 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMotifStyle *)cls)->drawPrimitive (qt_gsi::QtToCppAdaptor<QStyle::PrimitiveElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -169,7 +169,7 @@ static void _call_f_event_1217 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QMotifStyle *)cls)->event (arg1));
 }
 
@@ -192,9 +192,9 @@ static void _call_f_pixelMetric_c6642 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QMotifStyle *)cls)->pixelMetric (qt_gsi::QtToCppAdaptor<QStyle::PixelMetric>(arg1).cref(), arg2, arg3));
 }
 
@@ -213,7 +213,7 @@ static void _call_f_polish_1418 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPalette &arg1 = args.read<QPalette & > (heap);
+  QPalette &arg1 = gsi::arg_reader<QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMotifStyle *)cls)->polish (arg1);
 }
@@ -233,7 +233,7 @@ static void _call_f_polish_1315 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMotifStyle *)cls)->polish (arg1);
 }
@@ -253,7 +253,7 @@ static void _call_f_polish_1843 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMotifStyle *)cls)->polish (arg1);
 }
@@ -273,7 +273,7 @@ static void _call_f_setUseHighlightColors_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMotifStyle *)cls)->setUseHighlightColors (arg1);
 }
@@ -299,10 +299,10 @@ static void _call_f_sizeFromContents_c8477 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ContentsType>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QSize &arg3 = args.read<const QSize & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ContentsType>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QSize &arg3 = gsi::arg_reader<const QSize & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QSize > ((QSize)((QMotifStyle *)cls)->sizeFromContents (qt_gsi::QtToCppAdaptor<QStyle::ContentsType>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -340,9 +340,9 @@ static void _call_f_standardPixmap_c6956 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QPixmap > ((QPixmap)((QMotifStyle *)cls)->standardPixmap (qt_gsi::QtToCppAdaptor<QStyle::StandardPixmap>(arg1).cref(), arg2, arg3));
 }
 
@@ -367,10 +367,10 @@ static void _call_f_styleHint_c8615 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StyleHint>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
-  QStyleHintReturn *arg4 = args ? args.read<QStyleHintReturn * > (heap) : (QStyleHintReturn *)(0);
+  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StyleHint>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
+  QStyleHintReturn *arg4 = args ? gsi::arg_reader<QStyleHintReturn * >() (args, heap) : gsi::arg_maker<QStyleHintReturn * >() (0, heap);
   ret.write<int > ((int)((QMotifStyle *)cls)->styleHint (qt_gsi::QtToCppAdaptor<QStyle::StyleHint>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -395,10 +395,10 @@ static void _call_f_subControlRect_c9798 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = args.read<const qt_gsi::Converter<QStyle::SubControl>::target_type & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubControl>::target_type & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QRect > ((QRect)((QMotifStyle *)cls)->subControlRect (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, qt_gsi::QtToCppAdaptor<QStyle::SubControl>(arg3).cref(), arg4));
 }
 
@@ -421,9 +421,9 @@ static void _call_f_subElementRect_c6528 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::SubElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QRect > ((QRect)((QMotifStyle *)cls)->subElementRect (qt_gsi::QtToCppAdaptor<QStyle::SubElement>(arg1).cref(), arg2, arg3));
 }
 
@@ -442,7 +442,7 @@ static void _call_f_unpolish_1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMotifStyle *)cls)->unpolish (arg1);
 }
@@ -462,7 +462,7 @@ static void _call_f_unpolish_1843 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMotifStyle *)cls)->unpolish (arg1);
 }
@@ -499,8 +499,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMotifStyle::tr (arg1, arg2));
 }
 
@@ -523,9 +523,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMotifStyle::tr (arg1, arg2, arg3));
 }
 
@@ -546,8 +546,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMotifStyle::trUtf8 (arg1, arg2));
 }
 
@@ -570,9 +570,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMotifStyle::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1113,7 +1113,7 @@ static void _call_ctor_QMotifStyle_Adaptor_864 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<QMotifStyle_Adaptor *> (new QMotifStyle_Adaptor (arg1));
 }
 
@@ -1179,7 +1179,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QMotifStyle_Adaptor *)cls)->emitter_QMotifStyle_destroyed_1302 (arg1);
 }
 
@@ -1577,11 +1577,11 @@ static void _call_fp_layoutSpacingImplementation_c11697 (const qt_gsi::GenericMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QStyleOption *arg4 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg5 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QStyleOption *arg4 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg5 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QMotifStyle_Adaptor *)cls)->fp_QMotifStyle_layoutSpacingImplementation_c11697 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1700,7 +1700,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMotifStyle_Adaptor *)cls)->fp_QMotifStyle_receivers_c1731 (arg1));
 }
 
@@ -1768,9 +1768,9 @@ static void _call_fp_standardIconImplementation_c6956 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QIcon > ((QIcon)((QMotifStyle_Adaptor *)cls)->fp_QMotifStyle_standardIconImplementation_c6956 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMouseEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMouseEvent.cc
@@ -212,12 +212,12 @@ static void _call_f_createExtendedMouseEvent_12512 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg4 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
-  QFlags<Qt::MouseButton> arg5 = args.read<QFlags<Qt::MouseButton> > (heap);
-  QFlags<Qt::KeyboardModifier> arg6 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg4 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
+  QFlags<Qt::MouseButton> arg5 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg6 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   ret.write<QMouseEvent * > ((QMouseEvent *)QMouseEvent::createExtendedMouseEvent (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2, arg3, qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg4).cref(), arg5, arg6));
 }
 
@@ -296,11 +296,11 @@ static void _call_ctor_QMouseEvent_Adaptor_10634 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
-  QFlags<Qt::MouseButton> arg4 = args.read<QFlags<Qt::MouseButton> > (heap);
-  QFlags<Qt::KeyboardModifier> arg5 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
+  QFlags<Qt::MouseButton> arg4 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg5 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   ret.write<QMouseEvent_Adaptor *> (new QMouseEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2, qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg3).cref(), arg4, arg5));
 }
 
@@ -328,12 +328,12 @@ static void _call_ctor_QMouseEvent_Adaptor_12442 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
-  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg4 = args.read<const qt_gsi::Converter<Qt::MouseButton>::target_type & > (heap);
-  QFlags<Qt::MouseButton> arg5 = args.read<QFlags<Qt::MouseButton> > (heap);
-  QFlags<Qt::KeyboardModifier> arg6 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const qt_gsi::Converter<Qt::MouseButton>::target_type & arg4 = gsi::arg_reader<const qt_gsi::Converter<Qt::MouseButton>::target_type & >() (args, heap);
+  QFlags<Qt::MouseButton> arg5 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg6 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
   ret.write<QMouseEvent_Adaptor *> (new QMouseEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), arg2, arg3, qt_gsi::QtToCppAdaptor<Qt::MouseButton>(arg4).cref(), arg5, arg6));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMoveEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMoveEvent.cc
@@ -120,8 +120,8 @@ static void _call_ctor_QMoveEvent_Adaptor_3724 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QMoveEvent_Adaptor *> (new QMoveEvent_Adaptor (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQMovie.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQMovie.cc
@@ -254,7 +254,7 @@ static void _call_f_jumpToFrame_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QMovie *)cls)->jumpToFrame (arg1));
 }
 
@@ -333,7 +333,7 @@ static void _call_f_setBackgroundColor_1905 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMovie *)cls)->setBackgroundColor (arg1);
 }
@@ -353,7 +353,7 @@ static void _call_f_setCacheMode_2002 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMovie::CacheMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QMovie::CacheMode>::target_type & > (heap);
+  const qt_gsi::Converter<QMovie::CacheMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMovie::CacheMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMovie *)cls)->setCacheMode (qt_gsi::QtToCppAdaptor<QMovie::CacheMode>(arg1).cref());
 }
@@ -373,7 +373,7 @@ static void _call_f_setDevice_1447 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMovie *)cls)->setDevice (arg1);
 }
@@ -393,7 +393,7 @@ static void _call_f_setFileName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMovie *)cls)->setFileName (arg1);
 }
@@ -413,7 +413,7 @@ static void _call_f_setFormat_2309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMovie *)cls)->setFormat (arg1);
 }
@@ -433,7 +433,7 @@ static void _call_f_setPaused_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMovie *)cls)->setPaused (arg1);
 }
@@ -453,7 +453,7 @@ static void _call_f_setScaledSize_1805 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMovie *)cls)->setScaledSize (arg1);
 }
@@ -473,7 +473,7 @@ static void _call_f_setSpeed_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QMovie *)cls)->setSpeed (arg1);
 }
@@ -572,8 +572,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMovie::tr (arg1, arg2));
 }
 
@@ -596,9 +596,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMovie::tr (arg1, arg2, arg3));
 }
 
@@ -619,8 +619,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QMovie::trUtf8 (arg1, arg2));
 }
 
@@ -643,9 +643,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QMovie::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -937,7 +937,7 @@ static void _call_ctor_QMovie_Adaptor_1302 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QMovie_Adaptor *> (new QMovie_Adaptor (arg1));
 }
 
@@ -959,9 +959,9 @@ static void _call_ctor_QMovie_Adaptor_4842 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const QByteArray &arg2 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
-  QObject *arg3 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const QByteArray &arg2 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
+  QObject *arg3 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QMovie_Adaptor *> (new QMovie_Adaptor (arg1, arg2, arg3));
 }
 
@@ -983,9 +983,9 @@ static void _call_ctor_QMovie_Adaptor_5420 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QByteArray &arg2 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
-  QObject *arg3 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QByteArray &arg2 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
+  QObject *arg3 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QMovie_Adaptor *> (new QMovie_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1051,7 +1051,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QMovie_Adaptor *)cls)->emitter_QMovie_destroyed_1302 (arg1);
 }
 
@@ -1093,7 +1093,7 @@ static void _call_emitter_error_3311 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QImageReader::ImageReaderError>::target_type & arg1 = args.read<const qt_gsi::Converter<QImageReader::ImageReaderError>::target_type & > (heap);
+  const qt_gsi::Converter<QImageReader::ImageReaderError>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QImageReader::ImageReaderError>::target_type & >() (args, heap);
   ((QMovie_Adaptor *)cls)->emitter_QMovie_error_3311 (arg1);
 }
 
@@ -1174,7 +1174,7 @@ static void _call_emitter_frameChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QMovie_Adaptor *)cls)->emitter_QMovie_frameChanged_767 (arg1);
 }
 
@@ -1192,7 +1192,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QMovie_Adaptor *)cls)->fp_QMovie_receivers_c1731 (arg1));
 }
 
@@ -1210,7 +1210,7 @@ static void _call_emitter_resized_1805 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ((QMovie_Adaptor *)cls)->emitter_QMovie_resized_1805 (arg1);
 }
 
@@ -1256,7 +1256,7 @@ static void _call_emitter_stateChanged_2170 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QMovie::MovieState>::target_type & arg1 = args.read<const qt_gsi::Converter<QMovie::MovieState>::target_type & > (heap);
+  const qt_gsi::Converter<QMovie::MovieState>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QMovie::MovieState>::target_type & >() (args, heap);
   ((QMovie_Adaptor *)cls)->emitter_QMovie_stateChanged_2170 (arg1);
 }
 
@@ -1298,7 +1298,7 @@ static void _call_emitter_updated_1792 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ((QMovie_Adaptor *)cls)->emitter_QMovie_updated_1792 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPageSetupDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPageSetupDialog.cc
@@ -66,7 +66,7 @@ static void _call_f_addEnabledOption_4270 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & > (heap);
+  const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPageSetupDialog *)cls)->addEnabledOption (qt_gsi::QtToCppAdaptor<QPageSetupDialog::PageSetupDialogOption>(arg1).cref());
 }
@@ -116,7 +116,7 @@ static void _call_f_isOptionEnabled_c4270 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & > (heap);
+  const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QPageSetupDialog *)cls)->isOptionEnabled (qt_gsi::QtToCppAdaptor<QPageSetupDialog::PageSetupDialogOption>(arg1).cref()));
 }
 
@@ -153,8 +153,8 @@ static void _call_f_open_2925 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPageSetupDialog *)cls)->open (arg1, arg2);
 }
@@ -189,7 +189,7 @@ static void _call_f_setEnabledOptions_4966 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPageSetupDialog::PageSetupDialogOption> arg1 = args.read<QFlags<QPageSetupDialog::PageSetupDialogOption> > (heap);
+  QFlags<QPageSetupDialog::PageSetupDialogOption> arg1 = gsi::arg_reader<QFlags<QPageSetupDialog::PageSetupDialogOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPageSetupDialog *)cls)->setEnabledOptions (arg1);
 }
@@ -211,8 +211,8 @@ static void _call_f_setOption_5026 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPageSetupDialog *)cls)->setOption (qt_gsi::QtToCppAdaptor<QPageSetupDialog::PageSetupDialogOption>(arg1).cref(), arg2);
 }
@@ -232,7 +232,7 @@ static void _call_f_setOptions_4966 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPageSetupDialog::PageSetupDialogOption> arg1 = args.read<QFlags<QPageSetupDialog::PageSetupDialogOption> > (heap);
+  QFlags<QPageSetupDialog::PageSetupDialogOption> arg1 = gsi::arg_reader<QFlags<QPageSetupDialog::PageSetupDialogOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPageSetupDialog *)cls)->setOptions (arg1);
 }
@@ -252,7 +252,7 @@ static void _call_f_testOption_c4270 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & > (heap);
+  const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPageSetupDialog::PageSetupDialogOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QPageSetupDialog *)cls)->testOption (qt_gsi::QtToCppAdaptor<QPageSetupDialog::PageSetupDialogOption>(arg1).cref()));
 }
 
@@ -273,8 +273,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPageSetupDialog::tr (arg1, arg2));
 }
 
@@ -297,9 +297,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPageSetupDialog::tr (arg1, arg2, arg3));
 }
 
@@ -320,8 +320,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPageSetupDialog::trUtf8 (arg1, arg2));
 }
 
@@ -344,9 +344,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPageSetupDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -449,8 +449,8 @@ static void _call_ctor_QPageSetupDialog_Adaptor_2650 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QPageSetupDialog_Adaptor *> (new QPageSetupDialog_Adaptor (arg1, arg2));
 }
 
@@ -468,7 +468,7 @@ static void _call_ctor_QPageSetupDialog_Adaptor_1315 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QPageSetupDialog_Adaptor *> (new QPageSetupDialog_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPaintEngine.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPaintEngine.cc
@@ -62,7 +62,7 @@ static void _call_f_begin_1803 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPaintDevice *arg1 = args.read<QPaintDevice * > (heap);
+  QPaintDevice *arg1 = gsi::arg_reader<QPaintDevice * >() (args, heap);
   ret.write<bool > ((bool)((QPaintEngine *)cls)->begin (arg1));
 }
 
@@ -81,7 +81,7 @@ static void _call_f_clearDirty_3337 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPaintEngine::DirtyFlag> arg1 = args.read<QFlags<QPaintEngine::DirtyFlag> > (heap);
+  QFlags<QPaintEngine::DirtyFlag> arg1 = gsi::arg_reader<QFlags<QPaintEngine::DirtyFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->clearDirty (arg1);
 }
@@ -116,7 +116,7 @@ static void _call_f_drawEllipse_1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->drawEllipse (arg1);
 }
@@ -136,7 +136,7 @@ static void _call_f_drawEllipse_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->drawEllipse (arg1);
 }
@@ -162,10 +162,10 @@ static void _call_f_drawImage_8645 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QImage &arg2 = args.read<const QImage & > (heap);
-  const QRectF &arg3 = args.read<const QRectF & > (heap);
-  QFlags<Qt::ImageConversionFlag> arg4 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QImage &arg2 = gsi::arg_reader<const QImage & >() (args, heap);
+  const QRectF &arg3 = gsi::arg_reader<const QRectF & >() (args, heap);
+  QFlags<Qt::ImageConversionFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->drawImage (arg1, arg2, arg3, arg4);
 }
@@ -185,7 +185,7 @@ static void _call_f_drawPath_2514 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->drawPath (arg1);
 }
@@ -209,9 +209,9 @@ static void _call_f_drawPixmap_5525 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QRectF &arg3 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QRectF &arg3 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->drawPixmap (arg1, arg2, arg3);
 }
@@ -233,8 +233,8 @@ static void _call_f_drawTextItem_4092 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QTextItem &arg2 = args.read<const QTextItem & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QTextItem &arg2 = gsi::arg_reader<const QTextItem & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->drawTextItem (arg1, arg2);
 }
@@ -258,9 +258,9 @@ static void _call_f_drawTiledPixmap_5649 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QPointF &arg3 = args.read<const QPointF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QPointF &arg3 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->drawTiledPixmap (arg1, arg2, arg3);
 }
@@ -295,7 +295,7 @@ static void _call_f_hasFeature_c4257 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPaintEngine::PaintEngineFeature> arg1 = args.read<QFlags<QPaintEngine::PaintEngineFeature> > (heap);
+  QFlags<QPaintEngine::PaintEngineFeature> arg1 = gsi::arg_reader<QFlags<QPaintEngine::PaintEngineFeature> >() (args, heap);
   ret.write<bool > ((bool)((QPaintEngine *)cls)->hasFeature (arg1));
 }
 
@@ -374,7 +374,7 @@ static void _call_f_setActive_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->setActive (arg1);
 }
@@ -394,7 +394,7 @@ static void _call_f_setDirty_3337 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPaintEngine::DirtyFlag> arg1 = args.read<QFlags<QPaintEngine::DirtyFlag> > (heap);
+  QFlags<QPaintEngine::DirtyFlag> arg1 = gsi::arg_reader<QFlags<QPaintEngine::DirtyFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->setDirty (arg1);
 }
@@ -414,7 +414,7 @@ static void _call_f_setPaintDevice_1803 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPaintDevice *arg1 = args.read<QPaintDevice * > (heap);
+  QPaintDevice *arg1 = gsi::arg_reader<QPaintDevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->setPaintDevice (arg1);
 }
@@ -434,7 +434,7 @@ static void _call_f_setSystemClip_2006 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->setSystemClip (arg1);
 }
@@ -454,7 +454,7 @@ static void _call_f_setSystemRect_1792 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->setSystemRect (arg1);
 }
@@ -520,7 +520,7 @@ static void _call_f_testDirty_3337 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPaintEngine::DirtyFlag> arg1 = args.read<QFlags<QPaintEngine::DirtyFlag> > (heap);
+  QFlags<QPaintEngine::DirtyFlag> arg1 = gsi::arg_reader<QFlags<QPaintEngine::DirtyFlag> >() (args, heap);
   ret.write<bool > ((bool)((QPaintEngine *)cls)->testDirty (arg1));
 }
 
@@ -554,7 +554,7 @@ static void _call_f_updateState_3013 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPaintEngineState &arg1 = args.read<const QPaintEngineState & > (heap);
+  const QPaintEngineState &arg1 = gsi::arg_reader<const QPaintEngineState & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPaintEngine *)cls)->updateState (arg1);
 }
@@ -836,7 +836,7 @@ static void _call_ctor_QPaintEngine_Adaptor_4257 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPaintEngine::PaintEngineFeature> arg1 = args ? args.read<QFlags<QPaintEngine::PaintEngineFeature> > (heap) : (QFlags<QPaintEngine::PaintEngineFeature>)(0);
+  QFlags<QPaintEngine::PaintEngineFeature> arg1 = args ? gsi::arg_reader<QFlags<QPaintEngine::PaintEngineFeature> >() (args, heap) : gsi::arg_maker<QFlags<QPaintEngine::PaintEngineFeature> >() (0, heap);
   ret.write<QPaintEngine_Adaptor *> (new QPaintEngine_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPaintEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPaintEvent.cc
@@ -125,7 +125,7 @@ static void _call_ctor_QPaintEvent_Adaptor_2006 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QPaintEvent_Adaptor *> (new QPaintEvent_Adaptor (arg1));
 }
 
@@ -143,7 +143,7 @@ static void _call_ctor_QPaintEvent_Adaptor_1792 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QPaintEvent_Adaptor *> (new QPaintEvent_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPainter.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPainter.cc
@@ -91,7 +91,7 @@ static void _call_ctor_QPainter_1803 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPaintDevice *arg1 = args.read<QPaintDevice * > (heap);
+  QPaintDevice *arg1 = gsi::arg_reader<QPaintDevice * >() (args, heap);
   ret.write<QPainter *> (new QPainter (arg1));
 }
 
@@ -140,7 +140,7 @@ static void _call_f_begin_1803 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPaintDevice *arg1 = args.read<QPaintDevice * > (heap);
+  QPaintDevice *arg1 = gsi::arg_reader<QPaintDevice * >() (args, heap);
   ret.write<bool > ((bool)((QPainter *)cls)->begin (arg1));
 }
 
@@ -179,9 +179,9 @@ static void _call_f_boundingRect_4438 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QPainter *)cls)->boundingRect (arg1, arg2, arg3));
 }
 
@@ -204,9 +204,9 @@ static void _call_f_boundingRect_4368 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QRect > ((QRect)((QPainter *)cls)->boundingRect (arg1, arg2, arg3));
 }
 
@@ -235,12 +235,12 @@ static void _call_f_boundingRect_5320 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  const QString &arg6 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg6 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QRect > ((QRect)((QPainter *)cls)->boundingRect (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -263,9 +263,9 @@ static void _call_f_boundingRect_6119 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QTextOption &arg3 = args ? args.read<const QTextOption & > (heap) : (const QTextOption &)(QTextOption());
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QTextOption &arg3 = args ? gsi::arg_reader<const QTextOption & >() (args, heap) : gsi::arg_maker<const QTextOption & >() (QTextOption(), heap);
   ret.write<QRectF > ((QRectF)((QPainter *)cls)->boundingRect (arg1, arg2, arg3));
 }
 
@@ -438,9 +438,9 @@ static void _call_f_drawArc_3180 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawArc (arg1, arg2, arg3);
 }
@@ -464,9 +464,9 @@ static void _call_f_drawArc_3110 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawArc (arg1, arg2, arg3);
 }
@@ -496,12 +496,12 @@ static void _call_f_drawArc_4062 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  int arg6 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  int arg6 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawArc (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -525,9 +525,9 @@ static void _call_f_drawChord_3180 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawChord (arg1, arg2, arg3);
 }
@@ -557,12 +557,12 @@ static void _call_f_drawChord_4062 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  int arg6 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  int arg6 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawChord (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -586,9 +586,9 @@ static void _call_f_drawChord_3110 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawChord (arg1, arg2, arg3);
 }
@@ -608,7 +608,7 @@ static void _call_f_drawConvexPolygon_2208 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawConvexPolygon (arg1);
 }
@@ -628,7 +628,7 @@ static void _call_f_drawConvexPolygon_2138 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawConvexPolygon (arg1);
 }
@@ -648,7 +648,7 @@ static void _call_f_drawEllipse_1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawEllipse (arg1);
 }
@@ -668,7 +668,7 @@ static void _call_f_drawEllipse_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawEllipse (arg1);
 }
@@ -694,10 +694,10 @@ static void _call_f_drawEllipse_2744 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawEllipse (arg1, arg2, arg3, arg4);
 }
@@ -721,9 +721,9 @@ static void _call_f_drawEllipse_3912 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawEllipse (arg1, arg2, arg3);
 }
@@ -747,9 +747,9 @@ static void _call_f_drawEllipse_3234 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawEllipse (arg1, arg2, arg3);
 }
@@ -775,10 +775,10 @@ static void _call_f_drawImage_8645 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QImage &arg2 = args.read<const QImage & > (heap);
-  const QRectF &arg3 = args.read<const QRectF & > (heap);
-  QFlags<Qt::ImageConversionFlag> arg4 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QImage &arg2 = gsi::arg_reader<const QImage & >() (args, heap);
+  const QRectF &arg3 = gsi::arg_reader<const QRectF & >() (args, heap);
+  QFlags<Qt::ImageConversionFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawImage (arg1, arg2, arg3, arg4);
 }
@@ -804,10 +804,10 @@ static void _call_f_drawImage_8505 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const QImage &arg2 = args.read<const QImage & > (heap);
-  const QRect &arg3 = args.read<const QRect & > (heap);
-  QFlags<Qt::ImageConversionFlag> arg4 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QImage &arg2 = gsi::arg_reader<const QImage & >() (args, heap);
+  const QRect &arg3 = gsi::arg_reader<const QRect & >() (args, heap);
+  QFlags<Qt::ImageConversionFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawImage (arg1, arg2, arg3, arg4);
 }
@@ -833,10 +833,10 @@ static void _call_f_drawImage_8769 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QImage &arg2 = args.read<const QImage & > (heap);
-  const QRectF &arg3 = args.read<const QRectF & > (heap);
-  QFlags<Qt::ImageConversionFlag> arg4 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QImage &arg2 = gsi::arg_reader<const QImage & >() (args, heap);
+  const QRectF &arg3 = gsi::arg_reader<const QRectF & >() (args, heap);
+  QFlags<Qt::ImageConversionFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawImage (arg1, arg2, arg3, arg4);
 }
@@ -862,10 +862,10 @@ static void _call_f_drawImage_8629 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QImage &arg2 = args.read<const QImage & > (heap);
-  const QRect &arg3 = args.read<const QRect & > (heap);
-  QFlags<Qt::ImageConversionFlag> arg4 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QImage &arg2 = gsi::arg_reader<const QImage & >() (args, heap);
+  const QRect &arg3 = gsi::arg_reader<const QRect & >() (args, heap);
+  QFlags<Qt::ImageConversionFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawImage (arg1, arg2, arg3, arg4);
 }
@@ -887,8 +887,8 @@ static void _call_f_drawImage_3631 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QImage &arg2 = args.read<const QImage & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QImage &arg2 = gsi::arg_reader<const QImage & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawImage (arg1, arg2);
 }
@@ -910,8 +910,8 @@ static void _call_f_drawImage_3561 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const QImage &arg2 = args.read<const QImage & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QImage &arg2 = gsi::arg_reader<const QImage & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawImage (arg1, arg2);
 }
@@ -933,8 +933,8 @@ static void _call_f_drawImage_3755 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QImage &arg2 = args.read<const QImage & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QImage &arg2 = gsi::arg_reader<const QImage & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawImage (arg1, arg2);
 }
@@ -956,8 +956,8 @@ static void _call_f_drawImage_3685 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QImage &arg2 = args.read<const QImage & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QImage &arg2 = gsi::arg_reader<const QImage & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawImage (arg1, arg2);
 }
@@ -991,14 +991,14 @@ static void _call_f_drawImage_9091 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QImage &arg3 = args.read<const QImage & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
-  int arg5 = args ? args.read<int > (heap) : (int)(0);
-  int arg6 = args ? args.read<int > (heap) : (int)(-1);
-  int arg7 = args ? args.read<int > (heap) : (int)(-1);
-  QFlags<Qt::ImageConversionFlag> arg8 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QImage &arg3 = gsi::arg_reader<const QImage & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg6 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  int arg7 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  QFlags<Qt::ImageConversionFlag> arg8 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawImage (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 }
@@ -1018,7 +1018,7 @@ static void _call_f_drawLine_1856 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawLine (arg1);
 }
@@ -1038,7 +1038,7 @@ static void _call_f_drawLine_1786 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLine &arg1 = args.read<const QLine & > (heap);
+  const QLine &arg1 = gsi::arg_reader<const QLine & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawLine (arg1);
 }
@@ -1064,10 +1064,10 @@ static void _call_f_drawLine_2744 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawLine (arg1, arg2, arg3, arg4);
 }
@@ -1089,8 +1089,8 @@ static void _call_f_drawLine_3724 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawLine (arg1, arg2);
 }
@@ -1112,8 +1112,8 @@ static void _call_f_drawLine_3864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawLine (arg1, arg2);
 }
@@ -1133,7 +1133,7 @@ static void _call_f_drawLines_2686 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QLineF> &arg1 = args.read<const QVector<QLineF> & > (heap);
+  const QVector<QLineF> &arg1 = gsi::arg_reader<const QVector<QLineF> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawLines (arg1);
 }
@@ -1153,7 +1153,7 @@ static void _call_f_drawLines_2816 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QPointF> &arg1 = args.read<const QVector<QPointF> & > (heap);
+  const QVector<QPointF> &arg1 = gsi::arg_reader<const QVector<QPointF> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawLines (arg1);
 }
@@ -1173,7 +1173,7 @@ static void _call_f_drawLines_2616 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QLine> &arg1 = args.read<const QVector<QLine> & > (heap);
+  const QVector<QLine> &arg1 = gsi::arg_reader<const QVector<QLine> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawLines (arg1);
 }
@@ -1193,7 +1193,7 @@ static void _call_f_drawLines_2746 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QPoint> &arg1 = args.read<const QVector<QPoint> & > (heap);
+  const QVector<QPoint> &arg1 = gsi::arg_reader<const QVector<QPoint> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawLines (arg1);
 }
@@ -1213,7 +1213,7 @@ static void _call_f_drawPath_2514 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPath (arg1);
 }
@@ -1235,8 +1235,8 @@ static void _call_f_drawPicture_4004 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPicture &arg2 = args.read<const QPicture & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPicture &arg2 = gsi::arg_reader<const QPicture & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPicture (arg1, arg2);
 }
@@ -1260,9 +1260,9 @@ static void _call_f_drawPicture_3444 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QPicture &arg3 = args.read<const QPicture & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QPicture &arg3 = gsi::arg_reader<const QPicture & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPicture (arg1, arg2, arg3);
 }
@@ -1284,8 +1284,8 @@ static void _call_f_drawPicture_3934 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QPicture &arg2 = args.read<const QPicture & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPicture &arg2 = gsi::arg_reader<const QPicture & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPicture (arg1, arg2);
 }
@@ -1309,9 +1309,9 @@ static void _call_f_drawPie_3180 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPie (arg1, arg2, arg3);
 }
@@ -1341,12 +1341,12 @@ static void _call_f_drawPie_4062 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  int arg6 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  int arg6 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPie (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -1370,9 +1370,9 @@ static void _call_f_drawPie_3110 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPie (arg1, arg2, arg3);
 }
@@ -1396,9 +1396,9 @@ static void _call_f_drawPixmap_5525 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QRectF &arg3 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QRectF &arg3 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2, arg3);
 }
@@ -1422,9 +1422,9 @@ static void _call_f_drawPixmap_5385 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QRect &arg3 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QRect &arg3 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2, arg3);
 }
@@ -1460,15 +1460,15 @@ static void _call_f_drawPixmap_7289 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QPixmap &arg5 = args.read<const QPixmap & > (heap);
-  int arg6 = args.read<int > (heap);
-  int arg7 = args.read<int > (heap);
-  int arg8 = args.read<int > (heap);
-  int arg9 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg5 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  int arg6 = gsi::arg_reader<int >() (args, heap);
+  int arg7 = gsi::arg_reader<int >() (args, heap);
+  int arg8 = gsi::arg_reader<int >() (args, heap);
+  int arg9 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
 }
@@ -1500,13 +1500,13 @@ static void _call_f_drawPixmap_5971 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QPixmap &arg3 = args.read<const QPixmap & > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  int arg6 = args.read<int > (heap);
-  int arg7 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg3 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  int arg6 = gsi::arg_reader<int >() (args, heap);
+  int arg7 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 }
@@ -1530,9 +1530,9 @@ static void _call_f_drawPixmap_5649 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QRectF &arg3 = args.read<const QRectF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QRectF &arg3 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2, arg3);
 }
@@ -1556,9 +1556,9 @@ static void _call_f_drawPixmap_5509 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QRect &arg3 = args.read<const QRect & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QRect &arg3 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2, arg3);
 }
@@ -1580,8 +1580,8 @@ static void _call_f_drawPixmap_3895 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2);
 }
@@ -1603,8 +1603,8 @@ static void _call_f_drawPixmap_3825 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2);
 }
@@ -1628,9 +1628,9 @@ static void _call_f_drawPixmap_3335 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QPixmap &arg3 = args.read<const QPixmap & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg3 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2, arg3);
 }
@@ -1652,8 +1652,8 @@ static void _call_f_drawPixmap_3701 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2);
 }
@@ -1681,11 +1681,11 @@ static void _call_f_drawPixmap_4653 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QPixmap &arg5 = args.read<const QPixmap & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg5 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPixmap (arg1, arg2, arg3, arg4, arg5);
 }
@@ -1705,7 +1705,7 @@ static void _call_f_drawPoint_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPoint (arg1);
 }
@@ -1725,7 +1725,7 @@ static void _call_f_drawPoint_1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPoint (arg1);
 }
@@ -1747,8 +1747,8 @@ static void _call_f_drawPoint_1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPoint (arg1, arg2);
 }
@@ -1768,7 +1768,7 @@ static void _call_f_drawPoints_2208 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPoints (arg1);
 }
@@ -1788,7 +1788,7 @@ static void _call_f_drawPoints_2138 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPoints (arg1);
 }
@@ -1810,8 +1810,8 @@ static void _call_f_drawPolygon_3648 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
-  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::FillRule>::target_type & > (heap) : (const qt_gsi::Converter<Qt::FillRule>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::FillRule>(heap, Qt::OddEvenFill));
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
+  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::FillRule>(heap, Qt::OddEvenFill), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPolygon (arg1, qt_gsi::QtToCppAdaptor<Qt::FillRule>(arg2).cref());
 }
@@ -1833,8 +1833,8 @@ static void _call_f_drawPolygon_3578 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
-  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::FillRule>::target_type & > (heap) : (const qt_gsi::Converter<Qt::FillRule>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::FillRule>(heap, Qt::OddEvenFill));
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
+  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::FillRule>(heap, Qt::OddEvenFill), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPolygon (arg1, qt_gsi::QtToCppAdaptor<Qt::FillRule>(arg2).cref());
 }
@@ -1854,7 +1854,7 @@ static void _call_f_drawPolyline_2208 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPolyline (arg1);
 }
@@ -1874,7 +1874,7 @@ static void _call_f_drawPolyline_2138 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawPolyline (arg1);
 }
@@ -1894,7 +1894,7 @@ static void _call_f_drawRect_1862 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRect (arg1);
 }
@@ -1920,10 +1920,10 @@ static void _call_f_drawRect_2744 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRect (arg1, arg2, arg3, arg4);
 }
@@ -1943,7 +1943,7 @@ static void _call_f_drawRect_1792 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRect (arg1);
 }
@@ -1963,7 +1963,7 @@ static void _call_f_drawRects_2692 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QRectF> &arg1 = args.read<const QVector<QRectF> & > (heap);
+  const QVector<QRectF> &arg1 = gsi::arg_reader<const QVector<QRectF> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRects (arg1);
 }
@@ -1983,7 +1983,7 @@ static void _call_f_drawRects_2622 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QRect> &arg1 = args.read<const QVector<QRect> & > (heap);
+  const QVector<QRect> &arg1 = gsi::arg_reader<const QVector<QRect> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRects (arg1);
 }
@@ -2007,9 +2007,9 @@ static void _call_f_drawRoundRect_3180 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(25);
-  int arg3 = args ? args.read<int > (heap) : (int)(25);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (25, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (25, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRoundRect (arg1, arg2, arg3);
 }
@@ -2039,12 +2039,12 @@ static void _call_f_drawRoundRect_4062 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args ? args.read<int > (heap) : (int)(25);
-  int arg6 = args ? args.read<int > (heap) : (int)(25);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (25, heap);
+  int arg6 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (25, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRoundRect (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -2068,9 +2068,9 @@ static void _call_f_drawRoundRect_3110 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(25);
-  int arg3 = args ? args.read<int > (heap) : (int)(25);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (25, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (25, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRoundRect (arg1, arg2, arg3);
 }
@@ -2096,10 +2096,10 @@ static void _call_f_drawRoundedRect_5229 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<Qt::SizeMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SizeMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize));
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRoundedRect (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<Qt::SizeMode>(arg4).cref());
 }
@@ -2131,13 +2131,13 @@ static void _call_f_drawRoundedRect_6111 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg7 = args ? args.read<const qt_gsi::Converter<Qt::SizeMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SizeMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg7 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRoundedRect (arg1, arg2, arg3, arg4, arg5, arg6, qt_gsi::QtToCppAdaptor<Qt::SizeMode>(arg7).cref());
 }
@@ -2163,10 +2163,10 @@ static void _call_f_drawRoundedRect_5159 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<Qt::SizeMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SizeMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize));
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawRoundedRect (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<Qt::SizeMode>(arg4).cref());
 }
@@ -2188,8 +2188,8 @@ static void _call_f_drawText_3903 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawText (arg1, arg2);
 }
@@ -2211,8 +2211,8 @@ static void _call_f_drawText_3833 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawText (arg1, arg2);
 }
@@ -2236,9 +2236,9 @@ static void _call_f_drawText_3343 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawText (arg1, arg2, arg3);
 }
@@ -2264,10 +2264,10 @@ static void _call_f_drawText_5221 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawText (arg1, arg2, arg3, arg4);
 }
@@ -2293,10 +2293,10 @@ static void _call_f_drawText_5501 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  QRectF *arg4 = args ? args.read<QRectF * > (heap) : (QRectF *)(0);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  QRectF *arg4 = args ? gsi::arg_reader<QRectF * >() (args, heap) : gsi::arg_maker<QRectF * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawText (arg1, arg2, arg3, arg4);
 }
@@ -2322,10 +2322,10 @@ static void _call_f_drawText_5361 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  QRect *arg4 = args ? args.read<QRect * > (heap) : (QRect *)(0);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  QRect *arg4 = args ? gsi::arg_reader<QRect * >() (args, heap) : gsi::arg_maker<QRect * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawText (arg1, arg2, arg3, arg4);
 }
@@ -2357,13 +2357,13 @@ static void _call_f_drawText_6313 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  const QString &arg6 = args.read<const QString & > (heap);
-  QRect *arg7 = args ? args.read<QRect * > (heap) : (QRect *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg6 = gsi::arg_reader<const QString & >() (args, heap);
+  QRect *arg7 = args ? gsi::arg_reader<QRect * >() (args, heap) : gsi::arg_maker<QRect * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawText (arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 }
@@ -2387,9 +2387,9 @@ static void _call_f_drawText_6119 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QTextOption &arg3 = args ? args.read<const QTextOption & > (heap) : (const QTextOption &)(QTextOption());
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QTextOption &arg3 = args ? gsi::arg_reader<const QTextOption & >() (args, heap) : gsi::arg_maker<const QTextOption & >() (QTextOption(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawText (arg1, arg2, arg3);
 }
@@ -2411,8 +2411,8 @@ static void _call_f_drawTextItem_4092 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QTextItem &arg2 = args.read<const QTextItem & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QTextItem &arg2 = gsi::arg_reader<const QTextItem & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawTextItem (arg1, arg2);
 }
@@ -2436,9 +2436,9 @@ static void _call_f_drawTextItem_3532 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QTextItem &arg3 = args.read<const QTextItem & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QTextItem &arg3 = gsi::arg_reader<const QTextItem & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawTextItem (arg1, arg2, arg3);
 }
@@ -2460,8 +2460,8 @@ static void _call_f_drawTextItem_4022 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QTextItem &arg2 = args.read<const QTextItem & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QTextItem &arg2 = gsi::arg_reader<const QTextItem & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawTextItem (arg1, arg2);
 }
@@ -2485,9 +2485,9 @@ static void _call_f_drawTiledPixmap_5649 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QPointF &arg3 = args ? args.read<const QPointF & > (heap) : (const QPointF &)(QPointF());
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QPointF &arg3 = args ? gsi::arg_reader<const QPointF & >() (args, heap) : gsi::arg_maker<const QPointF & >() (QPointF(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawTiledPixmap (arg1, arg2, arg3);
 }
@@ -2519,13 +2519,13 @@ static void _call_f_drawTiledPixmap_5971 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QPixmap &arg5 = args.read<const QPixmap & > (heap);
-  int arg6 = args ? args.read<int > (heap) : (int)(0);
-  int arg7 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg5 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  int arg6 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg7 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawTiledPixmap (arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 }
@@ -2549,9 +2549,9 @@ static void _call_f_drawTiledPixmap_5509 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QPoint &arg3 = args ? args.read<const QPoint & > (heap) : (const QPoint &)(QPoint());
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QPoint &arg3 = args ? gsi::arg_reader<const QPoint & >() (args, heap) : gsi::arg_maker<const QPoint & >() (QPoint(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->drawTiledPixmap (arg1, arg2, arg3);
 }
@@ -2602,7 +2602,7 @@ static void _call_f_eraseRect_1862 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->eraseRect (arg1);
 }
@@ -2628,10 +2628,10 @@ static void _call_f_eraseRect_2744 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->eraseRect (arg1, arg2, arg3, arg4);
 }
@@ -2651,7 +2651,7 @@ static void _call_f_eraseRect_1792 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->eraseRect (arg1);
 }
@@ -2673,8 +2673,8 @@ static void _call_f_fillPath_4316 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const QBrush &arg2 = args.read<const QBrush & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const QBrush &arg2 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillPath (arg1, arg2);
 }
@@ -2696,8 +2696,8 @@ static void _call_f_fillRect_3664 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QBrush &arg2 = args.read<const QBrush & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QBrush &arg2 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, arg2);
 }
@@ -2725,11 +2725,11 @@ static void _call_f_fillRect_4546 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QBrush &arg5 = args.read<const QBrush & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QBrush &arg5 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, arg2, arg3, arg4, arg5);
 }
@@ -2751,8 +2751,8 @@ static void _call_f_fillRect_3594 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const QBrush &arg2 = args.read<const QBrush & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QBrush &arg2 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, arg2);
 }
@@ -2774,8 +2774,8 @@ static void _call_f_fillRect_3659 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const QColor &arg2 = args.read<const QColor & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const QColor &arg2 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, arg2);
 }
@@ -2803,11 +2803,11 @@ static void _call_f_fillRect_4541 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QColor &arg5 = args.read<const QColor & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QColor &arg5 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, arg2, arg3, arg4, arg5);
 }
@@ -2829,8 +2829,8 @@ static void _call_f_fillRect_3589 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const QColor &arg2 = args.read<const QColor & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QColor &arg2 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, arg2);
 }
@@ -2858,11 +2858,11 @@ static void _call_f_fillRect_4489 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg5 = args.read<const qt_gsi::Converter<Qt::GlobalColor>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg5 = gsi::arg_reader<const qt_gsi::Converter<Qt::GlobalColor>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::GlobalColor>(arg5).cref());
 }
@@ -2884,8 +2884,8 @@ static void _call_f_fillRect_3537 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::GlobalColor>::target_type & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::GlobalColor>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, qt_gsi::QtToCppAdaptor<Qt::GlobalColor>(arg2).cref());
 }
@@ -2907,8 +2907,8 @@ static void _call_f_fillRect_3607 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::GlobalColor>::target_type & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::GlobalColor>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, qt_gsi::QtToCppAdaptor<Qt::GlobalColor>(arg2).cref());
 }
@@ -2936,11 +2936,11 @@ static void _call_f_fillRect_4430 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg5 = args.read<const qt_gsi::Converter<Qt::BrushStyle>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg5 = gsi::arg_reader<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::BrushStyle>(arg5).cref());
 }
@@ -2962,8 +2962,8 @@ static void _call_f_fillRect_3478 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::BrushStyle>::target_type & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, qt_gsi::QtToCppAdaptor<Qt::BrushStyle>(arg2).cref());
 }
@@ -2985,8 +2985,8 @@ static void _call_f_fillRect_3548 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::BrushStyle>::target_type & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->fillRect (arg1, qt_gsi::QtToCppAdaptor<Qt::BrushStyle>(arg2).cref());
 }
@@ -3066,7 +3066,7 @@ static void _call_f_initFrom_2010 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->initFrom (arg1);
 }
@@ -3254,7 +3254,7 @@ static void _call_f_rotate_1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->rotate (arg1);
 }
@@ -3292,8 +3292,8 @@ static void _call_f_scale_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->scale (arg1, arg2);
 }
@@ -3313,7 +3313,7 @@ static void _call_f_setBackground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setBackground (arg1);
 }
@@ -3333,7 +3333,7 @@ static void _call_f_setBackgroundMode_1275 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::BGMode>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::BGMode>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::BGMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::BGMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setBackgroundMode (qt_gsi::QtToCppAdaptor<Qt::BGMode>(arg1).cref());
 }
@@ -3353,7 +3353,7 @@ static void _call_f_setBrush_1910 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setBrush (arg1);
 }
@@ -3373,7 +3373,7 @@ static void _call_f_setBrush_1794 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::BrushStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::BrushStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::BrushStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setBrush (qt_gsi::QtToCppAdaptor<Qt::BrushStyle>(arg1).cref());
 }
@@ -3395,8 +3395,8 @@ static void _call_f_setBrushOrigin_1426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setBrushOrigin (arg1, arg2);
 }
@@ -3416,7 +3416,7 @@ static void _call_f_setBrushOrigin_1916 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setBrushOrigin (arg1);
 }
@@ -3436,7 +3436,7 @@ static void _call_f_setBrushOrigin_1986 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setBrushOrigin (arg1);
 }
@@ -3458,8 +3458,8 @@ static void _call_f_setClipPath_4492 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ClipOperation>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ClipOperation>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip));
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setClipPath (arg1, qt_gsi::QtToCppAdaptor<Qt::ClipOperation>(arg2).cref());
 }
@@ -3481,8 +3481,8 @@ static void _call_f_setClipRect_3840 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ClipOperation>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ClipOperation>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip));
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setClipRect (arg1, qt_gsi::QtToCppAdaptor<Qt::ClipOperation>(arg2).cref());
 }
@@ -3504,8 +3504,8 @@ static void _call_f_setClipRect_3770 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ClipOperation>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ClipOperation>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip));
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setClipRect (arg1, qt_gsi::QtToCppAdaptor<Qt::ClipOperation>(arg2).cref());
 }
@@ -3533,11 +3533,11 @@ static void _call_f_setClipRect_4722 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<Qt::ClipOperation>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ClipOperation>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setClipRect (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::ClipOperation>(arg5).cref());
 }
@@ -3559,8 +3559,8 @@ static void _call_f_setClipRegion_3984 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
-  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ClipOperation>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ClipOperation>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip));
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
+  const qt_gsi::Converter<Qt::ClipOperation>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ClipOperation>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ClipOperation>(heap, Qt::ReplaceClip), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setClipRegion (arg1, qt_gsi::QtToCppAdaptor<Qt::ClipOperation>(arg2).cref());
 }
@@ -3580,7 +3580,7 @@ static void _call_f_setClipping_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setClipping (arg1);
 }
@@ -3600,7 +3600,7 @@ static void _call_f_setCompositionMode_2917 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPainter::CompositionMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QPainter::CompositionMode>::target_type & > (heap);
+  const qt_gsi::Converter<QPainter::CompositionMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPainter::CompositionMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setCompositionMode (qt_gsi::QtToCppAdaptor<QPainter::CompositionMode>(arg1).cref());
 }
@@ -3620,7 +3620,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setFont (arg1);
 }
@@ -3640,7 +3640,7 @@ static void _call_f_setLayoutDirection_2316 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setLayoutDirection (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref());
 }
@@ -3662,8 +3662,8 @@ static void _call_f_setMatrix_2779 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setMatrix (arg1, arg2);
 }
@@ -3683,7 +3683,7 @@ static void _call_f_setMatrixEnabled_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setMatrixEnabled (arg1);
 }
@@ -3703,7 +3703,7 @@ static void _call_f_setOpacity_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setOpacity (arg1);
 }
@@ -3723,7 +3723,7 @@ static void _call_f_setPen_1905 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setPen (arg1);
 }
@@ -3743,7 +3743,7 @@ static void _call_f_setPen_1685 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPen &arg1 = args.read<const QPen & > (heap);
+  const QPen &arg1 = gsi::arg_reader<const QPen & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setPen (arg1);
 }
@@ -3763,7 +3763,7 @@ static void _call_f_setPen_1569 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::PenStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::PenStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setPen (qt_gsi::QtToCppAdaptor<Qt::PenStyle>(arg1).cref());
 }
@@ -3785,8 +3785,8 @@ static void _call_f_setRenderHint_3123 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPainter::RenderHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QPainter::RenderHint>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QPainter::RenderHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPainter::RenderHint>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setRenderHint (qt_gsi::QtToCppAdaptor<QPainter::RenderHint>(arg1).cref(), arg2);
 }
@@ -3808,8 +3808,8 @@ static void _call_f_setRenderHints_3819 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPainter::RenderHint> arg1 = args.read<QFlags<QPainter::RenderHint> > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  QFlags<QPainter::RenderHint> arg1 = gsi::arg_reader<QFlags<QPainter::RenderHint> >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setRenderHints (arg1, arg2);
 }
@@ -3831,8 +3831,8 @@ static void _call_f_setTransform_3106 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setTransform (arg1, arg2);
 }
@@ -3852,7 +3852,7 @@ static void _call_f_setViewTransformEnabled_864 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setViewTransformEnabled (arg1);
 }
@@ -3872,7 +3872,7 @@ static void _call_f_setViewport_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setViewport (arg1);
 }
@@ -3898,10 +3898,10 @@ static void _call_f_setViewport_2744 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setViewport (arg1, arg2, arg3, arg4);
 }
@@ -3921,7 +3921,7 @@ static void _call_f_setWindow_1792 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setWindow (arg1);
 }
@@ -3947,10 +3947,10 @@ static void _call_f_setWindow_2744 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setWindow (arg1, arg2, arg3, arg4);
 }
@@ -3972,8 +3972,8 @@ static void _call_f_setWorldMatrix_2779 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setWorldMatrix (arg1, arg2);
 }
@@ -3993,7 +3993,7 @@ static void _call_f_setWorldMatrixEnabled_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setWorldMatrixEnabled (arg1);
 }
@@ -4015,8 +4015,8 @@ static void _call_f_setWorldTransform_3106 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->setWorldTransform (arg1, arg2);
 }
@@ -4038,8 +4038,8 @@ static void _call_f_shear_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->shear (arg1, arg2);
 }
@@ -4061,8 +4061,8 @@ static void _call_f_strokePath_4091 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
-  const QPen &arg2 = args.read<const QPen & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
+  const QPen &arg2 = gsi::arg_reader<const QPen & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->strokePath (arg1, arg2);
 }
@@ -4082,7 +4082,7 @@ static void _call_f_testRenderHint_c2367 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPainter::RenderHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QPainter::RenderHint>::target_type & > (heap);
+  const qt_gsi::Converter<QPainter::RenderHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPainter::RenderHint>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QPainter *)cls)->testRenderHint (qt_gsi::QtToCppAdaptor<QPainter::RenderHint>(arg1).cref()));
 }
 
@@ -4116,7 +4116,7 @@ static void _call_f_translate_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->translate (arg1);
 }
@@ -4136,7 +4136,7 @@ static void _call_f_translate_1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->translate (arg1);
 }
@@ -4158,8 +4158,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainter *)cls)->translate (arg1, arg2);
 }
@@ -4271,8 +4271,8 @@ static void _call_f_redirected_3615 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPaintDevice *arg1 = args.read<const QPaintDevice * > (heap);
-  QPoint *arg2 = args ? args.read<QPoint * > (heap) : (QPoint *)(0);
+  const QPaintDevice *arg1 = gsi::arg_reader<const QPaintDevice * >() (args, heap);
+  QPoint *arg2 = args ? gsi::arg_reader<QPoint * >() (args, heap) : gsi::arg_maker<QPoint * >() (0, heap);
   ret.write<QPaintDevice * > ((QPaintDevice *)QPainter::redirected (arg1, arg2));
 }
 
@@ -4291,7 +4291,7 @@ static void _call_f_restoreRedirected_2498 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPaintDevice *arg1 = args.read<const QPaintDevice * > (heap);
+  const QPaintDevice *arg1 = gsi::arg_reader<const QPaintDevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QPainter::restoreRedirected (arg1);
 }
@@ -4315,9 +4315,9 @@ static void _call_f_setRedirected_6001 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPaintDevice *arg1 = args.read<const QPaintDevice * > (heap);
-  QPaintDevice *arg2 = args.read<QPaintDevice * > (heap);
-  const QPoint &arg3 = args ? args.read<const QPoint & > (heap) : (const QPoint &)(QPoint());
+  const QPaintDevice *arg1 = gsi::arg_reader<const QPaintDevice * >() (args, heap);
+  QPaintDevice *arg2 = gsi::arg_reader<QPaintDevice * >() (args, heap);
+  const QPoint &arg3 = args ? gsi::arg_reader<const QPoint & >() (args, heap) : gsi::arg_maker<const QPoint & >() (QPoint(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QPainter::setRedirected (arg1, arg2, arg3);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPainterPath.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPainterPath.cc
@@ -72,7 +72,7 @@ static void _call_ctor_QPainterPath_1986 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPainterPath *> (new QPainterPath (arg1));
 }
 
@@ -91,7 +91,7 @@ static void _call_ctor_QPainterPath_2514 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath *> (new QPainterPath (arg1));
 }
 
@@ -110,7 +110,7 @@ static void _call_f_addEllipse_1862 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addEllipse (arg1);
 }
@@ -136,10 +136,10 @@ static void _call_f_addEllipse_3960 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addEllipse (arg1, arg2, arg3, arg4);
 }
@@ -163,9 +163,9 @@ static void _call_f_addEllipse_3912 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addEllipse (arg1, arg2, arg3);
 }
@@ -185,7 +185,7 @@ static void _call_f_addPath_2514 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addPath (arg1);
 }
@@ -205,7 +205,7 @@ static void _call_f_addPolygon_2208 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addPolygon (arg1);
 }
@@ -225,7 +225,7 @@ static void _call_f_addRect_1862 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addRect (arg1);
 }
@@ -251,10 +251,10 @@ static void _call_f_addRect_3960 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addRect (arg1, arg2, arg3, arg4);
 }
@@ -274,7 +274,7 @@ static void _call_f_addRegion_2006 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addRegion (arg1);
 }
@@ -298,9 +298,9 @@ static void _call_f_addRoundRect_3180 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addRoundRect (arg1, arg2, arg3);
 }
@@ -330,12 +330,12 @@ static void _call_f_addRoundRect_5278 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  int arg5 = args.read<int > (heap);
-  int arg6 = args.read<int > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  int arg6 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addRoundRect (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -357,8 +357,8 @@ static void _call_f_addRoundRect_2521 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  int arg2 = args.read<int > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addRoundRect (arg1, arg2);
 }
@@ -386,11 +386,11 @@ static void _call_f_addRoundRect_4619 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  int arg5 = args.read<int > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addRoundRect (arg1, arg2, arg3, arg4, arg5);
 }
@@ -416,10 +416,10 @@ static void _call_f_addRoundedRect_5229 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<Qt::SizeMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SizeMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize));
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addRoundedRect (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<Qt::SizeMode>(arg4).cref());
 }
@@ -451,13 +451,13 @@ static void _call_f_addRoundedRect_7327 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg7 = args ? args.read<const qt_gsi::Converter<Qt::SizeMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SizeMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize));
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::SizeMode>::target_type & arg7 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SizeMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SizeMode>(heap, Qt::AbsoluteSize), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addRoundedRect (arg1, arg2, arg3, arg4, arg5, arg6, qt_gsi::QtToCppAdaptor<Qt::SizeMode>(arg7).cref());
 }
@@ -481,9 +481,9 @@ static void _call_f_addText_5596 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QFont &arg2 = args.read<const QFont & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QFont &arg2 = gsi::arg_reader<const QFont & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addText (arg1, arg2, arg3);
 }
@@ -509,10 +509,10 @@ static void _call_f_addText_5644 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  const QFont &arg3 = args.read<const QFont & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  const QFont &arg3 = gsi::arg_reader<const QFont & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->addText (arg1, arg2, arg3, arg4);
 }
@@ -532,7 +532,7 @@ static void _call_f_angleAtPercent_c1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QPainterPath *)cls)->angleAtPercent (arg1));
 }
 
@@ -553,8 +553,8 @@ static void _call_f_arcMoveTo_2825 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  double arg2 = args.read<double > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->arcMoveTo (arg1, arg2);
 }
@@ -582,11 +582,11 @@ static void _call_f_arcMoveTo_4923 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->arcMoveTo (arg1, arg2, arg3, arg4, arg5);
 }
@@ -610,9 +610,9 @@ static void _call_f_arcTo_3788 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->arcTo (arg1, arg2, arg3);
 }
@@ -642,12 +642,12 @@ static void _call_f_arcTo_5886 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->arcTo (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -698,7 +698,7 @@ static void _call_f_connectPath_2514 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->connectPath (arg1);
 }
@@ -718,7 +718,7 @@ static void _call_f_contains_c1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<bool > ((bool)((QPainterPath *)cls)->contains (arg1));
 }
 
@@ -737,7 +737,7 @@ static void _call_f_contains_c1862 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<bool > ((bool)((QPainterPath *)cls)->contains (arg1));
 }
 
@@ -756,7 +756,7 @@ static void _call_f_contains_c2514 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<bool > ((bool)((QPainterPath *)cls)->contains (arg1));
 }
 
@@ -794,9 +794,9 @@ static void _call_f_cubicTo_5742 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
-  const QPointF &arg3 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPointF &arg3 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->cubicTo (arg1, arg2, arg3);
 }
@@ -826,12 +826,12 @@ static void _call_f_cubicTo_5886 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->cubicTo (arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -866,7 +866,7 @@ static void _call_f_elementAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<const QPainterPath::Element & > ((const QPainterPath::Element &)((QPainterPath *)cls)->elementAt (arg1));
 }
 
@@ -915,7 +915,7 @@ static void _call_f_intersected_c2514 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->intersected (arg1));
 }
 
@@ -934,7 +934,7 @@ static void _call_f_intersects_c1862 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<bool > ((bool)((QPainterPath *)cls)->intersects (arg1));
 }
 
@@ -953,7 +953,7 @@ static void _call_f_intersects_c2514 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<bool > ((bool)((QPainterPath *)cls)->intersects (arg1));
 }
 
@@ -1002,7 +1002,7 @@ static void _call_f_lineTo_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->lineTo (arg1);
 }
@@ -1024,8 +1024,8 @@ static void _call_f_lineTo_2034 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->lineTo (arg1, arg2);
 }
@@ -1045,7 +1045,7 @@ static void _call_f_moveTo_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->moveTo (arg1);
 }
@@ -1067,8 +1067,8 @@ static void _call_f_moveTo_2034 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->moveTo (arg1, arg2);
 }
@@ -1088,7 +1088,7 @@ static void _call_f_operator_excl__eq__c2514 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<bool > ((bool)((QPainterPath *)cls)->operator!= (arg1));
 }
 
@@ -1107,7 +1107,7 @@ static void _call_f_operator_amp__c2514 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->operator& (arg1));
 }
 
@@ -1126,7 +1126,7 @@ static void _call_f_operator_amp__eq__2514 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath & > ((QPainterPath &)((QPainterPath *)cls)->operator&= (arg1));
 }
 
@@ -1145,7 +1145,7 @@ static void _call_f_operator_plus__c2514 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->operator+ (arg1));
 }
 
@@ -1164,7 +1164,7 @@ static void _call_f_operator_plus__eq__2514 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath & > ((QPainterPath &)((QPainterPath *)cls)->operator+= (arg1));
 }
 
@@ -1183,7 +1183,7 @@ static void _call_f_operator_minus__c2514 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->operator- (arg1));
 }
 
@@ -1202,7 +1202,7 @@ static void _call_f_operator_minus__eq__2514 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath & > ((QPainterPath &)((QPainterPath *)cls)->operator-= (arg1));
 }
 
@@ -1221,7 +1221,7 @@ static void _call_f_operator_eq__2514 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath & > ((QPainterPath &)((QPainterPath *)cls)->operator= (arg1));
 }
 
@@ -1240,7 +1240,7 @@ static void _call_f_operator_eq__eq__c2514 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<bool > ((bool)((QPainterPath *)cls)->operator== (arg1));
 }
 
@@ -1259,7 +1259,7 @@ static void _call_f_operator_pipe__c2514 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->operator| (arg1));
 }
 
@@ -1278,7 +1278,7 @@ static void _call_f_operator_pipe__eq__2514 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath & > ((QPainterPath &)((QPainterPath *)cls)->operator|= (arg1));
 }
 
@@ -1297,7 +1297,7 @@ static void _call_f_percentAtLength_c1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QPainterPath *)cls)->percentAtLength (arg1));
 }
 
@@ -1316,7 +1316,7 @@ static void _call_f_pointAtPercent_c1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPointF > ((QPointF)((QPainterPath *)cls)->pointAtPercent (arg1));
 }
 
@@ -1337,8 +1337,8 @@ static void _call_f_quadTo_3864 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->quadTo (arg1, arg2);
 }
@@ -1364,10 +1364,10 @@ static void _call_f_quadTo_3960 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->quadTo (arg1, arg2, arg3, arg4);
 }
@@ -1391,9 +1391,9 @@ static void _call_f_setElementPositionAt_2693 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->setElementPositionAt (arg1, arg2, arg3);
 }
@@ -1413,7 +1413,7 @@ static void _call_f_setFillRule_1548 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::FillRule>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::FillRule>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::FillRule>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->setFillRule (qt_gsi::QtToCppAdaptor<Qt::FillRule>(arg1).cref());
 }
@@ -1448,7 +1448,7 @@ static void _call_f_slopeAtPercent_c1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QPainterPath *)cls)->slopeAtPercent (arg1));
 }
 
@@ -1467,7 +1467,7 @@ static void _call_f_subtracted_c2514 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->subtracted (arg1));
 }
 
@@ -1486,7 +1486,7 @@ static void _call_f_subtractedInverted_c2514 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->subtractedInverted (arg1));
 }
 
@@ -1505,7 +1505,7 @@ static void _call_f_toFillPolygon_c2023 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args ? args.read<const QMatrix & > (heap) : (const QMatrix &)(QMatrix());
+  const QMatrix &arg1 = args ? gsi::arg_reader<const QMatrix & >() (args, heap) : gsi::arg_maker<const QMatrix & >() (QMatrix(), heap);
   ret.write<QPolygonF > ((QPolygonF)((QPainterPath *)cls)->toFillPolygon (arg1));
 }
 
@@ -1524,7 +1524,7 @@ static void _call_f_toFillPolygon_c2350 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QPainterPath *)cls)->toFillPolygon (arg1));
 }
 
@@ -1543,7 +1543,7 @@ static void _call_f_toFillPolygons_c2023 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args ? args.read<const QMatrix & > (heap) : (const QMatrix &)(QMatrix());
+  const QMatrix &arg1 = args ? gsi::arg_reader<const QMatrix & >() (args, heap) : gsi::arg_maker<const QMatrix & >() (QMatrix(), heap);
   ret.write<QList<QPolygonF> > ((QList<QPolygonF>)((QPainterPath *)cls)->toFillPolygons (arg1));
 }
 
@@ -1562,7 +1562,7 @@ static void _call_f_toFillPolygons_c2350 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QList<QPolygonF> > ((QList<QPolygonF>)((QPainterPath *)cls)->toFillPolygons (arg1));
 }
 
@@ -1596,7 +1596,7 @@ static void _call_f_toSubpathPolygons_c2023 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args ? args.read<const QMatrix & > (heap) : (const QMatrix &)(QMatrix());
+  const QMatrix &arg1 = args ? gsi::arg_reader<const QMatrix & >() (args, heap) : gsi::arg_maker<const QMatrix & >() (QMatrix(), heap);
   ret.write<QList<QPolygonF> > ((QList<QPolygonF>)((QPainterPath *)cls)->toSubpathPolygons (arg1));
 }
 
@@ -1615,7 +1615,7 @@ static void _call_f_toSubpathPolygons_c2350 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QList<QPolygonF> > ((QList<QPolygonF>)((QPainterPath *)cls)->toSubpathPolygons (arg1));
 }
 
@@ -1636,8 +1636,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->translate (arg1, arg2);
 }
@@ -1657,7 +1657,7 @@ static void _call_f_translate_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPath *)cls)->translate (arg1);
 }
@@ -1679,8 +1679,8 @@ static void _call_f_translated_c2034 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->translated (arg1, arg2));
 }
 
@@ -1699,7 +1699,7 @@ static void _call_f_translated_c1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->translated (arg1));
 }
 
@@ -1718,7 +1718,7 @@ static void _call_f_united_c2514 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPath *)cls)->united (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPainterPathStroker.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPainterPathStroker.cc
@@ -81,7 +81,7 @@ static void _call_f_createStroke_c2514 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QPainterPathStroker *)cls)->createStroke (arg1));
 }
 
@@ -175,7 +175,7 @@ static void _call_f_setCapStyle_1845 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::PenCapStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::PenCapStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::PenCapStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::PenCapStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPathStroker *)cls)->setCapStyle (qt_gsi::QtToCppAdaptor<Qt::PenCapStyle>(arg1).cref());
 }
@@ -195,7 +195,7 @@ static void _call_f_setCurveThreshold_1071 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPathStroker *)cls)->setCurveThreshold (arg1);
 }
@@ -215,7 +215,7 @@ static void _call_f_setDashOffset_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPathStroker *)cls)->setDashOffset (arg1);
 }
@@ -235,7 +235,7 @@ static void _call_f_setDashPattern_1569 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::PenStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::PenStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPathStroker *)cls)->setDashPattern (qt_gsi::QtToCppAdaptor<Qt::PenStyle>(arg1).cref());
 }
@@ -255,7 +255,7 @@ static void _call_f_setDashPattern_2676 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<qreal> &arg1 = args.read<const QVector<qreal> & > (heap);
+  const QVector<qreal> &arg1 = gsi::arg_reader<const QVector<qreal> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPathStroker *)cls)->setDashPattern (arg1);
 }
@@ -275,7 +275,7 @@ static void _call_f_setJoinStyle_1969 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPathStroker *)cls)->setJoinStyle (qt_gsi::QtToCppAdaptor<Qt::PenJoinStyle>(arg1).cref());
 }
@@ -295,7 +295,7 @@ static void _call_f_setMiterLimit_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPathStroker *)cls)->setMiterLimit (arg1);
 }
@@ -315,7 +315,7 @@ static void _call_f_setWidth_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPainterPathStroker *)cls)->setWidth (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPainterPath_Element.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPainterPath_Element.cc
@@ -110,7 +110,7 @@ static void _call_f_operator_excl__eq__c3344 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath::Element &arg1 = args.read<const QPainterPath::Element & > (heap);
+  const QPainterPath::Element &arg1 = gsi::arg_reader<const QPainterPath::Element & >() (args, heap);
   ret.write<bool > ((bool)((QPainterPath::Element *)cls)->operator!= (arg1));
 }
 
@@ -129,7 +129,7 @@ static void _call_f_operator_eq__eq__c3344 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath::Element &arg1 = args.read<const QPainterPath::Element & > (heap);
+  const QPainterPath::Element &arg1 = gsi::arg_reader<const QPainterPath::Element & >() (args, heap);
   ret.write<bool > ((bool)((QPainterPath::Element *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPalette.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPalette.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QPalette_1905 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<QPalette *> (new QPalette (arg1));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QPalette_1853 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GlobalColor>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GlobalColor>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GlobalColor>::target_type & >() (args, heap);
   ret.write<QPalette *> (new QPalette (qt_gsi::QtToCppAdaptor<Qt::GlobalColor>(arg1).cref()));
 }
 
@@ -107,8 +107,8 @@ static void _call_ctor_QPalette_3702 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
-  const QColor &arg2 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
+  const QColor &arg2 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<QPalette *> (new QPalette (arg1, arg2));
 }
 
@@ -143,15 +143,15 @@ static void _call_ctor_QPalette_16326 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
-  const QBrush &arg2 = args.read<const QBrush & > (heap);
-  const QBrush &arg3 = args.read<const QBrush & > (heap);
-  const QBrush &arg4 = args.read<const QBrush & > (heap);
-  const QBrush &arg5 = args.read<const QBrush & > (heap);
-  const QBrush &arg6 = args.read<const QBrush & > (heap);
-  const QBrush &arg7 = args.read<const QBrush & > (heap);
-  const QBrush &arg8 = args.read<const QBrush & > (heap);
-  const QBrush &arg9 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg2 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg3 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg4 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg5 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg6 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg7 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg8 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg9 = gsi::arg_reader<const QBrush & >() (args, heap);
   ret.write<QPalette *> (new QPalette (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
 }
 
@@ -182,13 +182,13 @@ static void _call_ctor_QPalette_12687 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
-  const QColor &arg2 = args.read<const QColor & > (heap);
-  const QColor &arg3 = args.read<const QColor & > (heap);
-  const QColor &arg4 = args.read<const QColor & > (heap);
-  const QColor &arg5 = args.read<const QColor & > (heap);
-  const QColor &arg6 = args.read<const QColor & > (heap);
-  const QColor &arg7 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
+  const QColor &arg2 = gsi::arg_reader<const QColor & >() (args, heap);
+  const QColor &arg3 = gsi::arg_reader<const QColor & >() (args, heap);
+  const QColor &arg4 = gsi::arg_reader<const QColor & >() (args, heap);
+  const QColor &arg5 = gsi::arg_reader<const QColor & >() (args, heap);
+  const QColor &arg6 = gsi::arg_reader<const QColor & >() (args, heap);
+  const QColor &arg7 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<QPalette *> (new QPalette (arg1, arg2, arg3, arg4, arg5, arg6, arg7));
 }
 
@@ -207,7 +207,7 @@ static void _call_ctor_QPalette_2113 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   ret.write<QPalette *> (new QPalette (arg1));
 }
 
@@ -288,8 +288,8 @@ static void _call_f_brush_c4545 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & > (heap);
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
+  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
   ret.write<const QBrush & > ((const QBrush &)((QPalette *)cls)->brush (qt_gsi::QtToCppAdaptor<QPalette::ColorGroup>(arg1).cref(), qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg2).cref()));
 }
 
@@ -308,7 +308,7 @@ static void _call_f_brush_c2265 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
   ret.write<const QBrush & > ((const QBrush &)((QPalette *)cls)->brush (qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg1).cref()));
 }
 
@@ -374,8 +374,8 @@ static void _call_f_color_c4545 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & > (heap);
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
+  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
   ret.write<const QColor & > ((const QColor &)((QPalette *)cls)->color (qt_gsi::QtToCppAdaptor<QPalette::ColorGroup>(arg1).cref(), qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg2).cref()));
 }
 
@@ -394,7 +394,7 @@ static void _call_f_color_c2265 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
   ret.write<const QColor & > ((const QColor &)((QPalette *)cls)->color (qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg1).cref()));
 }
 
@@ -490,8 +490,8 @@ static void _call_f_isBrushSet_c4545 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & > (heap);
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
+  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QPalette *)cls)->isBrushSet (qt_gsi::QtToCppAdaptor<QPalette::ColorGroup>(arg1).cref(), qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg2).cref()));
 }
 
@@ -510,7 +510,7 @@ static void _call_f_isCopyOf_c2113 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   ret.write<bool > ((bool)((QPalette *)cls)->isCopyOf (arg1));
 }
 
@@ -531,8 +531,8 @@ static void _call_f_isEqual_c4668 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & > (heap);
-  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg2 = args.read<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & > (heap);
+  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QPalette *)cls)->isEqual (qt_gsi::QtToCppAdaptor<QPalette::ColorGroup>(arg1).cref(), qt_gsi::QtToCppAdaptor<QPalette::ColorGroup>(arg2).cref()));
 }
 
@@ -626,7 +626,7 @@ static void _call_f_operator_excl__eq__c2113 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   ret.write<bool > ((bool)((QPalette *)cls)->operator!= (arg1));
 }
 
@@ -645,7 +645,7 @@ static void _call_f_operator_eq__2113 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   ret.write<QPalette & > ((QPalette &)((QPalette *)cls)->operator= (arg1));
 }
 
@@ -664,7 +664,7 @@ static void _call_f_operator_eq__eq__c2113 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   ret.write<bool > ((bool)((QPalette *)cls)->operator== (arg1));
 }
 
@@ -683,7 +683,7 @@ static void _call_f_resolve_c2113 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   ret.write<QPalette > ((QPalette)((QPalette *)cls)->resolve (arg1));
 }
 
@@ -719,8 +719,8 @@ static void _call_f_setBrush_4067 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
-  const QBrush &arg2 = args.read<const QBrush & > (heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
+  const QBrush &arg2 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPalette *)cls)->setBrush (qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg1).cref(), arg2);
 }
@@ -744,9 +744,9 @@ static void _call_f_setBrush_6347 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & > (heap);
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
-  const QBrush &arg3 = args.read<const QBrush & > (heap);
+  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
+  const QBrush &arg3 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPalette *)cls)->setBrush (qt_gsi::QtToCppAdaptor<QPalette::ColorGroup>(arg1).cref(), qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg2).cref(), arg3);
 }
@@ -770,9 +770,9 @@ static void _call_f_setColor_6342 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & > (heap);
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
-  const QColor &arg3 = args.read<const QColor & > (heap);
+  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
+  const QColor &arg3 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPalette *)cls)->setColor (qt_gsi::QtToCppAdaptor<QPalette::ColorGroup>(arg1).cref(), qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg2).cref(), arg3);
 }
@@ -794,8 +794,8 @@ static void _call_f_setColor_4062 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
-  const QColor &arg2 = args.read<const QColor & > (heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
+  const QColor &arg2 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPalette *)cls)->setColor (qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg1).cref(), arg2);
 }
@@ -833,16 +833,16 @@ static void _call_f_setColorGroup_18606 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & > (heap);
-  const QBrush &arg2 = args.read<const QBrush & > (heap);
-  const QBrush &arg3 = args.read<const QBrush & > (heap);
-  const QBrush &arg4 = args.read<const QBrush & > (heap);
-  const QBrush &arg5 = args.read<const QBrush & > (heap);
-  const QBrush &arg6 = args.read<const QBrush & > (heap);
-  const QBrush &arg7 = args.read<const QBrush & > (heap);
-  const QBrush &arg8 = args.read<const QBrush & > (heap);
-  const QBrush &arg9 = args.read<const QBrush & > (heap);
-  const QBrush &arg10 = args.read<const QBrush & > (heap);
+  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & >() (args, heap);
+  const QBrush &arg2 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg3 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg4 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg5 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg6 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg7 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg8 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg9 = gsi::arg_reader<const QBrush & >() (args, heap);
+  const QBrush &arg10 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPalette *)cls)->setColorGroup (qt_gsi::QtToCppAdaptor<QPalette::ColorGroup>(arg1).cref(), arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
 }
@@ -862,7 +862,7 @@ static void _call_f_setCurrentColorGroup_2388 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & > (heap);
+  const qt_gsi::Converter<QPalette::ColorGroup>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorGroup>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPalette *)cls)->setCurrentColorGroup (qt_gsi::QtToCppAdaptor<QPalette::ColorGroup>(arg1).cref());
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPanGesture.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPanGesture.cc
@@ -129,7 +129,7 @@ static void _call_f_setAcceleration_1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPanGesture *)cls)->setAcceleration (arg1);
 }
@@ -149,7 +149,7 @@ static void _call_f_setLastOffset_1986 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPanGesture *)cls)->setLastOffset (arg1);
 }
@@ -169,7 +169,7 @@ static void _call_f_setOffset_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPanGesture *)cls)->setOffset (arg1);
 }
@@ -191,8 +191,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPanGesture::tr (arg1, arg2));
 }
 
@@ -215,9 +215,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPanGesture::tr (arg1, arg2, arg3));
 }
 
@@ -238,8 +238,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPanGesture::trUtf8 (arg1, arg2));
 }
 
@@ -262,9 +262,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPanGesture::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -448,7 +448,7 @@ static void _call_ctor_QPanGesture_Adaptor_1302 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QPanGesture_Adaptor *> (new QPanGesture_Adaptor (arg1));
 }
 
@@ -514,7 +514,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPanGesture_Adaptor *)cls)->emitter_QPanGesture_destroyed_1302 (arg1);
 }
 
@@ -605,7 +605,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPanGesture_Adaptor *)cls)->fp_QPanGesture_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPen.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPen.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QPen_1569 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::PenStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::PenStyle>::target_type & >() (args, heap);
   ret.write<QPen *> (new QPen (qt_gsi::QtToCppAdaptor<Qt::PenStyle>(arg1).cref()));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QPen_1905 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<QPen *> (new QPen (arg1));
 }
 
@@ -113,11 +113,11 @@ static void _call_ctor_QPen_7932 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
-  double arg2 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<Qt::PenStyle>::target_type & > (heap) : (const qt_gsi::Converter<Qt::PenStyle>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::PenStyle>(heap, Qt::SolidLine));
-  const qt_gsi::Converter<Qt::PenCapStyle>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<Qt::PenCapStyle>::target_type & > (heap) : (const qt_gsi::Converter<Qt::PenCapStyle>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::PenCapStyle>(heap, Qt::SquareCap));
-  const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & > (heap) : (const qt_gsi::Converter<Qt::PenJoinStyle>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::PenJoinStyle>(heap, Qt::BevelJoin));
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::PenStyle>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::PenStyle>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::PenStyle>(heap, Qt::SolidLine), heap);
+  const qt_gsi::Converter<Qt::PenCapStyle>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::PenCapStyle>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::PenCapStyle>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::PenCapStyle>(heap, Qt::SquareCap), heap);
+  const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::PenJoinStyle>(heap, Qt::BevelJoin), heap);
   ret.write<QPen *> (new QPen (arg1, arg2, qt_gsi::QtToCppAdaptor<Qt::PenStyle>(arg3).cref(), qt_gsi::QtToCppAdaptor<Qt::PenCapStyle>(arg4).cref(), qt_gsi::QtToCppAdaptor<Qt::PenJoinStyle>(arg5).cref()));
 }
 
@@ -136,7 +136,7 @@ static void _call_ctor_QPen_1685 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPen &arg1 = args.read<const QPen & > (heap);
+  const QPen &arg1 = gsi::arg_reader<const QPen & >() (args, heap);
   ret.write<QPen *> (new QPen (arg1));
 }
 
@@ -305,7 +305,7 @@ static void _call_f_operator_excl__eq__c1685 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPen &arg1 = args.read<const QPen & > (heap);
+  const QPen &arg1 = gsi::arg_reader<const QPen & >() (args, heap);
   ret.write<bool > ((bool)((QPen *)cls)->operator!= (arg1));
 }
 
@@ -324,7 +324,7 @@ static void _call_f_operator_eq__1685 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPen &arg1 = args.read<const QPen & > (heap);
+  const QPen &arg1 = gsi::arg_reader<const QPen & >() (args, heap);
   ret.write<QPen & > ((QPen &)((QPen *)cls)->operator= (arg1));
 }
 
@@ -343,7 +343,7 @@ static void _call_f_operator_eq__eq__c1685 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPen &arg1 = args.read<const QPen & > (heap);
+  const QPen &arg1 = gsi::arg_reader<const QPen & >() (args, heap);
   ret.write<bool > ((bool)((QPen *)cls)->operator== (arg1));
 }
 
@@ -362,7 +362,7 @@ static void _call_f_setBrush_1910 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setBrush (arg1);
 }
@@ -382,7 +382,7 @@ static void _call_f_setCapStyle_1845 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::PenCapStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::PenCapStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::PenCapStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::PenCapStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setCapStyle (qt_gsi::QtToCppAdaptor<Qt::PenCapStyle>(arg1).cref());
 }
@@ -402,7 +402,7 @@ static void _call_f_setColor_1905 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setColor (arg1);
 }
@@ -422,7 +422,7 @@ static void _call_f_setCosmetic_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setCosmetic (arg1);
 }
@@ -442,7 +442,7 @@ static void _call_f_setDashOffset_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setDashOffset (arg1);
 }
@@ -462,7 +462,7 @@ static void _call_f_setDashPattern_2676 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<qreal> &arg1 = args.read<const QVector<qreal> & > (heap);
+  const QVector<qreal> &arg1 = gsi::arg_reader<const QVector<qreal> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setDashPattern (arg1);
 }
@@ -482,7 +482,7 @@ static void _call_f_setJoinStyle_1969 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::PenJoinStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setJoinStyle (qt_gsi::QtToCppAdaptor<Qt::PenJoinStyle>(arg1).cref());
 }
@@ -502,7 +502,7 @@ static void _call_f_setMiterLimit_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setMiterLimit (arg1);
 }
@@ -522,7 +522,7 @@ static void _call_f_setStyle_1569u1 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::PenStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::PenStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setStyle (qt_gsi::QtToCppAdaptor<Qt::PenStyle>(arg1).cref());
 }
@@ -542,7 +542,7 @@ static void _call_f_setWidth_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setWidth (arg1);
 }
@@ -562,7 +562,7 @@ static void _call_f_setWidthF_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPen *)cls)->setWidthF (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPicture.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPicture.cc
@@ -132,8 +132,8 @@ static void _call_f_load_3070 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<bool > ((bool)((QPicture *)cls)->load (arg1, arg2));
 }
 
@@ -154,8 +154,8 @@ static void _call_f_load_3648 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<bool > ((bool)((QPicture *)cls)->load (arg1, arg2));
 }
 
@@ -174,7 +174,7 @@ static void _call_f_operator_eq__2126 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPicture &arg1 = args.read<const QPicture & > (heap);
+  const QPicture &arg1 = gsi::arg_reader<const QPicture & >() (args, heap);
   ret.write<QPicture & > ((QPicture &)((QPicture *)cls)->operator= (arg1));
 }
 
@@ -208,7 +208,7 @@ static void _call_f_play_1426 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   ret.write<bool > ((bool)((QPicture *)cls)->play (arg1));
 }
 
@@ -229,8 +229,8 @@ static void _call_f_save_3070 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<bool > ((bool)((QPicture *)cls)->save (arg1, arg2));
 }
 
@@ -251,8 +251,8 @@ static void _call_f_save_3648 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<bool > ((bool)((QPicture *)cls)->save (arg1, arg2));
 }
 
@@ -271,7 +271,7 @@ static void _call_f_setBoundingRect_1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPicture *)cls)->setBoundingRect (arg1);
 }
@@ -293,8 +293,8 @@ static void _call_f_setData_3395 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  unsigned int arg2 = args.read<unsigned int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  unsigned int arg2 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPicture *)cls)->setData (arg1, arg2);
 }
@@ -389,7 +389,7 @@ static void _call_f_pictureFormat_2025 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<const char * > ((const char *)QPicture::pictureFormat (arg1));
 }
 
@@ -522,7 +522,7 @@ static void _call_ctor_QPicture_Adaptor_767 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(-1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QPicture_Adaptor *> (new QPicture_Adaptor (arg1));
 }
 
@@ -540,7 +540,7 @@ static void _call_ctor_QPicture_Adaptor_2126 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPicture &arg1 = args.read<const QPicture & > (heap);
+  const QPicture &arg1 = gsi::arg_reader<const QPicture & >() (args, heap);
   ret.write<QPicture_Adaptor *> (new QPicture_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPinchGesture.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPinchGesture.cc
@@ -174,7 +174,7 @@ static void _call_f_setCenterPoint_1986 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setCenterPoint (arg1);
 }
@@ -194,7 +194,7 @@ static void _call_f_setChangeFlags_3522 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPinchGesture::ChangeFlag> arg1 = args.read<QFlags<QPinchGesture::ChangeFlag> > (heap);
+  QFlags<QPinchGesture::ChangeFlag> arg1 = gsi::arg_reader<QFlags<QPinchGesture::ChangeFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setChangeFlags (arg1);
 }
@@ -214,7 +214,7 @@ static void _call_f_setLastCenterPoint_1986 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setLastCenterPoint (arg1);
 }
@@ -234,7 +234,7 @@ static void _call_f_setLastRotationAngle_1071 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setLastRotationAngle (arg1);
 }
@@ -254,7 +254,7 @@ static void _call_f_setLastScaleFactor_1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setLastScaleFactor (arg1);
 }
@@ -274,7 +274,7 @@ static void _call_f_setRotationAngle_1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setRotationAngle (arg1);
 }
@@ -294,7 +294,7 @@ static void _call_f_setScaleFactor_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setScaleFactor (arg1);
 }
@@ -314,7 +314,7 @@ static void _call_f_setStartCenterPoint_1986 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setStartCenterPoint (arg1);
 }
@@ -334,7 +334,7 @@ static void _call_f_setTotalChangeFlags_3522 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QPinchGesture::ChangeFlag> arg1 = args.read<QFlags<QPinchGesture::ChangeFlag> > (heap);
+  QFlags<QPinchGesture::ChangeFlag> arg1 = gsi::arg_reader<QFlags<QPinchGesture::ChangeFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setTotalChangeFlags (arg1);
 }
@@ -354,7 +354,7 @@ static void _call_f_setTotalRotationAngle_1071 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setTotalRotationAngle (arg1);
 }
@@ -374,7 +374,7 @@ static void _call_f_setTotalScaleFactor_1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPinchGesture *)cls)->setTotalScaleFactor (arg1);
 }
@@ -456,8 +456,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPinchGesture::tr (arg1, arg2));
 }
 
@@ -480,9 +480,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPinchGesture::tr (arg1, arg2, arg3));
 }
 
@@ -503,8 +503,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPinchGesture::trUtf8 (arg1, arg2));
 }
 
@@ -527,9 +527,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPinchGesture::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -728,7 +728,7 @@ static void _call_ctor_QPinchGesture_Adaptor_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QPinchGesture_Adaptor *> (new QPinchGesture_Adaptor (arg1));
 }
 
@@ -794,7 +794,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPinchGesture_Adaptor *)cls)->emitter_QPinchGesture_destroyed_1302 (arg1);
 }
 
@@ -885,7 +885,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPinchGesture_Adaptor *)cls)->fp_QPinchGesture_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPixmap.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPixmap.cc
@@ -98,10 +98,10 @@ static void _call_f_copy_c2744 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPixmap > ((QPixmap)((QPixmap *)cls)->copy (arg1, arg2, arg3, arg4));
 }
 
@@ -120,7 +120,7 @@ static void _call_f_copy_c1792 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args ? args.read<const QRect & > (heap) : (const QRect &)(QRect());
+  const QRect &arg1 = args ? gsi::arg_reader<const QRect & >() (args, heap) : gsi::arg_maker<const QRect & >() (QRect(), heap);
   ret.write<QPixmap > ((QPixmap)((QPixmap *)cls)->copy (arg1));
 }
 
@@ -139,7 +139,7 @@ static void _call_f_createHeuristicMask_c864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   ret.write<QBitmap > ((QBitmap)((QPixmap *)cls)->createHeuristicMask (arg1));
 }
 
@@ -158,7 +158,7 @@ static void _call_f_createMaskFromColor_c1905 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   ret.write<QBitmap > ((QBitmap)((QPixmap *)cls)->createMaskFromColor (arg1));
 }
 
@@ -179,8 +179,8 @@ static void _call_f_createMaskFromColor_c3331 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
-  const qt_gsi::Converter<Qt::MaskMode>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::MaskMode>::target_type & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
+  const qt_gsi::Converter<Qt::MaskMode>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::MaskMode>::target_type & >() (args, heap);
   ret.write<QBitmap > ((QBitmap)((QPixmap *)cls)->createMaskFromColor (arg1, qt_gsi::QtToCppAdaptor<Qt::MaskMode>(arg2).cref()));
 }
 
@@ -230,7 +230,7 @@ static void _call_f_fill_1905 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args ? args.read<const QColor & > (heap) : (const QColor &)(Qt::white);
+  const QColor &arg1 = args ? gsi::arg_reader<const QColor & >() (args, heap) : gsi::arg_maker<const QColor & >() (Qt::white, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPixmap *)cls)->fill (arg1);
 }
@@ -252,8 +252,8 @@ static void _call_f_fill_3818 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPixmap *)cls)->fill (arg1, arg2);
 }
@@ -277,9 +277,9 @@ static void _call_f_fill_3328 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPixmap *)cls)->fill (arg1, arg2, arg3);
 }
@@ -393,9 +393,9 @@ static void _call_f_load_6908 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
-  QFlags<Qt::ImageConversionFlag> arg3 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  QFlags<Qt::ImageConversionFlag> arg3 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   ret.write<bool > ((bool)((QPixmap *)cls)->load (arg1, arg2, arg3));
 }
 
@@ -420,10 +420,10 @@ static void _call_f_loadFromData_9283 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const unsigned char *arg1 = args.read<const unsigned char * > (heap);
-  unsigned int arg2 = args.read<unsigned int > (heap);
-  const char *arg3 = args ? args.read<const char * > (heap) : (const char *)(0);
-  QFlags<Qt::ImageConversionFlag> arg4 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const unsigned char *arg1 = gsi::arg_reader<const unsigned char * >() (args, heap);
+  unsigned int arg2 = gsi::arg_reader<unsigned int >() (args, heap);
+  const char *arg3 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  QFlags<Qt::ImageConversionFlag> arg4 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   ret.write<bool > ((bool)((QPixmap *)cls)->loadFromData (arg1, arg2, arg3, arg4));
 }
 
@@ -446,9 +446,9 @@ static void _call_f_loadFromData_7192 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
-  QFlags<Qt::ImageConversionFlag> arg3 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  QFlags<Qt::ImageConversionFlag> arg3 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   ret.write<bool > ((bool)((QPixmap *)cls)->loadFromData (arg1, arg2, arg3));
 }
 
@@ -497,7 +497,7 @@ static void _call_f_operator_eq__2017 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QPixmap & > ((QPixmap &)((QPixmap *)cls)->operator= (arg1));
 }
 
@@ -550,9 +550,9 @@ static void _call_f_save_c4307 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(-1);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<bool > ((bool)((QPixmap *)cls)->save (arg1, arg2, arg3));
 }
 
@@ -575,9 +575,9 @@ static void _call_f_save_c3729 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(-1);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<bool > ((bool)((QPixmap *)cls)->save (arg1, arg2, arg3));
 }
 
@@ -602,10 +602,10 @@ static void _call_f_scaled_c6100 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::AspectRatioMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio));
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio), heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QPixmap > ((QPixmap)((QPixmap *)cls)->scaled (arg1, arg2, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg3).cref(), qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg4).cref()));
 }
 
@@ -628,9 +628,9 @@ static void _call_f_scaled_c6479 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::AspectRatioMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio));
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::AspectRatioMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::AspectRatioMode>(heap, Qt::IgnoreAspectRatio), heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QPixmap > ((QPixmap)((QPixmap *)cls)->scaled (arg1, qt_gsi::QtToCppAdaptor<Qt::AspectRatioMode>(arg2).cref(), qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg3).cref()));
 }
 
@@ -651,8 +651,8 @@ static void _call_f_scaledToHeight_c3292 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QPixmap > ((QPixmap)((QPixmap *)cls)->scaledToHeight (arg1, qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg2).cref()));
 }
 
@@ -673,8 +673,8 @@ static void _call_f_scaledToWidth_c3292 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QPixmap > ((QPixmap)((QPixmap *)cls)->scaledToWidth (arg1, qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg2).cref()));
 }
 
@@ -705,13 +705,13 @@ static void _call_f_scroll_5269 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  int arg5 = args.read<int > (heap);
-  int arg6 = args.read<int > (heap);
-  QRegion *arg7 = args ? args.read<QRegion * > (heap) : (QRegion *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
+  int arg6 = gsi::arg_reader<int >() (args, heap);
+  QRegion *arg7 = args ? gsi::arg_reader<QRegion * >() (args, heap) : gsi::arg_maker<QRegion * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPixmap *)cls)->scroll (arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 }
@@ -737,10 +737,10 @@ static void _call_f_scroll_4317 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QRect &arg3 = args.read<const QRect & > (heap);
-  QRegion *arg4 = args ? args.read<QRegion * > (heap) : (QRegion *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QRect &arg3 = gsi::arg_reader<const QRect & >() (args, heap);
+  QRegion *arg4 = args ? gsi::arg_reader<QRegion * >() (args, heap) : gsi::arg_maker<QRegion * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPixmap *)cls)->scroll (arg1, arg2, arg3, arg4);
 }
@@ -775,7 +775,7 @@ static void _call_f_setAlphaChannel_2017 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPixmap *)cls)->setAlphaChannel (arg1);
 }
@@ -795,7 +795,7 @@ static void _call_f_setMask_1999 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBitmap &arg1 = args.read<const QBitmap & > (heap);
+  const QBitmap &arg1 = gsi::arg_reader<const QBitmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPixmap *)cls)->setMask (arg1);
 }
@@ -847,8 +847,8 @@ static void _call_f_transformed_c4548 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QPixmap > ((QPixmap)((QPixmap *)cls)->transformed (arg1, qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg2).cref()));
 }
 
@@ -869,8 +869,8 @@ static void _call_f_transformed_c4875 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
-  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::TransformationMode>::target_type & > (heap) : (const qt_gsi::Converter<Qt::TransformationMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation));
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
+  const qt_gsi::Converter<Qt::TransformationMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::TransformationMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::TransformationMode>(heap, Qt::FastTransformation), heap);
   ret.write<QPixmap > ((QPixmap)((QPixmap *)cls)->transformed (arg1, qt_gsi::QtToCppAdaptor<Qt::TransformationMode>(arg2).cref()));
 }
 
@@ -921,8 +921,8 @@ static void _call_f_fromImage_5137 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
-  QFlags<Qt::ImageConversionFlag> arg2 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
+  QFlags<Qt::ImageConversionFlag> arg2 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   ret.write<QPixmap > ((QPixmap)QPixmap::fromImage (arg1, arg2));
 }
 
@@ -943,8 +943,8 @@ static void _call_f_grabWidget_2999 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QPixmap > ((QPixmap)QPixmap::grabWidget (arg1, arg2));
 }
 
@@ -971,11 +971,11 @@ static void _call_f_grabWidget_3951 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
-  int arg4 = args ? args.read<int > (heap) : (int)(-1);
-  int arg5 = args ? args.read<int > (heap) : (int)(-1);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QPixmap > ((QPixmap)QPixmap::grabWidget (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1002,11 +1002,11 @@ static void _call_f_grabWindow_3332 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args.read<const qt_gsi::Converter<WId>::target_type & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
-  int arg4 = args ? args.read<int > (heap) : (int)(-1);
-  int arg5 = args ? args.read<int > (heap) : (int)(-1);
+  const qt_gsi::Converter<WId>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QPixmap > ((QPixmap)QPixmap::grabWindow (qt_gsi::QtToCppAdaptor<WId>(arg1).cref(), arg2, arg3, arg4, arg5));
 }
 
@@ -1029,9 +1029,9 @@ static void _call_f_trueMatrix_3341 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QMatrix > ((QMatrix)QPixmap::trueMatrix (arg1, arg2, arg3));
 }
 
@@ -1054,9 +1054,9 @@ static void _call_f_trueMatrix_3668 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTransform > ((QTransform)QPixmap::trueMatrix (arg1, arg2, arg3));
 }
 
@@ -1242,8 +1242,8 @@ static void _call_ctor_QPixmap_Adaptor_1426 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPixmap_Adaptor *> (new QPixmap_Adaptor (arg1, arg2));
 }
 
@@ -1261,7 +1261,7 @@ static void _call_ctor_QPixmap_Adaptor_1805 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QPixmap_Adaptor *> (new QPixmap_Adaptor (arg1));
 }
 
@@ -1283,9 +1283,9 @@ static void _call_ctor_QPixmap_Adaptor_6908 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
-  QFlags<Qt::ImageConversionFlag> arg3 = args ? args.read<QFlags<Qt::ImageConversionFlag> > (heap) : (QFlags<Qt::ImageConversionFlag>)(Qt::AutoColor);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  QFlags<Qt::ImageConversionFlag> arg3 = args ? gsi::arg_reader<QFlags<Qt::ImageConversionFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::ImageConversionFlag> >() (Qt::AutoColor, heap);
   ret.write<QPixmap_Adaptor *> (new QPixmap_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1303,7 +1303,7 @@ static void _call_ctor_QPixmap_Adaptor_2017 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QPixmap_Adaptor *> (new QPixmap_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPixmapCache.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPixmapCache.cc
@@ -97,7 +97,7 @@ static void _call_f_find_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QPixmap * > ((QPixmap *)QPixmapCache::find (arg1));
 }
 
@@ -118,8 +118,8 @@ static void _call_f_find_3239 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QPixmap &arg2 = args.read<QPixmap & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QPixmap &arg2 = gsi::arg_reader<QPixmap & >() (args, heap);
   ret.write<bool > ((bool)QPixmapCache::find (arg1, arg2));
 }
 
@@ -140,8 +140,8 @@ static void _call_f_find_3243 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QPixmap *arg2 = args.read<QPixmap * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QPixmap *arg2 = gsi::arg_reader<QPixmap * >() (args, heap);
   ret.write<bool > ((bool)QPixmapCache::find (arg1, arg2));
 }
 
@@ -162,8 +162,8 @@ static void _call_f_insert_3934 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<bool > ((bool)QPixmapCache::insert (arg1, arg2));
 }
 
@@ -182,7 +182,7 @@ static void _call_f_remove_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QPixmapCache::remove (arg1);
 }
@@ -202,7 +202,7 @@ static void _call_f_setCacheLimit_767 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QPixmapCache::setCacheLimit (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPlainTextDocumentLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPlainTextDocumentLayout.cc
@@ -80,7 +80,7 @@ static void _call_f_blockBoundingRect_c2306 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QPlainTextDocumentLayout *)cls)->blockBoundingRect (arg1));
 }
 
@@ -131,8 +131,8 @@ static void _call_f_draw_6787 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QAbstractTextDocumentLayout::PaintContext &arg2 = args.read<const QAbstractTextDocumentLayout::PaintContext & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QAbstractTextDocumentLayout::PaintContext &arg2 = gsi::arg_reader<const QAbstractTextDocumentLayout::PaintContext & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextDocumentLayout *)cls)->draw (arg1, arg2);
 }
@@ -152,7 +152,7 @@ static void _call_f_ensureBlockLayout_c2306 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextDocumentLayout *)cls)->ensureBlockLayout (arg1);
 }
@@ -172,7 +172,7 @@ static void _call_f_frameBoundingRect_c1615 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextFrame *arg1 = args.read<QTextFrame * > (heap);
+  QTextFrame *arg1 = gsi::arg_reader<QTextFrame * >() (args, heap);
   ret.write<QRectF > ((QRectF)((QPlainTextDocumentLayout *)cls)->frameBoundingRect (arg1));
 }
 
@@ -193,8 +193,8 @@ static void _call_f_hitTest_c4147 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const qt_gsi::Converter<Qt::HitTestAccuracy>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::HitTestAccuracy>::target_type & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const qt_gsi::Converter<Qt::HitTestAccuracy>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::HitTestAccuracy>::target_type & >() (args, heap);
   ret.write<int > ((int)((QPlainTextDocumentLayout *)cls)->hitTest (arg1, qt_gsi::QtToCppAdaptor<Qt::HitTestAccuracy>(arg2).cref()));
 }
 
@@ -244,7 +244,7 @@ static void _call_f_setCursorWidth_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextDocumentLayout *)cls)->setCursorWidth (arg1);
 }
@@ -266,8 +266,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPlainTextDocumentLayout::tr (arg1, arg2));
 }
 
@@ -290,9 +290,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPlainTextDocumentLayout::tr (arg1, arg2, arg3));
 }
 
@@ -313,8 +313,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPlainTextDocumentLayout::trUtf8 (arg1, arg2));
 }
 
@@ -337,9 +337,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPlainTextDocumentLayout::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -718,7 +718,7 @@ static void _call_ctor_QPlainTextDocumentLayout_Adaptor_1955 (const qt_gsi::Gene
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   ret.write<QPlainTextDocumentLayout_Adaptor *> (new QPlainTextDocumentLayout_Adaptor (arg1));
 }
 
@@ -807,7 +807,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPlainTextDocumentLayout_Adaptor *)cls)->emitter_QPlainTextDocumentLayout_destroyed_1302 (arg1);
 }
 
@@ -898,7 +898,7 @@ static void _call_emitter_documentSizeChanged_1875 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   ((QPlainTextDocumentLayout_Adaptor *)cls)->emitter_QPlainTextDocumentLayout_documentSizeChanged_1875 (arg1);
 }
 
@@ -1028,7 +1028,7 @@ static void _call_fp_format_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextCharFormat > ((QTextCharFormat)((QPlainTextDocumentLayout_Adaptor *)cls)->fp_QPlainTextDocumentLayout_format_767 (arg1));
 }
 
@@ -1046,7 +1046,7 @@ static void _call_fp_formatIndex_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QPlainTextDocumentLayout_Adaptor *)cls)->fp_QPlainTextDocumentLayout_formatIndex_767 (arg1));
 }
 
@@ -1132,7 +1132,7 @@ static void _call_emitter_pageCountChanged_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QPlainTextDocumentLayout_Adaptor *)cls)->emitter_QPlainTextDocumentLayout_pageCountChanged_767 (arg1);
 }
 
@@ -1180,7 +1180,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPlainTextDocumentLayout_Adaptor *)cls)->fp_QPlainTextDocumentLayout_receivers_c1731 (arg1));
 }
 
@@ -1266,7 +1266,7 @@ static void _call_emitter_update_1862 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF(0., 0., 1000000000., 1000000000.));
+  const QRectF &arg1 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(0., 0., 1000000000., 1000000000.), heap);
   ((QPlainTextDocumentLayout_Adaptor *)cls)->emitter_QPlainTextDocumentLayout_update_1862 (arg1);
 }
 
@@ -1284,7 +1284,7 @@ static void _call_emitter_updateBlock_2306 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ((QPlainTextDocumentLayout_Adaptor *)cls)->emitter_QPlainTextDocumentLayout_updateBlock_2306 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPlainTextEdit.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPlainTextEdit.cc
@@ -122,7 +122,7 @@ static void _call_f_appendHtml_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->appendHtml (arg1);
 }
@@ -142,7 +142,7 @@ static void _call_f_appendPlainText_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->appendPlainText (arg1);
 }
@@ -300,7 +300,7 @@ static void _call_f_cursorForPosition_c1916 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QTextCursor > ((QTextCursor)((QPlainTextEdit *)cls)->cursorForPosition (arg1));
 }
 
@@ -319,7 +319,7 @@ static void _call_f_cursorRect_c2453 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<QRect > ((QRect)((QPlainTextEdit *)cls)->cursorRect (arg1));
 }
 
@@ -447,8 +447,8 @@ static void _call_f_find_5261 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<QTextDocument::FindFlag> arg2 = args ? args.read<QFlags<QTextDocument::FindFlag> > (heap) : (QFlags<QTextDocument::FindFlag>)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QTextDocument::FindFlag> arg2 = args ? gsi::arg_reader<QFlags<QTextDocument::FindFlag> >() (args, heap) : gsi::arg_maker<QFlags<QTextDocument::FindFlag> >() (0, heap);
   ret.write<bool > ((bool)((QPlainTextEdit *)cls)->find (arg1, arg2));
 }
 
@@ -467,7 +467,7 @@ static void _call_f_insertPlainText_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->insertPlainText (arg1);
 }
@@ -534,8 +534,8 @@ static void _call_f_loadResource_2360 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QUrl &arg2 = args.read<const QUrl & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QUrl &arg2 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QPlainTextEdit *)cls)->loadResource (arg1, arg2));
 }
 
@@ -569,7 +569,7 @@ static void _call_f_mergeCurrentCharFormat_2814 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->mergeCurrentCharFormat (arg1);
 }
@@ -591,8 +591,8 @@ static void _call_f_moveCursor_5424 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & > (heap);
-  const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & > (heap) : (const qt_gsi::Converter<QTextCursor::MoveMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTextCursor::MoveMode>(heap, QTextCursor::MoveAnchor));
+  const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTextCursor::MoveMode>(heap, QTextCursor::MoveAnchor), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->moveCursor (qt_gsi::QtToCppAdaptor<QTextCursor::MoveOperation>(arg1).cref(), qt_gsi::QtToCppAdaptor<QTextCursor::MoveMode>(arg2).cref());
 }
@@ -643,7 +643,7 @@ static void _call_f_print_c1443 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->print (arg1);
 }
@@ -695,7 +695,7 @@ static void _call_f_setBackgroundVisible_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setBackgroundVisible (arg1);
 }
@@ -715,7 +715,7 @@ static void _call_f_setCenterOnScroll_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setCenterOnScroll (arg1);
 }
@@ -735,7 +735,7 @@ static void _call_f_setCurrentCharFormat_2814 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setCurrentCharFormat (arg1);
 }
@@ -755,7 +755,7 @@ static void _call_f_setCursorWidth_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setCursorWidth (arg1);
 }
@@ -775,7 +775,7 @@ static void _call_f_setDocument_1955 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setDocument (arg1);
 }
@@ -795,7 +795,7 @@ static void _call_f_setDocumentTitle_2025 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setDocumentTitle (arg1);
 }
@@ -815,7 +815,7 @@ static void _call_f_setExtraSelections_4386 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QTextEdit::ExtraSelection> &arg1 = args.read<const QList<QTextEdit::ExtraSelection> & > (heap);
+  const QList<QTextEdit::ExtraSelection> &arg1 = gsi::arg_reader<const QList<QTextEdit::ExtraSelection> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setExtraSelections (arg1);
 }
@@ -835,7 +835,7 @@ static void _call_f_setLineWrapMode_3135 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPlainTextEdit::LineWrapMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QPlainTextEdit::LineWrapMode>::target_type & > (heap);
+  const qt_gsi::Converter<QPlainTextEdit::LineWrapMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPlainTextEdit::LineWrapMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setLineWrapMode (qt_gsi::QtToCppAdaptor<QPlainTextEdit::LineWrapMode>(arg1).cref());
 }
@@ -855,7 +855,7 @@ static void _call_f_setMaximumBlockCount_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setMaximumBlockCount (arg1);
 }
@@ -875,7 +875,7 @@ static void _call_f_setOverwriteMode_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setOverwriteMode (arg1);
 }
@@ -895,7 +895,7 @@ static void _call_f_setPlainText_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setPlainText (arg1);
 }
@@ -915,7 +915,7 @@ static void _call_f_setReadOnly_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setReadOnly (arg1);
 }
@@ -935,7 +935,7 @@ static void _call_f_setTabChangesFocus_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setTabChangesFocus (arg1);
 }
@@ -955,7 +955,7 @@ static void _call_f_setTabStopWidth_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setTabStopWidth (arg1);
 }
@@ -975,7 +975,7 @@ static void _call_f_setTextCursor_2453 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setTextCursor (arg1);
 }
@@ -995,7 +995,7 @@ static void _call_f_setTextInteractionFlags_3396 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::TextInteractionFlag> arg1 = args.read<QFlags<Qt::TextInteractionFlag> > (heap);
+  QFlags<Qt::TextInteractionFlag> arg1 = gsi::arg_reader<QFlags<Qt::TextInteractionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setTextInteractionFlags (arg1);
 }
@@ -1015,7 +1015,7 @@ static void _call_f_setUndoRedoEnabled_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setUndoRedoEnabled (arg1);
 }
@@ -1035,7 +1035,7 @@ static void _call_f_setWordWrapMode_2486 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextOption::WrapMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextOption::WrapMode>::target_type & > (heap);
+  const qt_gsi::Converter<QTextOption::WrapMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextOption::WrapMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit *)cls)->setWordWrapMode (qt_gsi::QtToCppAdaptor<QTextOption::WrapMode>(arg1).cref());
 }
@@ -1163,8 +1163,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPlainTextEdit::tr (arg1, arg2));
 }
 
@@ -1187,9 +1187,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPlainTextEdit::tr (arg1, arg2, arg3));
 }
 
@@ -1210,8 +1210,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPlainTextEdit::trUtf8 (arg1, arg2));
 }
 
@@ -1234,9 +1234,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPlainTextEdit::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2365,7 +2365,7 @@ static void _call_ctor_QPlainTextEdit_Adaptor_1315 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QPlainTextEdit_Adaptor *> (new QPlainTextEdit_Adaptor (arg1));
 }
 
@@ -2385,8 +2385,8 @@ static void _call_ctor_QPlainTextEdit_Adaptor_3232 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QPlainTextEdit_Adaptor *> (new QPlainTextEdit_Adaptor (arg1, arg2));
 }
 
@@ -2428,7 +2428,7 @@ static void _call_fp_blockBoundingGeometry_c2306 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QPlainTextEdit_Adaptor *)cls)->fp_QPlainTextEdit_blockBoundingGeometry_c2306 (arg1));
 }
 
@@ -2446,7 +2446,7 @@ static void _call_fp_blockBoundingRect_c2306 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QPlainTextEdit_Adaptor *)cls)->fp_QPlainTextEdit_blockBoundingRect_c2306 (arg1));
 }
 
@@ -2464,7 +2464,7 @@ static void _call_emitter_blockCountChanged_767 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QPlainTextEdit_Adaptor *)cls)->emitter_QPlainTextEdit_blockCountChanged_767 (arg1);
 }
 
@@ -2615,7 +2615,7 @@ static void _call_emitter_copyAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QPlainTextEdit_Adaptor *)cls)->emitter_QPlainTextEdit_copyAvailable_864 (arg1);
 }
 
@@ -2637,9 +2637,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit_Adaptor *)cls)->fp_QPlainTextEdit_create_2208 (arg1, arg2, arg3);
 }
@@ -2691,7 +2691,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QPlainTextEdit_Adaptor *)cls)->emitter_QPlainTextEdit_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2735,8 +2735,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit_Adaptor *)cls)->fp_QPlainTextEdit_destroy_1620 (arg1, arg2);
 }
@@ -2755,7 +2755,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPlainTextEdit_Adaptor *)cls)->emitter_QPlainTextEdit_destroyed_1302 (arg1);
 }
 
@@ -2869,7 +2869,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit_Adaptor *)cls)->fp_QPlainTextEdit_drawFrame_1426 (arg1);
 }
@@ -3438,7 +3438,7 @@ static void _call_emitter_modificationChanged_864 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QPlainTextEdit_Adaptor *)cls)->emitter_QPlainTextEdit_modificationChanged_864 (arg1);
 }
 
@@ -3643,7 +3643,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPlainTextEdit_Adaptor *)cls)->fp_QPlainTextEdit_receivers_c1731 (arg1));
 }
 
@@ -3661,7 +3661,7 @@ static void _call_emitter_redoAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QPlainTextEdit_Adaptor *)cls)->emitter_QPlainTextEdit_redoAvailable_864 (arg1);
 }
 
@@ -3779,10 +3779,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit_Adaptor *)cls)->fp_QPlainTextEdit_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -3801,7 +3801,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit_Adaptor *)cls)->fp_QPlainTextEdit_setViewportMargins_2115 (arg1);
 }
@@ -3844,7 +3844,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlainTextEdit_Adaptor *)cls)->fp_QPlainTextEdit_setupViewport_1315 (arg1);
 }
@@ -3992,7 +3992,7 @@ static void _call_emitter_undoAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QPlainTextEdit_Adaptor *)cls)->emitter_QPlainTextEdit_undoAvailable_864 (arg1);
 }
 
@@ -4027,8 +4027,8 @@ static void _call_emitter_updateRequest_2451 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QPlainTextEdit_Adaptor *)cls)->emitter_QPlainTextEdit_updateRequest_2451 (arg1, arg2);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPlastiqueStyle.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPlastiqueStyle.cc
@@ -88,10 +88,10 @@ static void _call_f_drawComplexControl_c9027 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args.read<const QWidget * > (heap);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = gsi::arg_reader<const QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlastiqueStyle *)cls)->drawComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -117,10 +117,10 @@ static void _call_f_drawControl_c8285 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ControlElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args.read<const QWidget * > (heap);
+  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ControlElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = gsi::arg_reader<const QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlastiqueStyle *)cls)->drawControl (qt_gsi::QtToCppAdaptor<QStyle::ControlElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -146,10 +146,10 @@ static void _call_f_drawPrimitive_c8501 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlastiqueStyle *)cls)->drawPrimitive (qt_gsi::QtToCppAdaptor<QStyle::PrimitiveElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -175,10 +175,10 @@ static void _call_f_hitTestComplexControl_c9517 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<qt_gsi::Converter<QStyle::SubControl>::target_type > ((qt_gsi::Converter<QStyle::SubControl>::target_type)qt_gsi::CppToQtAdaptor<QStyle::SubControl>(((QPlastiqueStyle *)cls)->hitTestComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4)));
 }
 
@@ -201,9 +201,9 @@ static void _call_f_pixelMetric_c6642 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QPlastiqueStyle *)cls)->pixelMetric (qt_gsi::QtToCppAdaptor<QStyle::PixelMetric>(arg1).cref(), arg2, arg3));
 }
 
@@ -222,7 +222,7 @@ static void _call_f_polish_1315 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlastiqueStyle *)cls)->polish (arg1);
 }
@@ -242,7 +242,7 @@ static void _call_f_polish_1843 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlastiqueStyle *)cls)->polish (arg1);
 }
@@ -262,7 +262,7 @@ static void _call_f_polish_1418 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPalette &arg1 = args.read<QPalette & > (heap);
+  QPalette &arg1 = gsi::arg_reader<QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlastiqueStyle *)cls)->polish (arg1);
 }
@@ -288,10 +288,10 @@ static void _call_f_sizeFromContents_c8477 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ContentsType>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QSize &arg3 = args.read<const QSize & > (heap);
-  const QWidget *arg4 = args.read<const QWidget * > (heap);
+  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ContentsType>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QSize &arg3 = gsi::arg_reader<const QSize & >() (args, heap);
+  const QWidget *arg4 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<QSize > ((QSize)((QPlastiqueStyle *)cls)->sizeFromContents (qt_gsi::QtToCppAdaptor<QStyle::ContentsType>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -329,9 +329,9 @@ static void _call_f_standardPixmap_c6956 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QPixmap > ((QPixmap)((QPlastiqueStyle *)cls)->standardPixmap (qt_gsi::QtToCppAdaptor<QStyle::StandardPixmap>(arg1).cref(), arg2, arg3));
 }
 
@@ -356,10 +356,10 @@ static void _call_f_styleHint_c8615 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StyleHint>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
-  QStyleHintReturn *arg4 = args ? args.read<QStyleHintReturn * > (heap) : (QStyleHintReturn *)(0);
+  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StyleHint>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
+  QStyleHintReturn *arg4 = args ? gsi::arg_reader<QStyleHintReturn * >() (args, heap) : gsi::arg_maker<QStyleHintReturn * >() (0, heap);
   ret.write<int > ((int)((QPlastiqueStyle *)cls)->styleHint (qt_gsi::QtToCppAdaptor<QStyle::StyleHint>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -384,10 +384,10 @@ static void _call_f_subControlRect_c9798 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = args.read<const qt_gsi::Converter<QStyle::SubControl>::target_type & > (heap);
-  const QWidget *arg4 = args.read<const QWidget * > (heap);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubControl>::target_type & >() (args, heap);
+  const QWidget *arg4 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<QRect > ((QRect)((QPlastiqueStyle *)cls)->subControlRect (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, qt_gsi::QtToCppAdaptor<QStyle::SubControl>(arg3).cref(), arg4));
 }
 
@@ -410,9 +410,9 @@ static void _call_f_subElementRect_c6528 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::SubElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args.read<const QWidget * > (heap);
+  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<QRect > ((QRect)((QPlastiqueStyle *)cls)->subElementRect (qt_gsi::QtToCppAdaptor<QStyle::SubElement>(arg1).cref(), arg2, arg3));
 }
 
@@ -431,7 +431,7 @@ static void _call_f_unpolish_1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlastiqueStyle *)cls)->unpolish (arg1);
 }
@@ -451,7 +451,7 @@ static void _call_f_unpolish_1843 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPlastiqueStyle *)cls)->unpolish (arg1);
 }
@@ -473,8 +473,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPlastiqueStyle::tr (arg1, arg2));
 }
 
@@ -497,9 +497,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPlastiqueStyle::tr (arg1, arg2, arg3));
 }
 
@@ -520,8 +520,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPlastiqueStyle::trUtf8 (arg1, arg2));
 }
 
@@ -544,9 +544,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPlastiqueStyle::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1141,7 +1141,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPlastiqueStyle_Adaptor *)cls)->emitter_QPlastiqueStyle_destroyed_1302 (arg1);
 }
 
@@ -1539,11 +1539,11 @@ static void _call_fp_layoutSpacingImplementation_c11697 (const qt_gsi::GenericMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QStyleOption *arg4 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg5 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QStyleOption *arg4 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg5 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QPlastiqueStyle_Adaptor *)cls)->fp_QPlastiqueStyle_layoutSpacingImplementation_c11697 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1662,7 +1662,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPlastiqueStyle_Adaptor *)cls)->fp_QPlastiqueStyle_receivers_c1731 (arg1));
 }
 
@@ -1730,9 +1730,9 @@ static void _call_fp_standardIconImplementation_c6956 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QIcon > ((QIcon)((QPlastiqueStyle_Adaptor *)cls)->fp_QPlastiqueStyle_standardIconImplementation_c6956 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPolygon.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPolygon.cc
@@ -174,7 +174,7 @@ static void _call_ctor_QPolygon_767 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPolygon *> (new QPolygon (arg1));
 }
 
@@ -193,7 +193,7 @@ static void _call_ctor_QPolygon_2138 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   ret.write<QPolygon *> (new QPolygon (arg1));
 }
 
@@ -212,7 +212,7 @@ static void _call_ctor_QPolygon_2746 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QPoint> &arg1 = args.read<const QVector<QPoint> & > (heap);
+  const QVector<QPoint> &arg1 = gsi::arg_reader<const QVector<QPoint> & >() (args, heap);
   ret.write<QPolygon *> (new QPolygon (arg1));
 }
 
@@ -233,8 +233,8 @@ static void _call_ctor_QPolygon_2548 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<QPolygon *> (new QPolygon (arg1, arg2));
 }
 
@@ -270,8 +270,8 @@ static void _call_f_containsPoint_c3356 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::FillRule>::target_type & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QPolygon *)cls)->containsPoint (arg1, qt_gsi::QtToCppAdaptor<Qt::FillRule>(arg2).cref()));
 }
 
@@ -290,7 +290,7 @@ static void _call_f_intersected_c2138 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QPolygon *)cls)->intersected (arg1));
 }
 
@@ -313,9 +313,9 @@ static void _call_f_point_c2457 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygon *)cls)->point (arg1, arg2, arg3);
 }
@@ -335,7 +335,7 @@ static void _call_f_point_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPoint > ((QPoint)((QPolygon *)cls)->point (arg1));
 }
 
@@ -360,10 +360,10 @@ static void _call_f_putPoints_2744 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygon *)cls)->putPoints (arg1, arg2, arg3, arg4);
 }
@@ -389,10 +389,10 @@ static void _call_f_putPoints_4115 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QPolygon &arg3 = args.read<const QPolygon & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QPolygon &arg3 = gsi::arg_reader<const QPolygon & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygon *)cls)->putPoints (arg1, arg2, arg3, arg4);
 }
@@ -416,9 +416,9 @@ static void _call_f_setPoint_2085 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygon *)cls)->setPoint (arg1, arg2, arg3);
 }
@@ -440,8 +440,8 @@ static void _call_f_setPoint_2575 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygon *)cls)->setPoint (arg1, arg2);
 }
@@ -465,9 +465,9 @@ static void _call_f_setPoints_2085 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygon *)cls)->setPoints (arg1, arg2, arg3);
 }
@@ -487,7 +487,7 @@ static void _call_f_subtracted_c2138 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QPolygon *)cls)->subtracted (arg1));
 }
 
@@ -508,8 +508,8 @@ static void _call_f_translate_1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygon *)cls)->translate (arg1, arg2);
 }
@@ -529,7 +529,7 @@ static void _call_f_translate_1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygon *)cls)->translate (arg1);
 }
@@ -551,8 +551,8 @@ static void _call_f_translated_c1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QPolygon *)cls)->translated (arg1, arg2));
 }
 
@@ -571,7 +571,7 @@ static void _call_f_translated_c1916 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QPolygon *)cls)->translated (arg1));
 }
 
@@ -590,7 +590,7 @@ static void _call_f_united_c2138 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QPolygon *)cls)->united (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPolygonF.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPolygonF.cc
@@ -175,7 +175,7 @@ static void _call_ctor_QPolygonF_767 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPolygonF *> (new QPolygonF (arg1));
 }
 
@@ -194,7 +194,7 @@ static void _call_ctor_QPolygonF_2208 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF *> (new QPolygonF (arg1));
 }
 
@@ -213,7 +213,7 @@ static void _call_ctor_QPolygonF_2816 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QPointF> &arg1 = args.read<const QVector<QPointF> & > (heap);
+  const QVector<QPointF> &arg1 = gsi::arg_reader<const QVector<QPointF> & >() (args, heap);
   ret.write<QPolygonF *> (new QPolygonF (arg1));
 }
 
@@ -232,7 +232,7 @@ static void _call_ctor_QPolygonF_1862 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QPolygonF *> (new QPolygonF (arg1));
 }
 
@@ -251,7 +251,7 @@ static void _call_ctor_QPolygonF_2138 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   ret.write<QPolygonF *> (new QPolygonF (arg1));
 }
 
@@ -287,8 +287,8 @@ static void _call_f_containsPoint_c3426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::FillRule>::target_type & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QPolygonF *)cls)->containsPoint (arg1, qt_gsi::QtToCppAdaptor<Qt::FillRule>(arg2).cref()));
 }
 
@@ -307,7 +307,7 @@ static void _call_f_intersected_c2208 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QPolygonF *)cls)->intersected (arg1));
 }
 
@@ -341,7 +341,7 @@ static void _call_f_subtracted_c2208 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QPolygonF *)cls)->subtracted (arg1));
 }
 
@@ -377,8 +377,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygonF *)cls)->translate (arg1, arg2);
 }
@@ -398,7 +398,7 @@ static void _call_f_translate_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPolygonF *)cls)->translate (arg1);
 }
@@ -420,8 +420,8 @@ static void _call_f_translated_c2034 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QPolygonF *)cls)->translated (arg1, arg2));
 }
 
@@ -440,7 +440,7 @@ static void _call_f_translated_c1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QPolygonF *)cls)->translated (arg1));
 }
 
@@ -459,7 +459,7 @@ static void _call_f_united_c2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QPolygonF *)cls)->united (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPrintDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPrintDialog.cc
@@ -128,7 +128,7 @@ static void _call_f_done_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintDialog *)cls)->done (arg1);
 }
@@ -181,8 +181,8 @@ static void _call_f_open_2925 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintDialog *)cls)->open (arg1, arg2);
 }
@@ -219,8 +219,8 @@ static void _call_f_setOption_5076 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintDialog *)cls)->setOption (qt_gsi::QtToCppAdaptor<QAbstractPrintDialog::PrintDialogOption>(arg1).cref(), arg2);
 }
@@ -240,7 +240,7 @@ static void _call_f_setOptions_5016 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QAbstractPrintDialog::PrintDialogOption> arg1 = args.read<QFlags<QAbstractPrintDialog::PrintDialogOption> > (heap);
+  QFlags<QAbstractPrintDialog::PrintDialogOption> arg1 = gsi::arg_reader<QFlags<QAbstractPrintDialog::PrintDialogOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintDialog *)cls)->setOptions (arg1);
 }
@@ -260,7 +260,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintDialog *)cls)->setVisible (arg1);
 }
@@ -280,7 +280,7 @@ static void _call_f_testOption_c4320 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractPrintDialog::PrintDialogOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QPrintDialog *)cls)->testOption (qt_gsi::QtToCppAdaptor<QAbstractPrintDialog::PrintDialogOption>(arg1).cref()));
 }
 
@@ -301,8 +301,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPrintDialog::tr (arg1, arg2));
 }
 
@@ -325,9 +325,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPrintDialog::tr (arg1, arg2, arg3));
 }
 
@@ -348,8 +348,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPrintDialog::trUtf8 (arg1, arg2));
 }
 
@@ -372,9 +372,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPrintDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1349,8 +1349,8 @@ static void _call_ctor_QPrintDialog_Adaptor_2650 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QPrintDialog_Adaptor *> (new QPrintDialog_Adaptor (arg1, arg2));
 }
 
@@ -1368,7 +1368,7 @@ static void _call_ctor_QPrintDialog_Adaptor_1315 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QPrintDialog_Adaptor *> (new QPrintDialog_Adaptor (arg1));
 }
 
@@ -1420,7 +1420,7 @@ static void _call_emitter_accepted_1443 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
   ((QPrintDialog_Adaptor *)cls)->emitter_QPrintDialog_accepted_1443 (arg1);
 }
 
@@ -1462,7 +1462,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintDialog_Adaptor *)cls)->fp_QPrintDialog_adjustPosition_1315 (arg1);
 }
@@ -1581,9 +1581,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintDialog_Adaptor *)cls)->fp_QPrintDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -1602,7 +1602,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QPrintDialog_Adaptor *)cls)->emitter_QPrintDialog_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1646,8 +1646,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintDialog_Adaptor *)cls)->fp_QPrintDialog_destroy_1620 (arg1, arg2);
 }
@@ -1666,7 +1666,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPrintDialog_Adaptor *)cls)->emitter_QPrintDialog_destroyed_1302 (arg1);
 }
 
@@ -1944,7 +1944,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QPrintDialog_Adaptor *)cls)->emitter_QPrintDialog_finished_767 (arg1);
 }
 
@@ -2500,7 +2500,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPrintDialog_Adaptor *)cls)->fp_QPrintDialog_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPrintEngine.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPrintEngine.cc
@@ -65,7 +65,7 @@ static void _call_f_metric_c3445 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPaintDevice::PaintDeviceMetric>::target_type & arg1 = args.read<const qt_gsi::Converter<QPaintDevice::PaintDeviceMetric>::target_type & > (heap);
+  const qt_gsi::Converter<QPaintDevice::PaintDeviceMetric>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPaintDevice::PaintDeviceMetric>::target_type & >() (args, heap);
   ret.write<int > ((int)((QPrintEngine *)cls)->metric (qt_gsi::QtToCppAdaptor<QPaintDevice::PaintDeviceMetric>(arg1).cref()));
 }
 
@@ -114,7 +114,7 @@ static void _call_f_property_c4045 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrintEngine::PrintEnginePropertyKey>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrintEngine::PrintEnginePropertyKey>::target_type & > (heap);
+  const qt_gsi::Converter<QPrintEngine::PrintEnginePropertyKey>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrintEngine::PrintEnginePropertyKey>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QPrintEngine *)cls)->property (qt_gsi::QtToCppAdaptor<QPrintEngine::PrintEnginePropertyKey>(arg1).cref()));
 }
 
@@ -135,8 +135,8 @@ static void _call_f_setProperty_6056 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrintEngine::PrintEnginePropertyKey>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrintEngine::PrintEnginePropertyKey>::target_type & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const qt_gsi::Converter<QPrintEngine::PrintEnginePropertyKey>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrintEngine::PrintEnginePropertyKey>::target_type & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintEngine *)cls)->setProperty (qt_gsi::QtToCppAdaptor<QPrintEngine::PrintEnginePropertyKey>(arg1).cref(), arg2);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPrintPreviewDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPrintPreviewDialog.cc
@@ -112,7 +112,7 @@ static void _call_f_done_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewDialog *)cls)->done (arg1);
 }
@@ -150,8 +150,8 @@ static void _call_f_open_2925 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewDialog *)cls)->open (arg1, arg2);
 }
@@ -186,7 +186,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewDialog *)cls)->setVisible (arg1);
 }
@@ -208,8 +208,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPrintPreviewDialog::tr (arg1, arg2));
 }
 
@@ -232,9 +232,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPrintPreviewDialog::tr (arg1, arg2, arg3));
 }
 
@@ -255,8 +255,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPrintPreviewDialog::trUtf8 (arg1, arg2));
 }
 
@@ -279,9 +279,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPrintPreviewDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1247,8 +1247,8 @@ static void _call_ctor_QPrintPreviewDialog_Adaptor_3702 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QPrintPreviewDialog_Adaptor *> (new QPrintPreviewDialog_Adaptor (arg1, arg2));
 }
 
@@ -1270,9 +1270,9 @@ static void _call_ctor_QPrintPreviewDialog_Adaptor_5037 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg3 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg3 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QPrintPreviewDialog_Adaptor *> (new QPrintPreviewDialog_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1348,7 +1348,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewDialog_Adaptor *)cls)->fp_QPrintPreviewDialog_adjustPosition_1315 (arg1);
 }
@@ -1467,9 +1467,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewDialog_Adaptor *)cls)->fp_QPrintPreviewDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -1488,7 +1488,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QPrintPreviewDialog_Adaptor *)cls)->emitter_QPrintPreviewDialog_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1532,8 +1532,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewDialog_Adaptor *)cls)->fp_QPrintPreviewDialog_destroy_1620 (arg1, arg2);
 }
@@ -1552,7 +1552,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPrintPreviewDialog_Adaptor *)cls)->emitter_QPrintPreviewDialog_destroyed_1302 (arg1);
 }
 
@@ -1811,7 +1811,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QPrintPreviewDialog_Adaptor *)cls)->emitter_QPrintPreviewDialog_finished_767 (arg1);
 }
 
@@ -2343,7 +2343,7 @@ static void _call_emitter_paintRequested_1443 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
   ((QPrintPreviewDialog_Adaptor *)cls)->emitter_QPrintPreviewDialog_paintRequested_1443 (arg1);
 }
 
@@ -2385,7 +2385,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPrintPreviewDialog_Adaptor *)cls)->fp_QPrintPreviewDialog_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPrintPreviewWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPrintPreviewWidget.cc
@@ -236,7 +236,7 @@ static void _call_f_setCurrentPage_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget *)cls)->setCurrentPage (arg1);
 }
@@ -288,7 +288,7 @@ static void _call_f_setOrientation_2537 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<QPrinter::Orientation>(arg1).cref());
 }
@@ -340,7 +340,7 @@ static void _call_f_setViewMode_3308 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrintPreviewWidget::ViewMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrintPreviewWidget::ViewMode>::target_type & > (heap);
+  const qt_gsi::Converter<QPrintPreviewWidget::ViewMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrintPreviewWidget::ViewMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget *)cls)->setViewMode (qt_gsi::QtToCppAdaptor<QPrintPreviewWidget::ViewMode>(arg1).cref());
 }
@@ -360,7 +360,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget *)cls)->setVisible (arg1);
 }
@@ -380,7 +380,7 @@ static void _call_f_setZoomFactor_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget *)cls)->setZoomFactor (arg1);
 }
@@ -400,7 +400,7 @@ static void _call_f_setZoomMode_3318 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrintPreviewWidget::ZoomMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrintPreviewWidget::ZoomMode>::target_type & > (heap);
+  const qt_gsi::Converter<QPrintPreviewWidget::ZoomMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrintPreviewWidget::ZoomMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget *)cls)->setZoomMode (qt_gsi::QtToCppAdaptor<QPrintPreviewWidget::ZoomMode>(arg1).cref());
 }
@@ -466,7 +466,7 @@ static void _call_f_zoomIn_1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args ? args.read<double > (heap) : (double)(1.1);
+  double arg1 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget *)cls)->zoomIn (arg1);
 }
@@ -501,7 +501,7 @@ static void _call_f_zoomOut_1071 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args ? args.read<double > (heap) : (double)(1.1);
+  double arg1 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget *)cls)->zoomOut (arg1);
 }
@@ -523,8 +523,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPrintPreviewWidget::tr (arg1, arg2));
 }
 
@@ -547,9 +547,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPrintPreviewWidget::tr (arg1, arg2, arg3));
 }
 
@@ -570,8 +570,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPrintPreviewWidget::trUtf8 (arg1, arg2));
 }
 
@@ -594,9 +594,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPrintPreviewWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1516,9 +1516,9 @@ static void _call_ctor_QPrintPreviewWidget_Adaptor_5037 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg3 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg3 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QPrintPreviewWidget_Adaptor *> (new QPrintPreviewWidget_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1538,8 +1538,8 @@ static void _call_ctor_QPrintPreviewWidget_Adaptor_3702 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QPrintPreviewWidget_Adaptor *> (new QPrintPreviewWidget_Adaptor (arg1, arg2));
 }
 
@@ -1681,9 +1681,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget_Adaptor *)cls)->fp_QPrintPreviewWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -1702,7 +1702,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QPrintPreviewWidget_Adaptor *)cls)->emitter_QPrintPreviewWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1746,8 +1746,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrintPreviewWidget_Adaptor *)cls)->fp_QPrintPreviewWidget_destroy_1620 (arg1, arg2);
 }
@@ -1766,7 +1766,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPrintPreviewWidget_Adaptor *)cls)->emitter_QPrintPreviewWidget_destroyed_1302 (arg1);
 }
 
@@ -2515,7 +2515,7 @@ static void _call_emitter_paintRequested_1443 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
   ((QPrintPreviewWidget_Adaptor *)cls)->emitter_QPrintPreviewWidget_paintRequested_1443 (arg1);
 }
 
@@ -2571,7 +2571,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPrintPreviewWidget_Adaptor *)cls)->fp_QPrintPreviewWidget_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPrinter.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPrinter.cc
@@ -229,11 +229,11 @@ static void _call_f_getPageMargins_c6385 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double *arg1 = args.read<double * > (heap);
-  double *arg2 = args.read<double * > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
-  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg5 = args.read<const qt_gsi::Converter<QPrinter::Unit>::target_type & > (heap);
+  double *arg1 = gsi::arg_reader<double * >() (args, heap);
+  double *arg2 = gsi::arg_reader<double * >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
+  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg5 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::Unit>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->getPageMargins (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<QPrinter::Unit>(arg5).cref());
 }
@@ -373,7 +373,7 @@ static void _call_f_pageRect_c1789 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::Unit>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::Unit>::target_type & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QPrinter *)cls)->pageRect (qt_gsi::QtToCppAdaptor<QPrinter::Unit>(arg1).cref()));
 }
 
@@ -437,7 +437,7 @@ static void _call_f_paperRect_c1789 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::Unit>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::Unit>::target_type & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QPrinter *)cls)->paperRect (qt_gsi::QtToCppAdaptor<QPrinter::Unit>(arg1).cref()));
 }
 
@@ -471,7 +471,7 @@ static void _call_f_paperSize_c1789 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::Unit>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::Unit>::target_type & >() (args, heap);
   ret.write<QSizeF > ((QSizeF)((QPrinter *)cls)->paperSize (qt_gsi::QtToCppAdaptor<QPrinter::Unit>(arg1).cref()));
 }
 
@@ -595,7 +595,7 @@ static void _call_f_setCollateCopies_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setCollateCopies (arg1);
 }
@@ -615,7 +615,7 @@ static void _call_f_setColorMode_2273 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::ColorMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::ColorMode>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::ColorMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::ColorMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setColorMode (qt_gsi::QtToCppAdaptor<QPrinter::ColorMode>(arg1).cref());
 }
@@ -635,7 +635,7 @@ static void _call_f_setCreator_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setCreator (arg1);
 }
@@ -655,7 +655,7 @@ static void _call_f_setDocName_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setDocName (arg1);
 }
@@ -675,7 +675,7 @@ static void _call_f_setDoubleSidedPrinting_864 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setDoubleSidedPrinting (arg1);
 }
@@ -695,7 +695,7 @@ static void _call_f_setDuplex_2388 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::DuplexMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::DuplexMode>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::DuplexMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::DuplexMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setDuplex (qt_gsi::QtToCppAdaptor<QPrinter::DuplexMode>(arg1).cref());
 }
@@ -715,7 +715,7 @@ static void _call_f_setFontEmbeddingEnabled_864 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setFontEmbeddingEnabled (arg1);
 }
@@ -737,8 +737,8 @@ static void _call_f_setFromTo_1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setFromTo (arg1, arg2);
 }
@@ -758,7 +758,7 @@ static void _call_f_setFullPage_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setFullPage (arg1);
 }
@@ -778,7 +778,7 @@ static void _call_f_setNumCopies_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setNumCopies (arg1);
 }
@@ -798,7 +798,7 @@ static void _call_f_setOrientation_2537 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<QPrinter::Orientation>(arg1).cref());
 }
@@ -818,7 +818,7 @@ static void _call_f_setOutputFileName_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setOutputFileName (arg1);
 }
@@ -838,7 +838,7 @@ static void _call_f_setOutputFormat_2647 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::OutputFormat>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::OutputFormat>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::OutputFormat>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::OutputFormat>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setOutputFormat (qt_gsi::QtToCppAdaptor<QPrinter::OutputFormat>(arg1).cref());
 }
@@ -866,11 +866,11 @@ static void _call_f_setPageMargins_5641 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg5 = args.read<const qt_gsi::Converter<QPrinter::Unit>::target_type & > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg5 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::Unit>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setPageMargins (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<QPrinter::Unit>(arg5).cref());
 }
@@ -890,7 +890,7 @@ static void _call_f_setPageOrder_2262 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::PageOrder>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::PageOrder>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::PageOrder>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::PageOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setPageOrder (qt_gsi::QtToCppAdaptor<QPrinter::PageOrder>(arg1).cref());
 }
@@ -910,7 +910,7 @@ static void _call_f_setPageSize_2165 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::PageSize>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::PageSize>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::PageSize>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::PageSize>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setPageSize (qt_gsi::QtToCppAdaptor<QPrinter::PageSize>(arg1).cref());
 }
@@ -930,7 +930,7 @@ static void _call_f_setPaperSize_2165 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::PageSize>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::PageSize>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::PageSize>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::PageSize>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setPaperSize (qt_gsi::QtToCppAdaptor<QPrinter::PageSize>(arg1).cref());
 }
@@ -952,8 +952,8 @@ static void _call_f_setPaperSize_3556 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
-  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg2 = args.read<const qt_gsi::Converter<QPrinter::Unit>::target_type & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
+  const qt_gsi::Converter<QPrinter::Unit>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::Unit>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setPaperSize (arg1, qt_gsi::QtToCppAdaptor<QPrinter::Unit>(arg2).cref());
 }
@@ -973,7 +973,7 @@ static void _call_f_setPaperSource_2502 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::PaperSource>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::PaperSource>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::PaperSource>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::PaperSource>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setPaperSource (qt_gsi::QtToCppAdaptor<QPrinter::PaperSource>(arg1).cref());
 }
@@ -993,7 +993,7 @@ static void _call_f_setPrintProgram_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setPrintProgram (arg1);
 }
@@ -1013,7 +1013,7 @@ static void _call_f_setPrintRange_2391 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::PrintRange>::target_type & arg1 = args.read<const qt_gsi::Converter<QPrinter::PrintRange>::target_type & > (heap);
+  const qt_gsi::Converter<QPrinter::PrintRange>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPrinter::PrintRange>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setPrintRange (qt_gsi::QtToCppAdaptor<QPrinter::PrintRange>(arg1).cref());
 }
@@ -1033,7 +1033,7 @@ static void _call_f_setPrinterName_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setPrinterName (arg1);
 }
@@ -1053,7 +1053,7 @@ static void _call_f_setResolution_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter *)cls)->setResolution (arg1);
 }
@@ -1251,7 +1251,7 @@ static void _call_ctor_QPrinter_Adaptor_2502 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & > (heap) : (const qt_gsi::Converter<QPrinter::PrinterMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QPrinter::PrinterMode>(heap, QPrinter::ScreenResolution));
+  const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QPrinter::PrinterMode>(heap, QPrinter::ScreenResolution), heap);
   ret.write<QPrinter_Adaptor *> (new QPrinter_Adaptor (qt_gsi::QtToCppAdaptor<QPrinter::PrinterMode>(arg1).cref()));
 }
 
@@ -1271,8 +1271,8 @@ static void _call_ctor_QPrinter_Adaptor_4924 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPrinterInfo &arg1 = args.read<const QPrinterInfo & > (heap);
-  const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & > (heap) : (const qt_gsi::Converter<QPrinter::PrinterMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QPrinter::PrinterMode>(heap, QPrinter::ScreenResolution));
+  const QPrinterInfo &arg1 = gsi::arg_reader<const QPrinterInfo & >() (args, heap);
+  const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QPrinter::PrinterMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QPrinter::PrinterMode>(heap, QPrinter::ScreenResolution), heap);
   ret.write<QPrinter_Adaptor *> (new QPrinter_Adaptor (arg1, qt_gsi::QtToCppAdaptor<QPrinter::PrinterMode>(arg2).cref()));
 }
 
@@ -1334,8 +1334,8 @@ static void _call_fp_setEngines_3527 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrintEngine *arg1 = args.read<QPrintEngine * > (heap);
-  QPaintEngine *arg2 = args.read<QPaintEngine * > (heap);
+  QPrintEngine *arg1 = gsi::arg_reader<QPrintEngine * >() (args, heap);
+  QPaintEngine *arg2 = gsi::arg_reader<QPaintEngine * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPrinter_Adaptor *)cls)->fp_QPrinter_setEngines_3527 (arg1, arg2);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPrinterInfo.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPrinterInfo.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QPrinterInfo_2530 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPrinterInfo &arg1 = args.read<const QPrinterInfo & > (heap);
+  const QPrinterInfo &arg1 = gsi::arg_reader<const QPrinterInfo & >() (args, heap);
   ret.write<QPrinterInfo *> (new QPrinterInfo (arg1));
 }
 
@@ -85,7 +85,7 @@ static void _call_ctor_QPrinterInfo_2134 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPrinter &arg1 = args.read<const QPrinter & > (heap);
+  const QPrinter &arg1 = gsi::arg_reader<const QPrinter & >() (args, heap);
   ret.write<QPrinterInfo *> (new QPrinterInfo (arg1));
 }
 
@@ -134,7 +134,7 @@ static void _call_f_operator_eq__2530 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPrinterInfo &arg1 = args.read<const QPrinterInfo & > (heap);
+  const QPrinterInfo &arg1 = gsi::arg_reader<const QPrinterInfo & >() (args, heap);
   ret.write<QPrinterInfo & > ((QPrinterInfo &)((QPrinterInfo *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQProgressBar.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQProgressBar.cc
@@ -248,7 +248,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setAlignment (arg1);
 }
@@ -268,7 +268,7 @@ static void _call_f_setFormat_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setFormat (arg1);
 }
@@ -288,7 +288,7 @@ static void _call_f_setInvertedAppearance_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setInvertedAppearance (arg1);
 }
@@ -308,7 +308,7 @@ static void _call_f_setMaximum_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setMaximum (arg1);
 }
@@ -328,7 +328,7 @@ static void _call_f_setMinimum_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setMinimum (arg1);
 }
@@ -348,7 +348,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -370,8 +370,8 @@ static void _call_f_setRange_1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setRange (arg1, arg2);
 }
@@ -391,7 +391,7 @@ static void _call_f_setTextDirection_2692 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QProgressBar::Direction>::target_type & arg1 = args.read<const qt_gsi::Converter<QProgressBar::Direction>::target_type & > (heap);
+  const qt_gsi::Converter<QProgressBar::Direction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QProgressBar::Direction>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setTextDirection (qt_gsi::QtToCppAdaptor<QProgressBar::Direction>(arg1).cref());
 }
@@ -411,7 +411,7 @@ static void _call_f_setTextVisible_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setTextVisible (arg1);
 }
@@ -431,7 +431,7 @@ static void _call_f_setValue_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar *)cls)->setValue (arg1);
 }
@@ -513,8 +513,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QProgressBar::tr (arg1, arg2));
 }
 
@@ -537,9 +537,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QProgressBar::tr (arg1, arg2, arg3));
 }
 
@@ -560,8 +560,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QProgressBar::trUtf8 (arg1, arg2));
 }
 
@@ -584,9 +584,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QProgressBar::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1491,7 +1491,7 @@ static void _call_ctor_QProgressBar_Adaptor_1315 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QProgressBar_Adaptor *> (new QProgressBar_Adaptor (arg1));
 }
 
@@ -1633,9 +1633,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar_Adaptor *)cls)->fp_QProgressBar_create_2208 (arg1, arg2, arg3);
 }
@@ -1654,7 +1654,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QProgressBar_Adaptor *)cls)->emitter_QProgressBar_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1698,8 +1698,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar_Adaptor *)cls)->fp_QProgressBar_destroy_1620 (arg1, arg2);
 }
@@ -1718,7 +1718,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QProgressBar_Adaptor *)cls)->emitter_QProgressBar_destroyed_1302 (arg1);
 }
 
@@ -2123,7 +2123,7 @@ static void _call_fp_initStyleOption_c2995 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionProgressBar *arg1 = args.read<QStyleOptionProgressBar * > (heap);
+  QStyleOptionProgressBar *arg1 = gsi::arg_reader<QStyleOptionProgressBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressBar_Adaptor *)cls)->fp_QProgressBar_initStyleOption_c2995 (arg1);
 }
@@ -2510,7 +2510,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QProgressBar_Adaptor *)cls)->fp_QProgressBar_receivers_c1731 (arg1));
 }
 
@@ -2754,7 +2754,7 @@ static void _call_emitter_valueChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QProgressBar_Adaptor *)cls)->emitter_QProgressBar_valueChanged_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQProgressDialog.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQProgressDialog.cc
@@ -238,8 +238,8 @@ static void _call_f_open_2925 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->open (arg1, arg2);
 }
@@ -275,7 +275,7 @@ static void _call_f_setAutoClose_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setAutoClose (arg1);
 }
@@ -295,7 +295,7 @@ static void _call_f_setAutoReset_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setAutoReset (arg1);
 }
@@ -315,7 +315,7 @@ static void _call_f_setBar_1833 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QProgressBar *arg1 = args.read<QProgressBar * > (heap);
+  QProgressBar *arg1 = gsi::arg_reader<QProgressBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setBar (arg1);
 }
@@ -335,7 +335,7 @@ static void _call_f_setCancelButton_1755 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPushButton *arg1 = args.read<QPushButton * > (heap);
+  QPushButton *arg1 = gsi::arg_reader<QPushButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setCancelButton (arg1);
 }
@@ -355,7 +355,7 @@ static void _call_f_setCancelButtonText_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setCancelButtonText (arg1);
 }
@@ -375,7 +375,7 @@ static void _call_f_setLabel_1183 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLabel *arg1 = args.read<QLabel * > (heap);
+  QLabel *arg1 = gsi::arg_reader<QLabel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setLabel (arg1);
 }
@@ -395,7 +395,7 @@ static void _call_f_setLabelText_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setLabelText (arg1);
 }
@@ -415,7 +415,7 @@ static void _call_f_setMaximum_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setMaximum (arg1);
 }
@@ -435,7 +435,7 @@ static void _call_f_setMinimum_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setMinimum (arg1);
 }
@@ -455,7 +455,7 @@ static void _call_f_setMinimumDuration_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setMinimumDuration (arg1);
 }
@@ -477,8 +477,8 @@ static void _call_f_setRange_1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setRange (arg1, arg2);
 }
@@ -498,7 +498,7 @@ static void _call_f_setValue_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog *)cls)->setValue (arg1);
 }
@@ -565,8 +565,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QProgressDialog::tr (arg1, arg2));
 }
 
@@ -589,9 +589,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QProgressDialog::tr (arg1, arg2, arg3));
 }
 
@@ -612,8 +612,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QProgressDialog::trUtf8 (arg1, arg2));
 }
 
@@ -636,9 +636,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QProgressDialog::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1629,8 +1629,8 @@ static void _call_ctor_QProgressDialog_Adaptor_3702 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QProgressDialog_Adaptor *> (new QProgressDialog_Adaptor (arg1, arg2));
 }
 
@@ -1658,12 +1658,12 @@ static void _call_ctor_QProgressDialog_Adaptor_8854 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  QWidget *arg5 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg6 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg5 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg6 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QProgressDialog_Adaptor *> (new QProgressDialog_Adaptor (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -1739,7 +1739,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog_Adaptor *)cls)->fp_QProgressDialog_adjustPosition_1315 (arg1);
 }
@@ -1872,9 +1872,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog_Adaptor *)cls)->fp_QProgressDialog_create_2208 (arg1, arg2, arg3);
 }
@@ -1893,7 +1893,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QProgressDialog_Adaptor *)cls)->emitter_QProgressDialog_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1937,8 +1937,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QProgressDialog_Adaptor *)cls)->fp_QProgressDialog_destroy_1620 (arg1, arg2);
 }
@@ -1957,7 +1957,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QProgressDialog_Adaptor *)cls)->emitter_QProgressDialog_destroyed_1302 (arg1);
 }
 
@@ -2216,7 +2216,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QProgressDialog_Adaptor *)cls)->emitter_QProgressDialog_finished_767 (arg1);
 }
 
@@ -2787,7 +2787,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QProgressDialog_Adaptor *)cls)->fp_QProgressDialog_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQPushButton.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQPushButton.cc
@@ -189,7 +189,7 @@ static void _call_f_setAutoDefault_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPushButton *)cls)->setAutoDefault (arg1);
 }
@@ -209,7 +209,7 @@ static void _call_f_setDefault_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPushButton *)cls)->setDefault (arg1);
 }
@@ -229,7 +229,7 @@ static void _call_f_setFlat_864 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPushButton *)cls)->setFlat (arg1);
 }
@@ -249,7 +249,7 @@ static void _call_f_setMenu_1108 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMenu *arg1 = args.read<QMenu * > (heap);
+  QMenu *arg1 = gsi::arg_reader<QMenu * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPushButton *)cls)->setMenu (arg1);
 }
@@ -302,8 +302,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPushButton::tr (arg1, arg2));
 }
 
@@ -326,9 +326,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPushButton::tr (arg1, arg2, arg3));
 }
 
@@ -349,8 +349,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QPushButton::trUtf8 (arg1, arg2));
 }
 
@@ -373,9 +373,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QPushButton::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1345,7 +1345,7 @@ static void _call_ctor_QPushButton_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QPushButton_Adaptor *> (new QPushButton_Adaptor (arg1));
 }
 
@@ -1365,8 +1365,8 @@ static void _call_ctor_QPushButton_Adaptor_3232 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QPushButton_Adaptor *> (new QPushButton_Adaptor (arg1, arg2));
 }
 
@@ -1388,9 +1388,9 @@ static void _call_ctor_QPushButton_Adaptor_4911 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QPushButton_Adaptor *> (new QPushButton_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1500,7 +1500,7 @@ static void _call_emitter_clicked_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ((QPushButton_Adaptor *)cls)->emitter_QPushButton_clicked_864 (arg1);
 }
 
@@ -1570,9 +1570,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPushButton_Adaptor *)cls)->fp_QPushButton_create_2208 (arg1, arg2, arg3);
 }
@@ -1591,7 +1591,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QPushButton_Adaptor *)cls)->emitter_QPushButton_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1635,8 +1635,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPushButton_Adaptor *)cls)->fp_QPushButton_destroy_1620 (arg1, arg2);
 }
@@ -1655,7 +1655,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QPushButton_Adaptor *)cls)->emitter_QPushButton_destroyed_1302 (arg1);
 }
 
@@ -2083,7 +2083,7 @@ static void _call_fp_initStyleOption_c2501 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionButton *arg1 = args.read<QStyleOptionButton * > (heap);
+  QStyleOptionButton *arg1 = gsi::arg_reader<QStyleOptionButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QPushButton_Adaptor *)cls)->fp_QPushButton_initStyleOption_c2501 (arg1);
 }
@@ -2504,7 +2504,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QPushButton_Adaptor *)cls)->fp_QPushButton_receivers_c1731 (arg1));
 }
 
@@ -2728,7 +2728,7 @@ static void _call_emitter_toggled_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QPushButton_Adaptor *)cls)->emitter_QPushButton_toggled_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQQuaternion.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQQuaternion.cc
@@ -73,10 +73,10 @@ static void _call_ctor_QQuaternion_3960 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QQuaternion *> (new QQuaternion (arg1, arg2, arg3, arg4));
 }
 
@@ -97,8 +97,8 @@ static void _call_ctor_QQuaternion_3103 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QQuaternion *> (new QQuaternion (arg1, arg2));
 }
 
@@ -117,7 +117,7 @@ static void _call_ctor_QQuaternion_2141 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector4D &arg1 = args.read<const QVector4D & > (heap);
+  const QVector4D &arg1 = gsi::arg_reader<const QVector4D & >() (args, heap);
   ret.write<QQuaternion *> (new QQuaternion (arg1));
 }
 
@@ -242,7 +242,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QQuaternion & > ((QQuaternion &)((QQuaternion *)cls)->operator*= (arg1));
 }
 
@@ -261,7 +261,7 @@ static void _call_f_operator_star__eq__2456 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QQuaternion &arg1 = args.read<const QQuaternion & > (heap);
+  const QQuaternion &arg1 = gsi::arg_reader<const QQuaternion & >() (args, heap);
   ret.write<QQuaternion & > ((QQuaternion &)((QQuaternion *)cls)->operator*= (arg1));
 }
 
@@ -280,7 +280,7 @@ static void _call_f_operator_plus__eq__2456 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QQuaternion &arg1 = args.read<const QQuaternion & > (heap);
+  const QQuaternion &arg1 = gsi::arg_reader<const QQuaternion & >() (args, heap);
   ret.write<QQuaternion & > ((QQuaternion &)((QQuaternion *)cls)->operator+= (arg1));
 }
 
@@ -299,7 +299,7 @@ static void _call_f_operator_minus__eq__2456 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QQuaternion &arg1 = args.read<const QQuaternion & > (heap);
+  const QQuaternion &arg1 = gsi::arg_reader<const QQuaternion & >() (args, heap);
   ret.write<QQuaternion & > ((QQuaternion &)((QQuaternion *)cls)->operator-= (arg1));
 }
 
@@ -318,7 +318,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QQuaternion & > ((QQuaternion &)((QQuaternion *)cls)->operator/= (arg1));
 }
 
@@ -337,7 +337,7 @@ static void _call_f_rotatedVector_c2140 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector3D > ((QVector3D)((QQuaternion *)cls)->rotatedVector (arg1));
 }
 
@@ -371,7 +371,7 @@ static void _call_f_setScalar_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QQuaternion *)cls)->setScalar (arg1);
 }
@@ -391,7 +391,7 @@ static void _call_f_setVector_2140 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QQuaternion *)cls)->setVector (arg1);
 }
@@ -415,9 +415,9 @@ static void _call_f_setVector_2997 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QQuaternion *)cls)->setVector (arg1, arg2, arg3);
 }
@@ -437,7 +437,7 @@ static void _call_f_setX_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QQuaternion *)cls)->setX (arg1);
 }
@@ -457,7 +457,7 @@ static void _call_f_setY_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QQuaternion *)cls)->setY (arg1);
 }
@@ -477,7 +477,7 @@ static void _call_f_setZ_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QQuaternion *)cls)->setZ (arg1);
 }
@@ -574,8 +574,8 @@ static void _call_f_fromAxisAndAngle_3103 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  double arg2 = args.read<double > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QQuaternion > ((QQuaternion)QQuaternion::fromAxisAndAngle (arg1, arg2));
 }
 
@@ -600,10 +600,10 @@ static void _call_f_fromAxisAndAngle_3960 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QQuaternion > ((QQuaternion)QQuaternion::fromAxisAndAngle (arg1, arg2, arg3, arg4));
 }
 
@@ -626,9 +626,9 @@ static void _call_f_nlerp_5767 (const qt_gsi::GenericStaticMethod * /*decl*/, gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QQuaternion &arg1 = args.read<const QQuaternion & > (heap);
-  const QQuaternion &arg2 = args.read<const QQuaternion & > (heap);
-  double arg3 = args.read<double > (heap);
+  const QQuaternion &arg1 = gsi::arg_reader<const QQuaternion & >() (args, heap);
+  const QQuaternion &arg2 = gsi::arg_reader<const QQuaternion & >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   ret.write<QQuaternion > ((QQuaternion)QQuaternion::nlerp (arg1, arg2, arg3));
 }
 
@@ -651,9 +651,9 @@ static void _call_f_slerp_5767 (const qt_gsi::GenericStaticMethod * /*decl*/, gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QQuaternion &arg1 = args.read<const QQuaternion & > (heap);
-  const QQuaternion &arg2 = args.read<const QQuaternion & > (heap);
-  double arg3 = args.read<double > (heap);
+  const QQuaternion &arg1 = gsi::arg_reader<const QQuaternion & >() (args, heap);
+  const QQuaternion &arg2 = gsi::arg_reader<const QQuaternion & >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   ret.write<QQuaternion > ((QQuaternion)QQuaternion::slerp (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQRadialGradient.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQRadialGradient.cc
@@ -72,9 +72,9 @@ static void _call_ctor_QRadialGradient_4827 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  double arg2 = args.read<double > (heap);
-  const QPointF &arg3 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  const QPointF &arg3 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QRadialGradient *> (new QRadialGradient (arg1, arg2, arg3));
 }
 
@@ -101,11 +101,11 @@ static void _call_ctor_QRadialGradient_4923 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRadialGradient *> (new QRadialGradient (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -126,8 +126,8 @@ static void _call_ctor_QRadialGradient_2949 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
-  double arg2 = args.read<double > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRadialGradient *> (new QRadialGradient (arg1, arg2));
 }
 
@@ -150,9 +150,9 @@ static void _call_ctor_QRadialGradient_2997 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   ret.write<QRadialGradient *> (new QRadialGradient (arg1, arg2, arg3));
 }
 
@@ -216,7 +216,7 @@ static void _call_f_setCenter_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRadialGradient *)cls)->setCenter (arg1);
 }
@@ -238,8 +238,8 @@ static void _call_f_setCenter_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRadialGradient *)cls)->setCenter (arg1, arg2);
 }
@@ -259,7 +259,7 @@ static void _call_f_setFocalPoint_1986 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRadialGradient *)cls)->setFocalPoint (arg1);
 }
@@ -281,8 +281,8 @@ static void _call_f_setFocalPoint_2034 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRadialGradient *)cls)->setFocalPoint (arg1, arg2);
 }
@@ -302,7 +302,7 @@ static void _call_f_setRadius_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRadialGradient *)cls)->setRadius (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQRadioButton.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQRadioButton.cc
@@ -130,8 +130,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QRadioButton::tr (arg1, arg2));
 }
 
@@ -154,9 +154,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QRadioButton::tr (arg1, arg2, arg3));
 }
 
@@ -177,8 +177,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QRadioButton::trUtf8 (arg1, arg2));
 }
 
@@ -201,9 +201,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QRadioButton::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1151,7 +1151,7 @@ static void _call_ctor_QRadioButton_Adaptor_1315 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QRadioButton_Adaptor *> (new QRadioButton_Adaptor (arg1));
 }
 
@@ -1171,8 +1171,8 @@ static void _call_ctor_QRadioButton_Adaptor_3232 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QRadioButton_Adaptor *> (new QRadioButton_Adaptor (arg1, arg2));
 }
 
@@ -1282,7 +1282,7 @@ static void _call_emitter_clicked_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ((QRadioButton_Adaptor *)cls)->emitter_QRadioButton_clicked_864 (arg1);
 }
 
@@ -1352,9 +1352,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRadioButton_Adaptor *)cls)->fp_QRadioButton_create_2208 (arg1, arg2, arg3);
 }
@@ -1373,7 +1373,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QRadioButton_Adaptor *)cls)->emitter_QRadioButton_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1417,8 +1417,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRadioButton_Adaptor *)cls)->fp_QRadioButton_destroy_1620 (arg1, arg2);
 }
@@ -1437,7 +1437,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QRadioButton_Adaptor *)cls)->emitter_QRadioButton_destroyed_1302 (arg1);
 }
 
@@ -1865,7 +1865,7 @@ static void _call_fp_initStyleOption_c2501 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionButton *arg1 = args.read<QStyleOptionButton * > (heap);
+  QStyleOptionButton *arg1 = gsi::arg_reader<QStyleOptionButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRadioButton_Adaptor *)cls)->fp_QRadioButton_initStyleOption_c2501 (arg1);
 }
@@ -2286,7 +2286,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QRadioButton_Adaptor *)cls)->fp_QRadioButton_receivers_c1731 (arg1));
 }
 
@@ -2510,7 +2510,7 @@ static void _call_emitter_toggled_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QRadioButton_Adaptor *)cls)->emitter_QRadioButton_toggled_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQRegExpValidator.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQRegExpValidator.cc
@@ -85,7 +85,7 @@ static void _call_f_setRegExp_1981 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegExp &arg1 = args.read<const QRegExp & > (heap);
+  const QRegExp &arg1 = gsi::arg_reader<const QRegExp & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRegExpValidator *)cls)->setRegExp (arg1);
 }
@@ -107,8 +107,8 @@ static void _call_f_validate_c2171 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
-  int &arg2 = args.read<int & > (heap);
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
+  int &arg2 = gsi::arg_reader<int & >() (args, heap);
   ret.write<qt_gsi::Converter<QValidator::State>::target_type > ((qt_gsi::Converter<QValidator::State>::target_type)qt_gsi::CppToQtAdaptor<QValidator::State>(((QRegExpValidator *)cls)->validate (arg1, arg2)));
 }
 
@@ -129,8 +129,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QRegExpValidator::tr (arg1, arg2));
 }
 
@@ -153,9 +153,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QRegExpValidator::tr (arg1, arg2, arg3));
 }
 
@@ -176,8 +176,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QRegExpValidator::trUtf8 (arg1, arg2));
 }
 
@@ -200,9 +200,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QRegExpValidator::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -414,7 +414,7 @@ static void _call_ctor_QRegExpValidator_Adaptor_1302 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QRegExpValidator_Adaptor *> (new QRegExpValidator_Adaptor (arg1));
 }
 
@@ -434,8 +434,8 @@ static void _call_ctor_QRegExpValidator_Adaptor_3175 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegExp &arg1 = args.read<const QRegExp & > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  const QRegExp &arg1 = gsi::arg_reader<const QRegExp & >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QRegExpValidator_Adaptor *> (new QRegExpValidator_Adaptor (arg1, arg2));
 }
 
@@ -501,7 +501,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QRegExpValidator_Adaptor *)cls)->emitter_QRegExpValidator_destroyed_1302 (arg1);
 }
 
@@ -616,7 +616,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QRegExpValidator_Adaptor *)cls)->fp_QRegExpValidator_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQRegion.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQRegion.cc
@@ -83,11 +83,11 @@ static void _call_ctor_QRegion_4911 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const qt_gsi::Converter<QRegion::RegionType>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<QRegion::RegionType>::target_type & > (heap) : (const qt_gsi::Converter<QRegion::RegionType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QRegion::RegionType>(heap, QRegion::Rectangle));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QRegion::RegionType>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<QRegion::RegionType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QRegion::RegionType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QRegion::RegionType>(heap, QRegion::Rectangle), heap);
   ret.write<QRegion *> (new QRegion (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<QRegion::RegionType>(arg5).cref()));
 }
 
@@ -108,8 +108,8 @@ static void _call_ctor_QRegion_3959 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  const qt_gsi::Converter<QRegion::RegionType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QRegion::RegionType>::target_type & > (heap) : (const qt_gsi::Converter<QRegion::RegionType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QRegion::RegionType>(heap, QRegion::Rectangle));
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  const qt_gsi::Converter<QRegion::RegionType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QRegion::RegionType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QRegion::RegionType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QRegion::RegionType>(heap, QRegion::Rectangle), heap);
   ret.write<QRegion *> (new QRegion (arg1, qt_gsi::QtToCppAdaptor<QRegion::RegionType>(arg2).cref()));
 }
 
@@ -130,8 +130,8 @@ static void _call_ctor_QRegion_3578 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
-  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::FillRule>::target_type & > (heap) : (const qt_gsi::Converter<Qt::FillRule>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::FillRule>(heap, Qt::OddEvenFill));
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
+  const qt_gsi::Converter<Qt::FillRule>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::FillRule>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::FillRule>(heap, Qt::OddEvenFill), heap);
   ret.write<QRegion *> (new QRegion (arg1, qt_gsi::QtToCppAdaptor<Qt::FillRule>(arg2).cref()));
 }
 
@@ -150,7 +150,7 @@ static void _call_ctor_QRegion_2006 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion *> (new QRegion (arg1));
 }
 
@@ -169,7 +169,7 @@ static void _call_ctor_QRegion_1999 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBitmap &arg1 = args.read<const QBitmap & > (heap);
+  const QBitmap &arg1 = gsi::arg_reader<const QBitmap & >() (args, heap);
   ret.write<QRegion *> (new QRegion (arg1));
 }
 
@@ -203,7 +203,7 @@ static void _call_f_contains_c1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<bool > ((bool)((QRegion *)cls)->contains (arg1));
 }
 
@@ -222,7 +222,7 @@ static void _call_f_contains_c1792 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<bool > ((bool)((QRegion *)cls)->contains (arg1));
 }
 
@@ -241,7 +241,7 @@ static void _call_f_eor_c2006 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->eor (arg1));
 }
 
@@ -260,7 +260,7 @@ static void _call_f_intersect_c2006 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->intersect (arg1));
 }
 
@@ -279,7 +279,7 @@ static void _call_f_intersect_c1792 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->intersect (arg1));
 }
 
@@ -298,7 +298,7 @@ static void _call_f_intersected_c2006 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->intersected (arg1));
 }
 
@@ -317,7 +317,7 @@ static void _call_f_intersected_c1792 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->intersected (arg1));
 }
 
@@ -336,7 +336,7 @@ static void _call_f_intersects_c2006 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<bool > ((bool)((QRegion *)cls)->intersects (arg1));
 }
 
@@ -355,7 +355,7 @@ static void _call_f_intersects_c1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<bool > ((bool)((QRegion *)cls)->intersects (arg1));
 }
 
@@ -404,7 +404,7 @@ static void _call_f_operator_excl__eq__c2006 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<bool > ((bool)((QRegion *)cls)->operator!= (arg1));
 }
 
@@ -423,7 +423,7 @@ static void _call_f_operator_amp__c2006 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<const QRegion > ((const QRegion)((QRegion *)cls)->operator& (arg1));
 }
 
@@ -442,7 +442,7 @@ static void _call_f_operator_amp__c1792 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<const QRegion > ((const QRegion)((QRegion *)cls)->operator& (arg1));
 }
 
@@ -461,7 +461,7 @@ static void _call_f_operator_amp__eq__2006 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion & > ((QRegion &)((QRegion *)cls)->operator&= (arg1));
 }
 
@@ -480,7 +480,7 @@ static void _call_f_operator_amp__eq__1792 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRegion & > ((QRegion &)((QRegion *)cls)->operator&= (arg1));
 }
 
@@ -499,7 +499,7 @@ static void _call_f_operator_plus__c2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<const QRegion > ((const QRegion)((QRegion *)cls)->operator+ (arg1));
 }
 
@@ -518,7 +518,7 @@ static void _call_f_operator_plus__c1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<const QRegion > ((const QRegion)((QRegion *)cls)->operator+ (arg1));
 }
 
@@ -537,7 +537,7 @@ static void _call_f_operator_plus__eq__2006 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion & > ((QRegion &)((QRegion *)cls)->operator+= (arg1));
 }
 
@@ -556,7 +556,7 @@ static void _call_f_operator_plus__eq__1792 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRegion & > ((QRegion &)((QRegion *)cls)->operator+= (arg1));
 }
 
@@ -575,7 +575,7 @@ static void _call_f_operator_minus__c2006 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<const QRegion > ((const QRegion)((QRegion *)cls)->operator- (arg1));
 }
 
@@ -594,7 +594,7 @@ static void _call_f_operator_minus__eq__2006 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion & > ((QRegion &)((QRegion *)cls)->operator-= (arg1));
 }
 
@@ -613,7 +613,7 @@ static void _call_f_operator_eq__2006 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion & > ((QRegion &)((QRegion *)cls)->operator= (arg1));
 }
 
@@ -632,7 +632,7 @@ static void _call_f_operator_eq__eq__c2006 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<bool > ((bool)((QRegion *)cls)->operator== (arg1));
 }
 
@@ -651,7 +651,7 @@ static void _call_f_operator_acute__c2006 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<const QRegion > ((const QRegion)((QRegion *)cls)->operator^ (arg1));
 }
 
@@ -670,7 +670,7 @@ static void _call_f_operator_acute__eq__2006 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion & > ((QRegion &)((QRegion *)cls)->operator^= (arg1));
 }
 
@@ -689,7 +689,7 @@ static void _call_f_operator_pipe__c2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<const QRegion > ((const QRegion)((QRegion *)cls)->operator| (arg1));
 }
 
@@ -708,7 +708,7 @@ static void _call_f_operator_pipe__eq__2006 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion & > ((QRegion &)((QRegion *)cls)->operator|= (arg1));
 }
 
@@ -757,7 +757,7 @@ static void _call_f_subtract_c2006 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->subtract (arg1));
 }
 
@@ -776,7 +776,7 @@ static void _call_f_subtracted_c2006 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->subtracted (arg1));
 }
 
@@ -797,8 +797,8 @@ static void _call_f_translate_1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRegion *)cls)->translate (arg1, arg2);
 }
@@ -818,7 +818,7 @@ static void _call_f_translate_1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRegion *)cls)->translate (arg1);
 }
@@ -840,8 +840,8 @@ static void _call_f_translated_c1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->translated (arg1, arg2));
 }
 
@@ -860,7 +860,7 @@ static void _call_f_translated_c1916 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->translated (arg1));
 }
 
@@ -879,7 +879,7 @@ static void _call_f_unite_c2006 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->unite (arg1));
 }
 
@@ -898,7 +898,7 @@ static void _call_f_unite_c1792 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->unite (arg1));
 }
 
@@ -917,7 +917,7 @@ static void _call_f_united_c2006 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->united (arg1));
 }
 
@@ -936,7 +936,7 @@ static void _call_f_united_c1792 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->united (arg1));
 }
 
@@ -955,7 +955,7 @@ static void _call_f_xored_c2006 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QRegion *)cls)->xored (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQResizeEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQResizeEvent.cc
@@ -120,8 +120,8 @@ static void _call_ctor_QResizeEvent_Adaptor_3502 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
-  const QSize &arg2 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
+  const QSize &arg2 = gsi::arg_reader<const QSize & >() (args, heap);
   ret.write<QResizeEvent_Adaptor *> (new QResizeEvent_Adaptor (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQRubberBand.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQRubberBand.cc
@@ -114,8 +114,8 @@ static void _call_f_move_1426 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRubberBand *)cls)->move (arg1, arg2);
 }
@@ -135,7 +135,7 @@ static void _call_f_move_1916 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRubberBand *)cls)->move (arg1);
 }
@@ -157,8 +157,8 @@ static void _call_f_resize_1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRubberBand *)cls)->resize (arg1, arg2);
 }
@@ -178,7 +178,7 @@ static void _call_f_resize_1805 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRubberBand *)cls)->resize (arg1);
 }
@@ -198,7 +198,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRubberBand *)cls)->setGeometry (arg1);
 }
@@ -224,10 +224,10 @@ static void _call_f_setGeometry_2744 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRubberBand *)cls)->setGeometry (arg1, arg2, arg3, arg4);
 }
@@ -264,8 +264,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QRubberBand::tr (arg1, arg2));
 }
 
@@ -288,9 +288,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QRubberBand::tr (arg1, arg2, arg3));
 }
 
@@ -311,8 +311,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QRubberBand::trUtf8 (arg1, arg2));
 }
 
@@ -335,9 +335,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QRubberBand::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1205,8 +1205,8 @@ static void _call_ctor_QRubberBand_Adaptor_3320 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QRubberBand::Shape>::target_type & arg1 = args.read<const qt_gsi::Converter<QRubberBand::Shape>::target_type & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const qt_gsi::Converter<QRubberBand::Shape>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QRubberBand::Shape>::target_type & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QRubberBand_Adaptor *> (new QRubberBand_Adaptor (qt_gsi::QtToCppAdaptor<QRubberBand::Shape>(arg1).cref(), arg2));
 }
 
@@ -1348,9 +1348,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRubberBand_Adaptor *)cls)->fp_QRubberBand_create_2208 (arg1, arg2, arg3);
 }
@@ -1369,7 +1369,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QRubberBand_Adaptor *)cls)->emitter_QRubberBand_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1413,8 +1413,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRubberBand_Adaptor *)cls)->fp_QRubberBand_destroy_1620 (arg1, arg2);
 }
@@ -1433,7 +1433,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QRubberBand_Adaptor *)cls)->emitter_QRubberBand_destroyed_1302 (arg1);
 }
 
@@ -1838,7 +1838,7 @@ static void _call_fp_initStyleOption_c2848 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionRubberBand *arg1 = args.read<QStyleOptionRubberBand * > (heap);
+  QStyleOptionRubberBand *arg1 = gsi::arg_reader<QStyleOptionRubberBand * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QRubberBand_Adaptor *)cls)->fp_QRubberBand_initStyleOption_c2848 (arg1);
 }
@@ -2225,7 +2225,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QRubberBand_Adaptor *)cls)->fp_QRubberBand_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQScrollArea.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQScrollArea.cc
@@ -133,10 +133,10 @@ static void _call_f_ensureVisible_2744 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(50);
-  int arg4 = args ? args.read<int > (heap) : (int)(50);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea *)cls)->ensureVisible (arg1, arg2, arg3, arg4);
 }
@@ -160,9 +160,9 @@ static void _call_f_ensureWidgetVisible_2633 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(50);
-  int arg3 = args ? args.read<int > (heap) : (int)(50);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea *)cls)->ensureWidgetVisible (arg1, arg2, arg3);
 }
@@ -182,7 +182,7 @@ static void _call_f_focusNextPrevChild_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ret.write<bool > ((bool)((QScrollArea *)cls)->focusNextPrevChild (arg1));
 }
 
@@ -201,7 +201,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea *)cls)->setAlignment (arg1);
 }
@@ -221,7 +221,7 @@ static void _call_f_setWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea *)cls)->setWidget (arg1);
 }
@@ -241,7 +241,7 @@ static void _call_f_setWidgetResizable_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea *)cls)->setWidgetResizable (arg1);
 }
@@ -323,8 +323,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QScrollArea::tr (arg1, arg2));
 }
 
@@ -347,9 +347,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QScrollArea::tr (arg1, arg2, arg3));
 }
 
@@ -370,8 +370,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QScrollArea::trUtf8 (arg1, arg2));
 }
 
@@ -394,9 +394,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QScrollArea::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1313,7 +1313,7 @@ static void _call_ctor_QScrollArea_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QScrollArea_Adaptor *> (new QScrollArea_Adaptor (arg1));
 }
 
@@ -1455,9 +1455,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea_Adaptor *)cls)->fp_QScrollArea_create_2208 (arg1, arg2, arg3);
 }
@@ -1476,7 +1476,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QScrollArea_Adaptor *)cls)->emitter_QScrollArea_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1520,8 +1520,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea_Adaptor *)cls)->fp_QScrollArea_destroy_1620 (arg1, arg2);
 }
@@ -1540,7 +1540,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QScrollArea_Adaptor *)cls)->emitter_QScrollArea_destroyed_1302 (arg1);
 }
 
@@ -1654,7 +1654,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea_Adaptor *)cls)->fp_QScrollArea_drawFrame_1426 (arg1);
 }
@@ -2332,7 +2332,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QScrollArea_Adaptor *)cls)->fp_QScrollArea_receivers_c1731 (arg1));
 }
 
@@ -2436,10 +2436,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea_Adaptor *)cls)->fp_QScrollArea_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -2458,7 +2458,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea_Adaptor *)cls)->fp_QScrollArea_setViewportMargins_2115 (arg1);
 }
@@ -2501,7 +2501,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollArea_Adaptor *)cls)->fp_QScrollArea_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQScrollBar.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQScrollBar.cc
@@ -112,7 +112,7 @@ static void _call_f_event_1217 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QScrollBar *)cls)->event (arg1));
 }
 
@@ -148,8 +148,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QScrollBar::tr (arg1, arg2));
 }
 
@@ -172,9 +172,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QScrollBar::tr (arg1, arg2, arg3));
 }
 
@@ -195,8 +195,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QScrollBar::trUtf8 (arg1, arg2));
 }
 
@@ -219,9 +219,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QScrollBar::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1162,7 +1162,7 @@ static void _call_ctor_QScrollBar_Adaptor_1315 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QScrollBar_Adaptor *> (new QScrollBar_Adaptor (arg1));
 }
 
@@ -1182,8 +1182,8 @@ static void _call_ctor_QScrollBar_Adaptor_3120 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QScrollBar_Adaptor *> (new QScrollBar_Adaptor (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref(), arg2));
 }
 
@@ -1225,7 +1225,7 @@ static void _call_emitter_actionTriggered_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QScrollBar_Adaptor *)cls)->emitter_QScrollBar_actionTriggered_767 (arg1);
 }
 
@@ -1343,9 +1343,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollBar_Adaptor *)cls)->fp_QScrollBar_create_2208 (arg1, arg2, arg3);
 }
@@ -1364,7 +1364,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QScrollBar_Adaptor *)cls)->emitter_QScrollBar_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1408,8 +1408,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollBar_Adaptor *)cls)->fp_QScrollBar_destroy_1620 (arg1, arg2);
 }
@@ -1428,7 +1428,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QScrollBar_Adaptor *)cls)->emitter_QScrollBar_destroyed_1302 (arg1);
 }
 
@@ -1833,7 +1833,7 @@ static void _call_fp_initStyleOption_c2476 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionSlider *arg1 = args.read<QStyleOptionSlider * > (heap);
+  QStyleOptionSlider *arg1 = gsi::arg_reader<QStyleOptionSlider * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollBar_Adaptor *)cls)->fp_QScrollBar_initStyleOption_c2476 (arg1);
 }
@@ -2222,8 +2222,8 @@ static void _call_emitter_rangeChanged_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QScrollBar_Adaptor *)cls)->emitter_QScrollBar_rangeChanged_1426 (arg1, arg2);
 }
 
@@ -2241,7 +2241,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QScrollBar_Adaptor *)cls)->fp_QScrollBar_receivers_c1731 (arg1));
 }
 
@@ -2330,9 +2330,9 @@ static void _call_fp_setRepeatAction_4599 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(500);
-  int arg3 = args ? args.read<int > (heap) : (int)(50);
+  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (500, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QScrollBar_Adaptor *)cls)->fp_QScrollBar_setRepeatAction_4599 (arg1, arg2, arg3);
 }
@@ -2442,7 +2442,7 @@ static void _call_emitter_sliderMoved_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QScrollBar_Adaptor *)cls)->emitter_QScrollBar_sliderMoved_767 (arg1);
 }
 
@@ -2575,7 +2575,7 @@ static void _call_emitter_valueChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QScrollBar_Adaptor *)cls)->emitter_QScrollBar_valueChanged_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQShortcut.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQShortcut.cc
@@ -160,7 +160,7 @@ static void _call_f_setAutoRepeat_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QShortcut *)cls)->setAutoRepeat (arg1);
 }
@@ -180,7 +180,7 @@ static void _call_f_setContext_2350 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QShortcut *)cls)->setContext (qt_gsi::QtToCppAdaptor<Qt::ShortcutContext>(arg1).cref());
 }
@@ -200,7 +200,7 @@ static void _call_f_setEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QShortcut *)cls)->setEnabled (arg1);
 }
@@ -220,7 +220,7 @@ static void _call_f_setKey_2516 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QShortcut *)cls)->setKey (arg1);
 }
@@ -240,7 +240,7 @@ static void _call_f_setWhatsThis_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QShortcut *)cls)->setWhatsThis (arg1);
 }
@@ -277,8 +277,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QShortcut::tr (arg1, arg2));
 }
 
@@ -301,9 +301,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QShortcut::tr (arg1, arg2, arg3));
 }
 
@@ -324,8 +324,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QShortcut::trUtf8 (arg1, arg2));
 }
 
@@ -348,9 +348,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QShortcut::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -571,7 +571,7 @@ static void _call_ctor_QShortcut_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QShortcut_Adaptor *> (new QShortcut_Adaptor (arg1));
 }
 
@@ -597,11 +597,11 @@ static void _call_ctor_QShortcut_Adaptor_9211 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  const char *arg3 = args ? args.read<const char * > (heap) : (const char *)(0);
-  const char *arg4 = args ? args.read<const char * > (heap) : (const char *)(0);
-  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ShortcutContext>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ShortcutContext>(heap, Qt::WindowShortcut));
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  const char *arg3 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  const char *arg4 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ShortcutContext>(heap, Qt::WindowShortcut), heap);
   ret.write<QShortcut_Adaptor *> (new QShortcut_Adaptor (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::ShortcutContext>(arg5).cref()));
 }
 
@@ -695,7 +695,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QShortcut_Adaptor *)cls)->emitter_QShortcut_destroyed_1302 (arg1);
 }
 
@@ -786,7 +786,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QShortcut_Adaptor *)cls)->fp_QShortcut_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQShortcutEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQShortcutEvent.cc
@@ -192,9 +192,9 @@ static void _call_ctor_QShortcutEvent_Adaptor_3931 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
-  int arg2 = args.read<int > (heap);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(false);
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<QShortcutEvent_Adaptor *> (new QShortcutEvent_Adaptor (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSizeGrip.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSizeGrip.cc
@@ -111,7 +111,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizeGrip *)cls)->setVisible (arg1);
 }
@@ -148,8 +148,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSizeGrip::tr (arg1, arg2));
 }
 
@@ -172,9 +172,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSizeGrip::tr (arg1, arg2, arg3));
 }
 
@@ -195,8 +195,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSizeGrip::trUtf8 (arg1, arg2));
 }
 
@@ -219,9 +219,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSizeGrip::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1071,7 +1071,7 @@ static void _call_ctor_QSizeGrip_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QSizeGrip_Adaptor *> (new QSizeGrip_Adaptor (arg1));
 }
 
@@ -1213,9 +1213,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizeGrip_Adaptor *)cls)->fp_QSizeGrip_create_2208 (arg1, arg2, arg3);
 }
@@ -1234,7 +1234,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QSizeGrip_Adaptor *)cls)->emitter_QSizeGrip_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1278,8 +1278,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizeGrip_Adaptor *)cls)->fp_QSizeGrip_destroy_1620 (arg1, arg2);
 }
@@ -1298,7 +1298,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSizeGrip_Adaptor *)cls)->emitter_QSizeGrip_destroyed_1302 (arg1);
 }
 
@@ -2071,7 +2071,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSizeGrip_Adaptor *)cls)->fp_QSizeGrip_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSizePolicy.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSizePolicy.cc
@@ -67,8 +67,8 @@ static void _call_ctor_QSizePolicy_4476 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
   ret.write<QSizePolicy *> (new QSizePolicy (qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg1).cref(), qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg2).cref()));
 }
 
@@ -91,9 +91,9 @@ static void _call_ctor_QSizePolicy_7191 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg3 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
   ret.write<QSizePolicy *> (new QSizePolicy (qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg1).cref(), qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg2).cref(), qt_gsi::QtToCppAdaptor<QSizePolicy::ControlType>(arg3).cref()));
 }
 
@@ -187,7 +187,7 @@ static void _call_f_operator_excl__eq__c2429 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizePolicy &arg1 = args.read<const QSizePolicy & > (heap);
+  const QSizePolicy &arg1 = gsi::arg_reader<const QSizePolicy & >() (args, heap);
   ret.write<bool > ((bool)((QSizePolicy *)cls)->operator!= (arg1));
 }
 
@@ -206,7 +206,7 @@ static void _call_f_operator_eq__eq__c2429 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizePolicy &arg1 = args.read<const QSizePolicy & > (heap);
+  const QSizePolicy &arg1 = gsi::arg_reader<const QSizePolicy & >() (args, heap);
   ret.write<bool > ((bool)((QSizePolicy *)cls)->operator== (arg1));
 }
 
@@ -225,7 +225,7 @@ static void _call_f_setControlType_2823 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizePolicy *)cls)->setControlType (qt_gsi::QtToCppAdaptor<QSizePolicy::ControlType>(arg1).cref());
 }
@@ -245,7 +245,7 @@ static void _call_f_setHeightForWidth_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizePolicy *)cls)->setHeightForWidth (arg1);
 }
@@ -265,7 +265,7 @@ static void _call_f_setHorizontalPolicy_2292 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizePolicy *)cls)->setHorizontalPolicy (qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg1).cref());
 }
@@ -285,7 +285,7 @@ static void _call_f_setHorizontalStretch_1855 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned char arg1 = args.read<unsigned char > (heap);
+  unsigned char arg1 = gsi::arg_reader<unsigned char >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizePolicy *)cls)->setHorizontalStretch (arg1);
 }
@@ -305,7 +305,7 @@ static void _call_f_setVerticalPolicy_2292 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizePolicy *)cls)->setVerticalPolicy (qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg1).cref());
 }
@@ -325,7 +325,7 @@ static void _call_f_setVerticalStretch_1855 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned char arg1 = args.read<unsigned char > (heap);
+  unsigned char arg1 = gsi::arg_reader<unsigned char >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSizePolicy *)cls)->setVerticalStretch (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSlider.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSlider.cc
@@ -112,7 +112,7 @@ static void _call_f_event_1217 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   ret.write<bool > ((bool)((QSlider *)cls)->event (arg1));
 }
 
@@ -146,7 +146,7 @@ static void _call_f_setTickInterval_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSlider *)cls)->setTickInterval (arg1);
 }
@@ -166,7 +166,7 @@ static void _call_f_setTickPosition_2492 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSlider::TickPosition>::target_type & arg1 = args.read<const qt_gsi::Converter<QSlider::TickPosition>::target_type & > (heap);
+  const qt_gsi::Converter<QSlider::TickPosition>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSlider::TickPosition>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSlider *)cls)->setTickPosition (qt_gsi::QtToCppAdaptor<QSlider::TickPosition>(arg1).cref());
 }
@@ -233,8 +233,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSlider::tr (arg1, arg2));
 }
 
@@ -257,9 +257,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSlider::tr (arg1, arg2, arg3));
 }
 
@@ -280,8 +280,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSlider::trUtf8 (arg1, arg2));
 }
 
@@ -304,9 +304,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSlider::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1252,7 +1252,7 @@ static void _call_ctor_QSlider_Adaptor_1315 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QSlider_Adaptor *> (new QSlider_Adaptor (arg1));
 }
 
@@ -1272,8 +1272,8 @@ static void _call_ctor_QSlider_Adaptor_3120 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QSlider_Adaptor *> (new QSlider_Adaptor (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref(), arg2));
 }
 
@@ -1315,7 +1315,7 @@ static void _call_emitter_actionTriggered_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QSlider_Adaptor *)cls)->emitter_QSlider_actionTriggered_767 (arg1);
 }
 
@@ -1433,9 +1433,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSlider_Adaptor *)cls)->fp_QSlider_create_2208 (arg1, arg2, arg3);
 }
@@ -1454,7 +1454,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QSlider_Adaptor *)cls)->emitter_QSlider_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1498,8 +1498,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSlider_Adaptor *)cls)->fp_QSlider_destroy_1620 (arg1, arg2);
 }
@@ -1518,7 +1518,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSlider_Adaptor *)cls)->emitter_QSlider_destroyed_1302 (arg1);
 }
 
@@ -1923,7 +1923,7 @@ static void _call_fp_initStyleOption_c2476 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionSlider *arg1 = args.read<QStyleOptionSlider * > (heap);
+  QStyleOptionSlider *arg1 = gsi::arg_reader<QStyleOptionSlider * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSlider_Adaptor *)cls)->fp_QSlider_initStyleOption_c2476 (arg1);
 }
@@ -2312,8 +2312,8 @@ static void _call_emitter_rangeChanged_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QSlider_Adaptor *)cls)->emitter_QSlider_rangeChanged_1426 (arg1, arg2);
 }
 
@@ -2331,7 +2331,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSlider_Adaptor *)cls)->fp_QSlider_receivers_c1731 (arg1));
 }
 
@@ -2420,9 +2420,9 @@ static void _call_fp_setRepeatAction_4599 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(500);
-  int arg3 = args ? args.read<int > (heap) : (int)(50);
+  const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSlider::SliderAction>::target_type & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (500, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (50, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSlider_Adaptor *)cls)->fp_QSlider_setRepeatAction_4599 (arg1, arg2, arg3);
 }
@@ -2532,7 +2532,7 @@ static void _call_emitter_sliderMoved_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QSlider_Adaptor *)cls)->emitter_QSlider_sliderMoved_767 (arg1);
 }
 
@@ -2665,7 +2665,7 @@ static void _call_emitter_valueChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QSlider_Adaptor *)cls)->emitter_QSlider_valueChanged_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSortFilterProxyModel.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSortFilterProxyModel.cc
@@ -75,7 +75,7 @@ static void _call_f_buddy_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSortFilterProxyModel *)cls)->buddy (arg1));
 }
 
@@ -94,7 +94,7 @@ static void _call_f_canFetchMore_c2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel *)cls)->canFetchMore (arg1));
 }
 
@@ -129,7 +129,7 @@ static void _call_f_columnCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QSortFilterProxyModel *)cls)->columnCount (arg1));
 }
 
@@ -150,8 +150,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QSortFilterProxyModel *)cls)->data (arg1, arg2));
 }
 
@@ -178,11 +178,11 @@ static void _call_f_dropMimeData_7425 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QModelIndex &arg5 = args.read<const QModelIndex & > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg5 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel *)cls)->dropMimeData (arg1, qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg2).cref(), arg3, arg4, arg5));
 }
 
@@ -216,7 +216,7 @@ static void _call_f_fetchMore_2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->fetchMore (arg1);
 }
@@ -296,7 +296,7 @@ static void _call_f_flags_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFlags<Qt::ItemFlag> > ((QFlags<Qt::ItemFlag>)((QSortFilterProxyModel *)cls)->flags (arg1));
 }
 
@@ -315,7 +315,7 @@ static void _call_f_hasChildren_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel *)cls)->hasChildren (arg1));
 }
 
@@ -338,9 +338,9 @@ static void _call_f_headerData_c3231 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QSortFilterProxyModel *)cls)->headerData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3));
 }
 
@@ -363,9 +363,9 @@ static void _call_f_index_c3713 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<QModelIndex > ((QModelIndex)((QSortFilterProxyModel *)cls)->index (arg1, arg2, arg3));
 }
 
@@ -388,9 +388,9 @@ static void _call_f_insertColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel *)cls)->insertColumns (arg1, arg2, arg3));
 }
 
@@ -413,9 +413,9 @@ static void _call_f_insertRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel *)cls)->insertRows (arg1, arg2, arg3));
 }
 
@@ -465,7 +465,7 @@ static void _call_f_mapFromSource_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSortFilterProxyModel *)cls)->mapFromSource (arg1));
 }
 
@@ -484,7 +484,7 @@ static void _call_f_mapSelectionFromSource_c2727 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelection &arg1 = args.read<const QItemSelection & > (heap);
+  const QItemSelection &arg1 = gsi::arg_reader<const QItemSelection & >() (args, heap);
   ret.write<QItemSelection > ((QItemSelection)((QSortFilterProxyModel *)cls)->mapSelectionFromSource (arg1));
 }
 
@@ -503,7 +503,7 @@ static void _call_f_mapSelectionToSource_c2727 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QItemSelection &arg1 = args.read<const QItemSelection & > (heap);
+  const QItemSelection &arg1 = gsi::arg_reader<const QItemSelection & >() (args, heap);
   ret.write<QItemSelection > ((QItemSelection)((QSortFilterProxyModel *)cls)->mapSelectionToSource (arg1));
 }
 
@@ -522,7 +522,7 @@ static void _call_f_mapToSource_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSortFilterProxyModel *)cls)->mapToSource (arg1));
 }
 
@@ -549,11 +549,11 @@ static void _call_f_match_c7932 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(1);
-  QFlags<Qt::MatchFlag> arg5 = args ? args.read<QFlags<Qt::MatchFlag> > (heap) : (QFlags<Qt::MatchFlag>)(Qt::MatchFlags(Qt::MatchStartsWith|Qt::MatchWrap));
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
+  QFlags<Qt::MatchFlag> arg5 = args ? gsi::arg_reader<QFlags<Qt::MatchFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::MatchFlag> >() (Qt::MatchFlags(Qt::MatchStartsWith|Qt::MatchWrap), heap);
   ret.write<QList<QModelIndex> > ((QList<QModelIndex>)((QSortFilterProxyModel *)cls)->match (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -572,7 +572,7 @@ static void _call_f_mimeData_c3010 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   ret.write<QMimeData * > ((QMimeData *)((QSortFilterProxyModel *)cls)->mimeData (arg1));
 }
 
@@ -621,7 +621,7 @@ static void _call_f_parent_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSortFilterProxyModel *)cls)->parent (arg1));
 }
 
@@ -644,9 +644,9 @@ static void _call_f_removeColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel *)cls)->removeColumns (arg1, arg2, arg3));
 }
 
@@ -669,9 +669,9 @@ static void _call_f_removeRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel *)cls)->removeRows (arg1, arg2, arg3));
 }
 
@@ -690,7 +690,7 @@ static void _call_f_rowCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QSortFilterProxyModel *)cls)->rowCount (arg1));
 }
 
@@ -713,9 +713,9 @@ static void _call_f_setData_5065 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel *)cls)->setData (arg1, arg2, arg3));
 }
 
@@ -734,7 +734,7 @@ static void _call_f_setDynamicSortFilter_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setDynamicSortFilter (arg1);
 }
@@ -754,7 +754,7 @@ static void _call_f_setFilterCaseSensitivity_2324 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setFilterCaseSensitivity (qt_gsi::QtToCppAdaptor<Qt::CaseSensitivity>(arg1).cref());
 }
@@ -774,7 +774,7 @@ static void _call_f_setFilterFixedString_2025 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setFilterFixedString (arg1);
 }
@@ -794,7 +794,7 @@ static void _call_f_setFilterKeyColumn_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setFilterKeyColumn (arg1);
 }
@@ -814,7 +814,7 @@ static void _call_f_setFilterRegExp_1981 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegExp &arg1 = args.read<const QRegExp & > (heap);
+  const QRegExp &arg1 = gsi::arg_reader<const QRegExp & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setFilterRegExp (arg1);
 }
@@ -834,7 +834,7 @@ static void _call_f_setFilterRegExp_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setFilterRegExp (arg1);
 }
@@ -854,7 +854,7 @@ static void _call_f_setFilterRole_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setFilterRole (arg1);
 }
@@ -874,7 +874,7 @@ static void _call_f_setFilterWildcard_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setFilterWildcard (arg1);
 }
@@ -900,10 +900,10 @@ static void _call_f_setHeaderData_5242 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel *)cls)->setHeaderData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3, arg4));
 }
 
@@ -922,7 +922,7 @@ static void _call_f_setSortCaseSensitivity_2324 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CaseSensitivity>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setSortCaseSensitivity (qt_gsi::QtToCppAdaptor<Qt::CaseSensitivity>(arg1).cref());
 }
@@ -942,7 +942,7 @@ static void _call_f_setSortLocaleAware_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setSortLocaleAware (arg1);
 }
@@ -962,7 +962,7 @@ static void _call_f_setSortRole_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setSortRole (arg1);
 }
@@ -982,7 +982,7 @@ static void _call_f_setSourceModel_2419 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->setSourceModel (arg1);
 }
@@ -1004,8 +1004,8 @@ static void _call_f_sort_2340 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SortOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel *)cls)->sort (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -1085,7 +1085,7 @@ static void _call_f_span_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QSize > ((QSize)((QSortFilterProxyModel *)cls)->span (arg1));
 }
 
@@ -1121,8 +1121,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSortFilterProxyModel::tr (arg1, arg2));
 }
 
@@ -1145,9 +1145,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSortFilterProxyModel::tr (arg1, arg2, arg3));
 }
 
@@ -1168,8 +1168,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSortFilterProxyModel::trUtf8 (arg1, arg2));
 }
 
@@ -1192,9 +1192,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSortFilterProxyModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2158,7 +2158,7 @@ static void _call_ctor_QSortFilterProxyModel_Adaptor_1302 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSortFilterProxyModel_Adaptor *> (new QSortFilterProxyModel_Adaptor (arg1));
 }
 
@@ -2180,9 +2180,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -2205,9 +2205,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -2234,11 +2234,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -2264,11 +2264,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -2290,9 +2290,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -2315,9 +2315,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -2399,8 +2399,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -2421,8 +2421,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -2492,9 +2492,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -2516,9 +2516,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -2540,9 +2540,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -2612,8 +2612,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QSortFilterProxyModel_Adaptor *)cls)->emitter_QSortFilterProxyModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -2637,10 +2637,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -2658,7 +2658,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSortFilterProxyModel_Adaptor *)cls)->emitter_QSortFilterProxyModel_destroyed_1302 (arg1);
 }
 
@@ -2737,8 +2737,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_encodeData_c4599 (arg1, arg2);
 }
@@ -3081,9 +3081,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QSortFilterProxyModel_Adaptor *)cls)->emitter_QSortFilterProxyModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -3486,7 +3486,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_receivers_c1731 (arg1));
 }
 
@@ -3721,7 +3721,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSortFilterProxyModel_Adaptor *)cls)->fp_QSortFilterProxyModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSound.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSound.cc
@@ -144,7 +144,7 @@ static void _call_f_setLoops_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSound *)cls)->setLoops (arg1);
 }
@@ -195,7 +195,7 @@ static void _call_f_play_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSound::play (arg1);
 }
@@ -217,8 +217,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSound::tr (arg1, arg2));
 }
 
@@ -241,9 +241,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSound::tr (arg1, arg2, arg3));
 }
 
@@ -264,8 +264,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSound::trUtf8 (arg1, arg2));
 }
 
@@ -288,9 +288,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSound::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -478,8 +478,8 @@ static void _call_ctor_QSound_Adaptor_3219 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSound_Adaptor *> (new QSound_Adaptor (arg1, arg2));
 }
 
@@ -545,7 +545,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSound_Adaptor *)cls)->emitter_QSound_destroyed_1302 (arg1);
 }
 
@@ -636,7 +636,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSound_Adaptor *)cls)->fp_QSound_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSpacerItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSpacerItem.cc
@@ -60,10 +60,10 @@ static void _call_f_changeSize_5794 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap) : (const qt_gsi::Converter<QSizePolicy::Policy>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSizePolicy::Policy>(heap, QSizePolicy::Minimum));
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap) : (const qt_gsi::Converter<QSizePolicy::Policy>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSizePolicy::Policy>(heap, QSizePolicy::Minimum));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSizePolicy::Policy>(heap, QSizePolicy::Minimum), heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSizePolicy::Policy>(heap, QSizePolicy::Minimum), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpacerItem *)cls)->changeSize (arg1, arg2, qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg3).cref(), qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg4).cref());
 }
@@ -158,7 +158,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpacerItem *)cls)->setGeometry (arg1);
 }
@@ -493,10 +493,10 @@ static void _call_ctor_QSpacerItem_Adaptor_5794 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap) : (const qt_gsi::Converter<QSizePolicy::Policy>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSizePolicy::Policy>(heap, QSizePolicy::Minimum));
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap) : (const qt_gsi::Converter<QSizePolicy::Policy>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSizePolicy::Policy>(heap, QSizePolicy::Minimum));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSizePolicy::Policy>(heap, QSizePolicy::Minimum), heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSizePolicy::Policy>(heap, QSizePolicy::Minimum), heap);
   ret.write<QSpacerItem_Adaptor *> (new QSpacerItem_Adaptor (arg1, arg2, qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg3).cref(), qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg4).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSpinBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSpinBox.cc
@@ -173,7 +173,7 @@ static void _call_f_setMaximum_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox *)cls)->setMaximum (arg1);
 }
@@ -193,7 +193,7 @@ static void _call_f_setMinimum_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox *)cls)->setMinimum (arg1);
 }
@@ -213,7 +213,7 @@ static void _call_f_setPrefix_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox *)cls)->setPrefix (arg1);
 }
@@ -235,8 +235,8 @@ static void _call_f_setRange_1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox *)cls)->setRange (arg1, arg2);
 }
@@ -256,7 +256,7 @@ static void _call_f_setSingleStep_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox *)cls)->setSingleStep (arg1);
 }
@@ -276,7 +276,7 @@ static void _call_f_setSuffix_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox *)cls)->setSuffix (arg1);
 }
@@ -296,7 +296,7 @@ static void _call_f_setValue_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox *)cls)->setValue (arg1);
 }
@@ -363,8 +363,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSpinBox::tr (arg1, arg2));
 }
 
@@ -387,9 +387,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSpinBox::tr (arg1, arg2, arg3));
 }
 
@@ -410,8 +410,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSpinBox::trUtf8 (arg1, arg2));
 }
 
@@ -434,9 +434,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSpinBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1452,7 +1452,7 @@ static void _call_ctor_QSpinBox_Adaptor_1315 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QSpinBox_Adaptor *> (new QSpinBox_Adaptor (arg1));
 }
 
@@ -1614,9 +1614,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox_Adaptor *)cls)->fp_QSpinBox_create_2208 (arg1, arg2, arg3);
 }
@@ -1635,7 +1635,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QSpinBox_Adaptor *)cls)->emitter_QSpinBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1679,8 +1679,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox_Adaptor *)cls)->fp_QSpinBox_destroy_1620 (arg1, arg2);
 }
@@ -1699,7 +1699,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSpinBox_Adaptor *)cls)->emitter_QSpinBox_destroyed_1302 (arg1);
 }
 
@@ -2142,7 +2142,7 @@ static void _call_fp_initStyleOption_c2572 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionSpinBox *arg1 = args.read<QStyleOptionSpinBox * > (heap);
+  QStyleOptionSpinBox *arg1 = gsi::arg_reader<QStyleOptionSpinBox * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox_Adaptor *)cls)->fp_QSpinBox_initStyleOption_c2572 (arg1);
 }
@@ -2543,7 +2543,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSpinBox_Adaptor *)cls)->fp_QSpinBox_receivers_c1731 (arg1));
 }
 
@@ -2614,7 +2614,7 @@ static void _call_fp_setLineEdit_1485 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLineEdit *arg1 = args.read<QLineEdit * > (heap);
+  QLineEdit *arg1 = gsi::arg_reader<QLineEdit * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSpinBox_Adaptor *)cls)->fp_QSpinBox_setLineEdit_1485 (arg1);
 }
@@ -2879,7 +2879,7 @@ static void _call_emitter_valueChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QSpinBox_Adaptor *)cls)->emitter_QSpinBox_valueChanged_767 (arg1);
 }
 
@@ -2897,7 +2897,7 @@ static void _call_emitter_valueChanged_2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QSpinBox_Adaptor *)cls)->emitter_QSpinBox_valueChanged_2025 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSplashScreen.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSplashScreen.cc
@@ -129,7 +129,7 @@ static void _call_f_finish_1315 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplashScreen *)cls)->finish (arg1);
 }
@@ -180,7 +180,7 @@ static void _call_f_setPixmap_2017 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args.read<const QPixmap & > (heap);
+  const QPixmap &arg1 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplashScreen *)cls)->setPixmap (arg1);
 }
@@ -204,9 +204,9 @@ static void _call_f_showMessage_4481 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::AlignLeft);
-  const QColor &arg3 = args ? args.read<const QColor & > (heap) : (const QColor &)(Qt::black);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::AlignLeft, heap);
+  const QColor &arg3 = args ? gsi::arg_reader<const QColor & >() (args, heap) : gsi::arg_maker<const QColor & >() (Qt::black, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplashScreen *)cls)->showMessage (arg1, arg2, arg3);
 }
@@ -228,8 +228,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSplashScreen::tr (arg1, arg2));
 }
 
@@ -252,9 +252,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSplashScreen::tr (arg1, arg2, arg3));
 }
 
@@ -275,8 +275,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSplashScreen::trUtf8 (arg1, arg2));
 }
 
@@ -299,9 +299,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSplashScreen::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1210,8 +1210,8 @@ static void _call_ctor_QSplashScreen_Adaptor_4404 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPixmap &arg1 = args ? args.read<const QPixmap & > (heap) : (const QPixmap &)(QPixmap());
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  const QPixmap &arg1 = args ? gsi::arg_reader<const QPixmap & >() (args, heap) : gsi::arg_maker<const QPixmap & >() (QPixmap(), heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QSplashScreen_Adaptor *> (new QSplashScreen_Adaptor (arg1, arg2));
 }
 
@@ -1233,9 +1233,9 @@ static void _call_ctor_QSplashScreen_Adaptor_5611 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QPixmap &arg2 = args ? args.read<const QPixmap & > (heap) : (const QPixmap &)(QPixmap());
-  QFlags<Qt::WindowType> arg3 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QPixmap &arg2 = args ? gsi::arg_reader<const QPixmap & >() (args, heap) : gsi::arg_maker<const QPixmap & >() (QPixmap(), heap);
+  QFlags<Qt::WindowType> arg3 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QSplashScreen_Adaptor *> (new QSplashScreen_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1377,9 +1377,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplashScreen_Adaptor *)cls)->fp_QSplashScreen_create_2208 (arg1, arg2, arg3);
 }
@@ -1398,7 +1398,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QSplashScreen_Adaptor *)cls)->emitter_QSplashScreen_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1442,8 +1442,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplashScreen_Adaptor *)cls)->fp_QSplashScreen_destroy_1620 (arg1, arg2);
 }
@@ -1462,7 +1462,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSplashScreen_Adaptor *)cls)->emitter_QSplashScreen_destroyed_1302 (arg1);
 }
 
@@ -2030,7 +2030,7 @@ static void _call_emitter_messageChanged_2025 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QSplashScreen_Adaptor *)cls)->emitter_QSplashScreen_messageChanged_2025 (arg1);
 }
 
@@ -2277,7 +2277,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSplashScreen_Adaptor *)cls)->fp_QSplashScreen_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSplitter.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSplitter.cc
@@ -112,7 +112,7 @@ static void _call_f_addWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->addWidget (arg1);
 }
@@ -166,9 +166,9 @@ static void _call_f_getRange_c2457 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->getRange (arg1, arg2, arg3);
 }
@@ -188,7 +188,7 @@ static void _call_f_handle_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QSplitterHandle * > ((QSplitterHandle *)((QSplitter *)cls)->handle (arg1));
 }
 
@@ -222,7 +222,7 @@ static void _call_f_indexOf_c1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QSplitter *)cls)->indexOf (arg1));
 }
 
@@ -243,8 +243,8 @@ static void _call_f_insertWidget_1974 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->insertWidget (arg1, arg2);
 }
@@ -264,7 +264,7 @@ static void _call_f_isCollapsible_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSplitter *)cls)->isCollapsible (arg1));
 }
 
@@ -344,7 +344,7 @@ static void _call_f_restoreState_2309 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<bool > ((bool)((QSplitter *)cls)->restoreState (arg1));
 }
 
@@ -378,7 +378,7 @@ static void _call_f_setChildrenCollapsible_864 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->setChildrenCollapsible (arg1);
 }
@@ -400,8 +400,8 @@ static void _call_f_setCollapsible_1523 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->setCollapsible (arg1, arg2);
 }
@@ -421,7 +421,7 @@ static void _call_f_setHandleWidth_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->setHandleWidth (arg1);
 }
@@ -441,7 +441,7 @@ static void _call_f_setOpaqueResize_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->setOpaqueResize (arg1);
 }
@@ -461,7 +461,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -481,7 +481,7 @@ static void _call_f_setSizes_2259 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<int> &arg1 = args.read<const QList<int> & > (heap);
+  const QList<int> &arg1 = gsi::arg_reader<const QList<int> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->setSizes (arg1);
 }
@@ -503,8 +503,8 @@ static void _call_f_setStretchFactor_1426 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter *)cls)->setStretchFactor (arg1, arg2);
 }
@@ -554,7 +554,7 @@ static void _call_f_widget_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QSplitter *)cls)->widget (arg1));
 }
 
@@ -575,8 +575,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSplitter::tr (arg1, arg2));
 }
 
@@ -599,9 +599,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSplitter::tr (arg1, arg2, arg3));
 }
 
@@ -622,8 +622,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSplitter::trUtf8 (arg1, arg2));
 }
 
@@ -646,9 +646,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSplitter::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1582,7 +1582,7 @@ static void _call_ctor_QSplitter_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QSplitter_Adaptor *> (new QSplitter_Adaptor (arg1));
 }
 
@@ -1602,8 +1602,8 @@ static void _call_ctor_QSplitter_Adaptor_3120 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QSplitter_Adaptor *> (new QSplitter_Adaptor (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref(), arg2));
 }
 
@@ -1719,8 +1719,8 @@ static void _call_fp_closestLegalPosition_1426 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QSplitter_Adaptor *)cls)->fp_QSplitter_closestLegalPosition_1426 (arg1, arg2));
 }
 
@@ -1766,9 +1766,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter_Adaptor *)cls)->fp_QSplitter_create_2208 (arg1, arg2, arg3);
 }
@@ -1806,7 +1806,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QSplitter_Adaptor *)cls)->emitter_QSplitter_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1850,8 +1850,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter_Adaptor *)cls)->fp_QSplitter_destroy_1620 (arg1, arg2);
 }
@@ -1870,7 +1870,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSplitter_Adaptor *)cls)->emitter_QSplitter_destroyed_1302 (arg1);
 }
 
@@ -1984,7 +1984,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter_Adaptor *)cls)->fp_QSplitter_drawFrame_1426 (arg1);
 }
@@ -2597,8 +2597,8 @@ static void _call_fp_moveSplitter_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter_Adaptor *)cls)->fp_QSplitter_moveSplitter_1426 (arg1, arg2);
 }
@@ -2684,7 +2684,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSplitter_Adaptor *)cls)->fp_QSplitter_receivers_c1731 (arg1));
 }
 
@@ -2755,7 +2755,7 @@ static void _call_fp_setRubberBand_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitter_Adaptor *)cls)->fp_QSplitter_setRubberBand_767 (arg1);
 }
@@ -2843,8 +2843,8 @@ static void _call_emitter_splitterMoved_1426 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QSplitter_Adaptor *)cls)->emitter_QSplitter_splitterMoved_1426 (arg1, arg2);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSplitterHandle.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSplitterHandle.cc
@@ -142,7 +142,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitterHandle *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -194,8 +194,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSplitterHandle::tr (arg1, arg2));
 }
 
@@ -218,9 +218,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSplitterHandle::tr (arg1, arg2, arg3));
 }
 
@@ -241,8 +241,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSplitterHandle::trUtf8 (arg1, arg2));
 }
 
@@ -265,9 +265,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSplitterHandle::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1132,8 +1132,8 @@ static void _call_ctor_QSplitterHandle_Adaptor_3363 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  QSplitter *arg2 = args.read<QSplitter * > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  QSplitter *arg2 = gsi::arg_reader<QSplitter * >() (args, heap);
   ret.write<QSplitterHandle_Adaptor *> (new QSplitterHandle_Adaptor (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref(), arg2));
 }
 
@@ -1247,7 +1247,7 @@ static void _call_fp_closestLegalPosition_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QSplitterHandle_Adaptor *)cls)->fp_QSplitterHandle_closestLegalPosition_767 (arg1));
 }
 
@@ -1293,9 +1293,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitterHandle_Adaptor *)cls)->fp_QSplitterHandle_create_2208 (arg1, arg2, arg3);
 }
@@ -1314,7 +1314,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QSplitterHandle_Adaptor *)cls)->emitter_QSplitterHandle_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1358,8 +1358,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitterHandle_Adaptor *)cls)->fp_QSplitterHandle_destroy_1620 (arg1, arg2);
 }
@@ -1378,7 +1378,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSplitterHandle_Adaptor *)cls)->emitter_QSplitterHandle_destroyed_1302 (arg1);
 }
 
@@ -2084,7 +2084,7 @@ static void _call_fp_moveSplitter_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSplitterHandle_Adaptor *)cls)->fp_QSplitterHandle_moveSplitter_767 (arg1);
 }
@@ -2170,7 +2170,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSplitterHandle_Adaptor *)cls)->fp_QSplitterHandle_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStackedLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStackedLayout.cc
@@ -75,7 +75,7 @@ static void _call_f_addItem_1740 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayoutItem *arg1 = args.read<QLayoutItem * > (heap);
+  QLayoutItem *arg1 = gsi::arg_reader<QLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedLayout *)cls)->addItem (arg1);
 }
@@ -95,7 +95,7 @@ static void _call_f_addWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QStackedLayout *)cls)->addWidget (arg1));
 }
 
@@ -161,8 +161,8 @@ static void _call_f_insertWidget_1974 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QStackedLayout *)cls)->insertWidget (arg1, arg2));
 }
 
@@ -181,7 +181,7 @@ static void _call_f_itemAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QStackedLayout *)cls)->itemAt (arg1));
 }
 
@@ -215,7 +215,7 @@ static void _call_f_setCurrentIndex_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedLayout *)cls)->setCurrentIndex (arg1);
 }
@@ -235,7 +235,7 @@ static void _call_f_setCurrentWidget_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedLayout *)cls)->setCurrentWidget (arg1);
 }
@@ -255,7 +255,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedLayout *)cls)->setGeometry (arg1);
 }
@@ -275,7 +275,7 @@ static void _call_f_setStackingMode_3183 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStackedLayout::StackingMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QStackedLayout::StackingMode>::target_type & > (heap);
+  const qt_gsi::Converter<QStackedLayout::StackingMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStackedLayout::StackingMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedLayout *)cls)->setStackingMode (qt_gsi::QtToCppAdaptor<QStackedLayout::StackingMode>(arg1).cref());
 }
@@ -325,7 +325,7 @@ static void _call_f_takeAt_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QLayoutItem * > ((QLayoutItem *)((QStackedLayout *)cls)->takeAt (arg1));
 }
 
@@ -359,7 +359,7 @@ static void _call_f_widget_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QStackedLayout *)cls)->widget (arg1));
 }
 
@@ -380,8 +380,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStackedLayout::tr (arg1, arg2));
 }
 
@@ -404,9 +404,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStackedLayout::tr (arg1, arg2, arg3));
 }
 
@@ -427,8 +427,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStackedLayout::trUtf8 (arg1, arg2));
 }
 
@@ -451,9 +451,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStackedLayout::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1005,7 +1005,7 @@ static void _call_ctor_QStackedLayout_Adaptor_1315 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QStackedLayout_Adaptor *> (new QStackedLayout_Adaptor (arg1));
 }
 
@@ -1023,7 +1023,7 @@ static void _call_ctor_QStackedLayout_Adaptor_1341 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   ret.write<QStackedLayout_Adaptor *> (new QStackedLayout_Adaptor (arg1));
 }
 
@@ -1041,7 +1041,7 @@ static void _call_fp_addChildLayout_1341 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedLayout_Adaptor *)cls)->fp_QStackedLayout_addChildLayout_1341 (arg1);
@@ -1061,7 +1061,7 @@ static void _call_fp_addChildWidget_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedLayout_Adaptor *)cls)->fp_QStackedLayout_addChildWidget_1315 (arg1);
 }
@@ -1104,7 +1104,7 @@ static void _call_fp_alignmentRect_c1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QStackedLayout_Adaptor *)cls)->fp_QStackedLayout_alignmentRect_c1792 (arg1));
 }
 
@@ -1165,7 +1165,7 @@ static void _call_emitter_currentChanged_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QStackedLayout_Adaptor *)cls)->emitter_QStackedLayout_currentChanged_767 (arg1);
 }
 
@@ -1207,7 +1207,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QStackedLayout_Adaptor *)cls)->emitter_QStackedLayout_destroyed_1302 (arg1);
 }
 
@@ -1543,7 +1543,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QStackedLayout_Adaptor *)cls)->fp_QStackedLayout_receivers_c1731 (arg1));
 }
 
@@ -1703,7 +1703,7 @@ static void _call_fp_widgetEvent_1217 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedLayout_Adaptor *)cls)->fp_QStackedLayout_widgetEvent_1217 (arg1);
 }
@@ -1722,7 +1722,7 @@ static void _call_emitter_widgetRemoved_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QStackedLayout_Adaptor *)cls)->emitter_QStackedLayout_widgetRemoved_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStackedWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStackedWidget.cc
@@ -111,7 +111,7 @@ static void _call_f_addWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QStackedWidget *)cls)->addWidget (arg1));
 }
 
@@ -175,7 +175,7 @@ static void _call_f_indexOf_c1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QStackedWidget *)cls)->indexOf (arg1));
 }
 
@@ -196,8 +196,8 @@ static void _call_f_insertWidget_1974 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QStackedWidget *)cls)->insertWidget (arg1, arg2));
 }
 
@@ -216,7 +216,7 @@ static void _call_f_removeWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedWidget *)cls)->removeWidget (arg1);
 }
@@ -236,7 +236,7 @@ static void _call_f_setCurrentIndex_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedWidget *)cls)->setCurrentIndex (arg1);
 }
@@ -256,7 +256,7 @@ static void _call_f_setCurrentWidget_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedWidget *)cls)->setCurrentWidget (arg1);
 }
@@ -276,7 +276,7 @@ static void _call_f_widget_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QStackedWidget *)cls)->widget (arg1));
 }
 
@@ -297,8 +297,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStackedWidget::tr (arg1, arg2));
 }
 
@@ -321,9 +321,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStackedWidget::tr (arg1, arg2, arg3));
 }
 
@@ -344,8 +344,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStackedWidget::trUtf8 (arg1, arg2));
 }
 
@@ -368,9 +368,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStackedWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1253,7 +1253,7 @@ static void _call_ctor_QStackedWidget_Adaptor_1315 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QStackedWidget_Adaptor *> (new QStackedWidget_Adaptor (arg1));
 }
 
@@ -1395,9 +1395,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedWidget_Adaptor *)cls)->fp_QStackedWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -1416,7 +1416,7 @@ static void _call_emitter_currentChanged_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QStackedWidget_Adaptor *)cls)->emitter_QStackedWidget_currentChanged_767 (arg1);
 }
 
@@ -1434,7 +1434,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QStackedWidget_Adaptor *)cls)->emitter_QStackedWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1478,8 +1478,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedWidget_Adaptor *)cls)->fp_QStackedWidget_destroy_1620 (arg1, arg2);
 }
@@ -1498,7 +1498,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QStackedWidget_Adaptor *)cls)->emitter_QStackedWidget_destroyed_1302 (arg1);
 }
 
@@ -1612,7 +1612,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStackedWidget_Adaptor *)cls)->fp_QStackedWidget_drawFrame_1426 (arg1);
 }
@@ -2290,7 +2290,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QStackedWidget_Adaptor *)cls)->fp_QStackedWidget_receivers_c1731 (arg1));
 }
 
@@ -2539,7 +2539,7 @@ static void _call_emitter_widgetRemoved_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QStackedWidget_Adaptor *)cls)->emitter_QStackedWidget_widgetRemoved_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStandardItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStandardItem.cc
@@ -87,7 +87,7 @@ static void _call_f_appendColumn_3267 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QStandardItem*> &arg1 = args.read<const QList<QStandardItem*> & > (heap);
+  const QList<QStandardItem*> &arg1 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->appendColumn (arg1);
 }
@@ -107,7 +107,7 @@ static void _call_f_appendRow_3267 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QStandardItem*> &arg1 = args.read<const QList<QStandardItem*> & > (heap);
+  const QList<QStandardItem*> &arg1 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->appendRow (arg1);
 }
@@ -127,7 +127,7 @@ static void _call_f_appendRow_1919 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStandardItem *arg1 = args.read<QStandardItem * > (heap);
+  QStandardItem *arg1 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->appendRow (arg1);
 }
@@ -147,7 +147,7 @@ static void _call_f_appendRows_3267 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QStandardItem*> &arg1 = args.read<const QList<QStandardItem*> & > (heap);
+  const QList<QStandardItem*> &arg1 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->appendRows (arg1);
 }
@@ -199,8 +199,8 @@ static void _call_f_child_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QStandardItem * > ((QStandardItem *)((QStandardItem *)cls)->child (arg1, arg2));
 }
 
@@ -264,7 +264,7 @@ static void _call_f_data_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(Qt::UserRole + 1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::UserRole + 1, heap);
   ret.write<QVariant > ((QVariant)((QStandardItem *)cls)->data (arg1));
 }
 
@@ -375,8 +375,8 @@ static void _call_f_insertColumn_3926 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QList<QStandardItem*> &arg2 = args.read<const QList<QStandardItem*> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QList<QStandardItem*> &arg2 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->insertColumn (arg1, arg2);
 }
@@ -398,8 +398,8 @@ static void _call_f_insertColumns_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->insertColumns (arg1, arg2);
 }
@@ -421,8 +421,8 @@ static void _call_f_insertRow_3926 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QList<QStandardItem*> &arg2 = args.read<const QList<QStandardItem*> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QList<QStandardItem*> &arg2 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->insertRow (arg1, arg2);
 }
@@ -444,8 +444,8 @@ static void _call_f_insertRow_2578 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QStandardItem *arg2 = args.read<QStandardItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QStandardItem *arg2 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->insertRow (arg1, arg2);
 }
@@ -467,8 +467,8 @@ static void _call_f_insertRows_3926 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QList<QStandardItem*> &arg2 = args.read<const QList<QStandardItem*> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QList<QStandardItem*> &arg2 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->insertRows (arg1, arg2);
 }
@@ -490,8 +490,8 @@ static void _call_f_insertRows_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->insertRows (arg1, arg2);
 }
@@ -631,7 +631,7 @@ static void _call_f_operator_lt__c2610 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStandardItem &arg1 = args.read<const QStandardItem & > (heap);
+  const QStandardItem &arg1 = gsi::arg_reader<const QStandardItem & >() (args, heap);
   ret.write<bool > ((bool)((QStandardItem *)cls)->operator< (arg1));
 }
 
@@ -665,7 +665,7 @@ static void _call_f_read_1697 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->read (arg1);
 }
@@ -685,7 +685,7 @@ static void _call_f_removeColumn_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->removeColumn (arg1);
 }
@@ -707,8 +707,8 @@ static void _call_f_removeColumns_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->removeColumns (arg1, arg2);
 }
@@ -728,7 +728,7 @@ static void _call_f_removeRow_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->removeRow (arg1);
 }
@@ -750,8 +750,8 @@ static void _call_f_removeRows_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->removeRows (arg1, arg2);
 }
@@ -801,7 +801,7 @@ static void _call_f_setAccessibleDescription_2025 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setAccessibleDescription (arg1);
 }
@@ -821,7 +821,7 @@ static void _call_f_setAccessibleText_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setAccessibleText (arg1);
 }
@@ -841,7 +841,7 @@ static void _call_f_setBackground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setBackground (arg1);
 }
@@ -861,7 +861,7 @@ static void _call_f_setCheckState_1740 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CheckState>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CheckState>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CheckState>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CheckState>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setCheckState (qt_gsi::QtToCppAdaptor<Qt::CheckState>(arg1).cref());
 }
@@ -881,7 +881,7 @@ static void _call_f_setCheckable_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setCheckable (arg1);
 }
@@ -905,9 +905,9 @@ static void _call_f_setChild_3237 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  QStandardItem *arg3 = args.read<QStandardItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QStandardItem *arg3 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setChild (arg1, arg2, arg3);
 }
@@ -929,8 +929,8 @@ static void _call_f_setChild_2578 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QStandardItem *arg2 = args.read<QStandardItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QStandardItem *arg2 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setChild (arg1, arg2);
 }
@@ -950,7 +950,7 @@ static void _call_f_setColumnCount_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setColumnCount (arg1);
 }
@@ -972,8 +972,8 @@ static void _call_f_setData_2778u1 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::UserRole + 1);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::UserRole + 1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setData (arg1, arg2);
 }
@@ -993,7 +993,7 @@ static void _call_f_setDragEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setDragEnabled (arg1);
 }
@@ -1013,7 +1013,7 @@ static void _call_f_setDropEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setDropEnabled (arg1);
 }
@@ -1033,7 +1033,7 @@ static void _call_f_setEditable_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setEditable (arg1);
 }
@@ -1053,7 +1053,7 @@ static void _call_f_setEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setEnabled (arg1);
 }
@@ -1073,7 +1073,7 @@ static void _call_f_setFlags_2222 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::ItemFlag> arg1 = args.read<QFlags<Qt::ItemFlag> > (heap);
+  QFlags<Qt::ItemFlag> arg1 = gsi::arg_reader<QFlags<Qt::ItemFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setFlags (arg1);
 }
@@ -1093,7 +1093,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setFont (arg1);
 }
@@ -1113,7 +1113,7 @@ static void _call_f_setForeground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setForeground (arg1);
 }
@@ -1133,7 +1133,7 @@ static void _call_f_setIcon_1787 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setIcon (arg1);
 }
@@ -1153,7 +1153,7 @@ static void _call_f_setRowCount_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setRowCount (arg1);
 }
@@ -1173,7 +1173,7 @@ static void _call_f_setSelectable_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setSelectable (arg1);
 }
@@ -1193,7 +1193,7 @@ static void _call_f_setSizeHint_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setSizeHint (arg1);
 }
@@ -1213,7 +1213,7 @@ static void _call_f_setStatusTip_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setStatusTip (arg1);
 }
@@ -1233,7 +1233,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setText (arg1);
 }
@@ -1253,7 +1253,7 @@ static void _call_f_setTextAlignment_2750 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setTextAlignment (arg1);
 }
@@ -1273,7 +1273,7 @@ static void _call_f_setToolTip_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setToolTip (arg1);
 }
@@ -1293,7 +1293,7 @@ static void _call_f_setTristate_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setTristate (arg1);
 }
@@ -1313,7 +1313,7 @@ static void _call_f_setWhatsThis_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->setWhatsThis (arg1);
 }
@@ -1350,8 +1350,8 @@ static void _call_f_sortChildren_2340 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SortOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->sortChildren (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -1388,8 +1388,8 @@ static void _call_f_takeChild_1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QStandardItem * > ((QStandardItem *)((QStandardItem *)cls)->takeChild (arg1, arg2));
 }
 
@@ -1408,7 +1408,7 @@ static void _call_f_takeColumn_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QList<QStandardItem*> > ((QList<QStandardItem*>)((QStandardItem *)cls)->takeColumn (arg1));
 }
 
@@ -1427,7 +1427,7 @@ static void _call_f_takeRow_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QList<QStandardItem*> > ((QList<QStandardItem*>)((QStandardItem *)cls)->takeRow (arg1));
 }
 
@@ -1521,7 +1521,7 @@ static void _call_f_write_c1697 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItem *)cls)->write (arg1);
 }
@@ -1813,7 +1813,7 @@ static void _call_ctor_QStandardItem_Adaptor_2025 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStandardItem_Adaptor *> (new QStandardItem_Adaptor (arg1));
 }
 
@@ -1833,8 +1833,8 @@ static void _call_ctor_QStandardItem_Adaptor_3704 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStandardItem_Adaptor *> (new QStandardItem_Adaptor (arg1, arg2));
 }
 
@@ -1854,8 +1854,8 @@ static void _call_ctor_QStandardItem_Adaptor_1426 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   ret.write<QStandardItem_Adaptor *> (new QStandardItem_Adaptor (arg1, arg2));
 }
 
@@ -1953,7 +1953,7 @@ static void _call_fp_operator_eq__2610 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStandardItem &arg1 = args.read<const QStandardItem & > (heap);
+  const QStandardItem &arg1 = gsi::arg_reader<const QStandardItem & >() (args, heap);
   ret.write<QStandardItem & > ((QStandardItem &)((QStandardItem_Adaptor *)cls)->fp_QStandardItem_operator_eq__2610 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStandardItemModel.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStandardItemModel.cc
@@ -73,7 +73,7 @@ static void _call_f_appendColumn_3267 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QStandardItem*> &arg1 = args.read<const QList<QStandardItem*> & > (heap);
+  const QList<QStandardItem*> &arg1 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->appendColumn (arg1);
 }
@@ -93,7 +93,7 @@ static void _call_f_appendRow_3267 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QStandardItem*> &arg1 = args.read<const QList<QStandardItem*> & > (heap);
+  const QList<QStandardItem*> &arg1 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->appendRow (arg1);
 }
@@ -113,7 +113,7 @@ static void _call_f_appendRow_1919 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStandardItem *arg1 = args.read<QStandardItem * > (heap);
+  QStandardItem *arg1 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->appendRow (arg1);
 }
@@ -149,7 +149,7 @@ static void _call_f_columnCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QStandardItemModel *)cls)->columnCount (arg1));
 }
 
@@ -170,8 +170,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QStandardItemModel *)cls)->data (arg1, arg2));
 }
 
@@ -198,11 +198,11 @@ static void _call_f_dropMimeData_7425 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
-  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::DropAction>::target_type & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  const QModelIndex &arg5 = args.read<const QModelIndex & > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
+  const qt_gsi::Converter<Qt::DropAction>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::DropAction>::target_type & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg5 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->dropMimeData (arg1, qt_gsi::QtToCppAdaptor<Qt::DropAction>(arg2).cref(), arg3, arg4, arg5));
 }
 
@@ -225,9 +225,9 @@ static void _call_f_findItems_c4892 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<Qt::MatchFlag> arg2 = args ? args.read<QFlags<Qt::MatchFlag> > (heap) : (QFlags<Qt::MatchFlag>)(Qt::MatchExactly);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<Qt::MatchFlag> arg2 = args ? gsi::arg_reader<QFlags<Qt::MatchFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::MatchFlag> >() (Qt::MatchExactly, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QList<QStandardItem*> > ((QList<QStandardItem*>)((QStandardItemModel *)cls)->findItems (arg1, arg2, arg3));
 }
 
@@ -246,7 +246,7 @@ static void _call_f_flags_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFlags<Qt::ItemFlag> > ((QFlags<Qt::ItemFlag>)((QStandardItemModel *)cls)->flags (arg1));
 }
 
@@ -265,7 +265,7 @@ static void _call_f_hasChildren_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->hasChildren (arg1));
 }
 
@@ -288,9 +288,9 @@ static void _call_f_headerData_c3231 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QStandardItemModel *)cls)->headerData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3));
 }
 
@@ -309,7 +309,7 @@ static void _call_f_horizontalHeaderItem_c767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QStandardItem * > ((QStandardItem *)((QStandardItemModel *)cls)->horizontalHeaderItem (arg1));
 }
 
@@ -332,9 +332,9 @@ static void _call_f_index_c3713 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<QModelIndex > ((QModelIndex)((QStandardItemModel *)cls)->index (arg1, arg2, arg3));
 }
 
@@ -353,7 +353,7 @@ static void _call_f_indexFromItem_c2614 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStandardItem *arg1 = args.read<const QStandardItem * > (heap);
+  const QStandardItem *arg1 = gsi::arg_reader<const QStandardItem * >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QStandardItemModel *)cls)->indexFromItem (arg1));
 }
 
@@ -374,8 +374,8 @@ static void _call_f_insertColumn_3926 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QList<QStandardItem*> &arg2 = args.read<const QList<QStandardItem*> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QList<QStandardItem*> &arg2 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->insertColumn (arg1, arg2);
 }
@@ -397,8 +397,8 @@ static void _call_f_insertColumn_3054 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->insertColumn (arg1, arg2));
 }
 
@@ -421,9 +421,9 @@ static void _call_f_insertColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->insertColumns (arg1, arg2, arg3));
 }
 
@@ -444,8 +444,8 @@ static void _call_f_insertRow_3926 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QList<QStandardItem*> &arg2 = args.read<const QList<QStandardItem*> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QList<QStandardItem*> &arg2 = gsi::arg_reader<const QList<QStandardItem*> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->insertRow (arg1, arg2);
 }
@@ -467,8 +467,8 @@ static void _call_f_insertRow_2578 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QStandardItem *arg2 = args.read<QStandardItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QStandardItem *arg2 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->insertRow (arg1, arg2);
 }
@@ -490,8 +490,8 @@ static void _call_f_insertRow_3054 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->insertRow (arg1, arg2));
 }
 
@@ -514,9 +514,9 @@ static void _call_f_insertRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->insertRows (arg1, arg2, arg3));
 }
 
@@ -552,8 +552,8 @@ static void _call_f_item_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QStandardItem * > ((QStandardItem *)((QStandardItemModel *)cls)->item (arg1, arg2));
 }
 
@@ -572,7 +572,7 @@ static void _call_f_itemData_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QMap<int, QVariant> > ((QMap<int, QVariant>)((QStandardItemModel *)cls)->itemData (arg1));
 }
 
@@ -591,7 +591,7 @@ static void _call_f_itemFromIndex_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QStandardItem * > ((QStandardItem *)((QStandardItemModel *)cls)->itemFromIndex (arg1));
 }
 
@@ -625,7 +625,7 @@ static void _call_f_mimeData_c3010 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   ret.write<QMimeData * > ((QMimeData *)((QStandardItemModel *)cls)->mimeData (arg1));
 }
 
@@ -659,7 +659,7 @@ static void _call_f_parent_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QStandardItemModel *)cls)->parent (arg1));
 }
 
@@ -697,9 +697,9 @@ static void _call_f_removeColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->removeColumns (arg1, arg2, arg3));
 }
 
@@ -722,9 +722,9 @@ static void _call_f_removeRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->removeRows (arg1, arg2, arg3));
 }
 
@@ -743,7 +743,7 @@ static void _call_f_rowCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QStandardItemModel *)cls)->rowCount (arg1));
 }
 
@@ -762,7 +762,7 @@ static void _call_f_setColumnCount_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setColumnCount (arg1);
 }
@@ -786,9 +786,9 @@ static void _call_f_setData_5065 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->setData (arg1, arg2, arg3));
 }
 
@@ -813,10 +813,10 @@ static void _call_f_setHeaderData_5242 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->setHeaderData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3, arg4));
 }
 
@@ -837,8 +837,8 @@ static void _call_f_setHorizontalHeaderItem_2578 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QStandardItem *arg2 = args.read<QStandardItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QStandardItem *arg2 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setHorizontalHeaderItem (arg1, arg2);
 }
@@ -858,7 +858,7 @@ static void _call_f_setHorizontalHeaderLabels_2437 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setHorizontalHeaderLabels (arg1);
 }
@@ -882,9 +882,9 @@ static void _call_f_setItem_3237 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  QStandardItem *arg3 = args.read<QStandardItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QStandardItem *arg3 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setItem (arg1, arg2, arg3);
 }
@@ -906,8 +906,8 @@ static void _call_f_setItem_2578 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QStandardItem *arg2 = args.read<QStandardItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QStandardItem *arg2 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setItem (arg1, arg2);
 }
@@ -929,8 +929,8 @@ static void _call_f_setItemData_5414 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QMap<int, QVariant> &arg2 = args.read<const QMap<int, QVariant> & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QMap<int, QVariant> &arg2 = gsi::arg_reader<const QMap<int, QVariant> & >() (args, heap);
   ret.write<bool > ((bool)((QStandardItemModel *)cls)->setItemData (arg1, arg2));
 }
 
@@ -949,7 +949,7 @@ static void _call_f_setItemPrototype_2614 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStandardItem *arg1 = args.read<const QStandardItem * > (heap);
+  const QStandardItem *arg1 = gsi::arg_reader<const QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setItemPrototype (arg1);
 }
@@ -969,7 +969,7 @@ static void _call_f_setRowCount_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setRowCount (arg1);
 }
@@ -989,7 +989,7 @@ static void _call_f_setSortRole_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setSortRole (arg1);
 }
@@ -1011,8 +1011,8 @@ static void _call_f_setVerticalHeaderItem_2578 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QStandardItem *arg2 = args.read<QStandardItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QStandardItem *arg2 = gsi::arg_reader<QStandardItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setVerticalHeaderItem (arg1, arg2);
 }
@@ -1032,7 +1032,7 @@ static void _call_f_setVerticalHeaderLabels_2437 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->setVerticalHeaderLabels (arg1);
 }
@@ -1054,8 +1054,8 @@ static void _call_f_sort_2340 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SortOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel *)cls)->sort (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -1105,7 +1105,7 @@ static void _call_f_takeColumn_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QList<QStandardItem*> > ((QList<QStandardItem*>)((QStandardItemModel *)cls)->takeColumn (arg1));
 }
 
@@ -1124,7 +1124,7 @@ static void _call_f_takeHorizontalHeaderItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QStandardItem * > ((QStandardItem *)((QStandardItemModel *)cls)->takeHorizontalHeaderItem (arg1));
 }
 
@@ -1145,8 +1145,8 @@ static void _call_f_takeItem_1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QStandardItem * > ((QStandardItem *)((QStandardItemModel *)cls)->takeItem (arg1, arg2));
 }
 
@@ -1165,7 +1165,7 @@ static void _call_f_takeRow_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QList<QStandardItem*> > ((QList<QStandardItem*>)((QStandardItemModel *)cls)->takeRow (arg1));
 }
 
@@ -1184,7 +1184,7 @@ static void _call_f_takeVerticalHeaderItem_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QStandardItem * > ((QStandardItem *)((QStandardItemModel *)cls)->takeVerticalHeaderItem (arg1));
 }
 
@@ -1203,7 +1203,7 @@ static void _call_f_verticalHeaderItem_c767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QStandardItem * > ((QStandardItem *)((QStandardItemModel *)cls)->verticalHeaderItem (arg1));
 }
 
@@ -1224,8 +1224,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStandardItemModel::tr (arg1, arg2));
 }
 
@@ -1248,9 +1248,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStandardItemModel::tr (arg1, arg2, arg3));
 }
 
@@ -1271,8 +1271,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStandardItemModel::trUtf8 (arg1, arg2));
 }
 
@@ -1295,9 +1295,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStandardItemModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2144,7 +2144,7 @@ static void _call_ctor_QStandardItemModel_Adaptor_1302 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QStandardItemModel_Adaptor *> (new QStandardItemModel_Adaptor (arg1));
 }
 
@@ -2166,9 +2166,9 @@ static void _call_ctor_QStandardItemModel_Adaptor_2620 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  QObject *arg3 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QObject *arg3 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QStandardItemModel_Adaptor *> (new QStandardItemModel_Adaptor (arg1, arg2, arg3));
 }
 
@@ -2190,9 +2190,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -2215,9 +2215,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -2244,11 +2244,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -2274,11 +2274,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -2300,9 +2300,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -2325,9 +2325,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -2409,8 +2409,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -2431,8 +2431,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -2502,9 +2502,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -2526,9 +2526,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -2550,9 +2550,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -2622,8 +2622,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QStandardItemModel_Adaptor *)cls)->emitter_QStandardItemModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -2647,10 +2647,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -2668,7 +2668,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QStandardItemModel_Adaptor *)cls)->emitter_QStandardItemModel_destroyed_1302 (arg1);
 }
 
@@ -2747,8 +2747,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_encodeData_c4599 (arg1, arg2);
 }
@@ -3024,9 +3024,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QStandardItemModel_Adaptor *)cls)->emitter_QStandardItemModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -3131,7 +3131,7 @@ static void _call_emitter_itemChanged_1919 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStandardItem *arg1 = args.read<QStandardItem * > (heap);
+  QStandardItem *arg1 = gsi::arg_reader<QStandardItem * >() (args, heap);
   ((QStandardItemModel_Adaptor *)cls)->emitter_QStandardItemModel_itemChanged_1919 (arg1);
 }
 
@@ -3314,7 +3314,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_receivers_c1731 (arg1));
 }
 
@@ -3549,7 +3549,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStandardItemModel_Adaptor *)cls)->fp_QStandardItemModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStatusBar.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStatusBar.cc
@@ -113,8 +113,8 @@ static void _call_f_addPermanentWidget_1974 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStatusBar *)cls)->addPermanentWidget (arg1, arg2);
 }
@@ -136,8 +136,8 @@ static void _call_f_addWidget_1974 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStatusBar *)cls)->addWidget (arg1, arg2);
 }
@@ -192,9 +192,9 @@ static void _call_f_insertPermanentWidget_2633 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<int > ((int)((QStatusBar *)cls)->insertPermanentWidget (arg1, arg2, arg3));
 }
 
@@ -217,9 +217,9 @@ static void _call_f_insertWidget_2633 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<int > ((int)((QStatusBar *)cls)->insertWidget (arg1, arg2, arg3));
 }
 
@@ -253,7 +253,7 @@ static void _call_f_removeWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStatusBar *)cls)->removeWidget (arg1);
 }
@@ -273,7 +273,7 @@ static void _call_f_setSizeGripEnabled_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStatusBar *)cls)->setSizeGripEnabled (arg1);
 }
@@ -295,8 +295,8 @@ static void _call_f_showMessage_2684 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStatusBar *)cls)->showMessage (arg1, arg2);
 }
@@ -318,8 +318,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStatusBar::tr (arg1, arg2));
 }
 
@@ -342,9 +342,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStatusBar::tr (arg1, arg2, arg3));
 }
 
@@ -365,8 +365,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStatusBar::trUtf8 (arg1, arg2));
 }
 
@@ -389,9 +389,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStatusBar::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1272,7 +1272,7 @@ static void _call_ctor_QStatusBar_Adaptor_1315 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QStatusBar_Adaptor *> (new QStatusBar_Adaptor (arg1));
 }
 
@@ -1414,9 +1414,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStatusBar_Adaptor *)cls)->fp_QStatusBar_create_2208 (arg1, arg2, arg3);
 }
@@ -1435,7 +1435,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QStatusBar_Adaptor *)cls)->emitter_QStatusBar_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1479,8 +1479,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStatusBar_Adaptor *)cls)->fp_QStatusBar_destroy_1620 (arg1, arg2);
 }
@@ -1499,7 +1499,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QStatusBar_Adaptor *)cls)->emitter_QStatusBar_destroyed_1302 (arg1);
 }
 
@@ -2058,7 +2058,7 @@ static void _call_emitter_messageChanged_2025 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QStatusBar_Adaptor *)cls)->emitter_QStatusBar_messageChanged_2025 (arg1);
 }
 
@@ -2305,7 +2305,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QStatusBar_Adaptor *)cls)->fp_QStatusBar_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStatusTipEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStatusTipEvent.cc
@@ -101,7 +101,7 @@ static void _call_ctor_QStatusTipEvent_Adaptor_2025 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStatusTipEvent_Adaptor *> (new QStatusTipEvent_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStringListModel.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStringListModel.cc
@@ -74,8 +74,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QStringListModel *)cls)->data (arg1, arg2));
 }
 
@@ -94,7 +94,7 @@ static void _call_f_flags_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFlags<Qt::ItemFlag> > ((QFlags<Qt::ItemFlag>)((QStringListModel *)cls)->flags (arg1));
 }
 
@@ -117,9 +117,9 @@ static void _call_f_insertRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QStringListModel *)cls)->insertRows (arg1, arg2, arg3));
 }
 
@@ -142,9 +142,9 @@ static void _call_f_removeRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QStringListModel *)cls)->removeRows (arg1, arg2, arg3));
 }
 
@@ -163,7 +163,7 @@ static void _call_f_rowCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QStringListModel *)cls)->rowCount (arg1));
 }
 
@@ -186,9 +186,9 @@ static void _call_f_setData_5065 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QStringListModel *)cls)->setData (arg1, arg2, arg3));
 }
 
@@ -207,7 +207,7 @@ static void _call_f_setStringList_2437 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel *)cls)->setStringList (arg1);
 }
@@ -229,8 +229,8 @@ static void _call_f_sort_2340 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SortOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel *)cls)->sort (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -282,8 +282,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStringListModel::tr (arg1, arg2));
 }
 
@@ -306,9 +306,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStringListModel::tr (arg1, arg2, arg3));
 }
 
@@ -329,8 +329,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStringListModel::trUtf8 (arg1, arg2));
 }
 
@@ -353,9 +353,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStringListModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1102,7 +1102,7 @@ static void _call_ctor_QStringListModel_Adaptor_1302 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QStringListModel_Adaptor *> (new QStringListModel_Adaptor (arg1));
 }
 
@@ -1122,8 +1122,8 @@ static void _call_ctor_QStringListModel_Adaptor_3631 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QStringListModel_Adaptor *> (new QStringListModel_Adaptor (arg1, arg2));
 }
 
@@ -1145,9 +1145,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel_Adaptor *)cls)->fp_QStringListModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -1170,9 +1170,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel_Adaptor *)cls)->fp_QStringListModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1199,11 +1199,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QStringListModel_Adaptor *)cls)->fp_QStringListModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1229,11 +1229,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QStringListModel_Adaptor *)cls)->fp_QStringListModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1255,9 +1255,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel_Adaptor *)cls)->fp_QStringListModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -1280,9 +1280,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel_Adaptor *)cls)->fp_QStringListModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -1364,8 +1364,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel_Adaptor *)cls)->fp_QStringListModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -1386,8 +1386,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel_Adaptor *)cls)->fp_QStringListModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -1434,9 +1434,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QStringListModel_Adaptor *)cls)->fp_QStringListModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -1458,9 +1458,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QStringListModel_Adaptor *)cls)->fp_QStringListModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -1482,9 +1482,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QStringListModel_Adaptor *)cls)->fp_QStringListModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -1554,8 +1554,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QStringListModel_Adaptor *)cls)->emitter_QStringListModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -1579,10 +1579,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QStringListModel_Adaptor *)cls)->fp_QStringListModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -1600,7 +1600,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QStringListModel_Adaptor *)cls)->emitter_QStringListModel_destroyed_1302 (arg1);
 }
 
@@ -1679,8 +1679,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel_Adaptor *)cls)->fp_QStringListModel_encodeData_c4599 (arg1, arg2);
 }
@@ -1933,9 +1933,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QStringListModel_Adaptor *)cls)->emitter_QStringListModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -2182,7 +2182,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QStringListModel_Adaptor *)cls)->fp_QStringListModel_receivers_c1731 (arg1));
 }
 
@@ -2417,7 +2417,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStringListModel_Adaptor *)cls)->fp_QStringListModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyle.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyle.cc
@@ -89,11 +89,11 @@ static void _call_f_combinedLayoutSpacing_c11699 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QSizePolicy::ControlType> arg1 = args.read<QFlags<QSizePolicy::ControlType> > (heap);
-  QFlags<QSizePolicy::ControlType> arg2 = args.read<QFlags<QSizePolicy::ControlType> > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  QStyleOption *arg4 = args ? args.read<QStyleOption * > (heap) : (QStyleOption *)(0);
-  QWidget *arg5 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QFlags<QSizePolicy::ControlType> arg1 = gsi::arg_reader<QFlags<QSizePolicy::ControlType> >() (args, heap);
+  QFlags<QSizePolicy::ControlType> arg2 = gsi::arg_reader<QFlags<QSizePolicy::ControlType> >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  QStyleOption *arg4 = args ? gsi::arg_reader<QStyleOption * >() (args, heap) : gsi::arg_maker<QStyleOption * >() (0, heap);
+  QWidget *arg5 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<int > ((int)((QStyle *)cls)->combinedLayoutSpacing (arg1, arg2, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg3).cref(), arg4, arg5));
 }
 
@@ -118,10 +118,10 @@ static void _call_f_drawComplexControl_c9027 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->drawComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -147,10 +147,10 @@ static void _call_f_drawControl_c8285 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ControlElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ControlElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->drawControl (qt_gsi::QtToCppAdaptor<QStyle::ControlElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -176,10 +176,10 @@ static void _call_f_drawItemPixmap_c5678 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  int arg3 = args.read<int > (heap);
-  const QPixmap &arg4 = args.read<const QPixmap & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg4 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->drawItemPixmap (arg1, arg2, arg3, arg4);
 }
@@ -211,13 +211,13 @@ static void _call_f_drawItemText_c10604 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  int arg3 = args.read<int > (heap);
-  const QPalette &arg4 = args.read<const QPalette & > (heap);
-  bool arg5 = args.read<bool > (heap);
-  const QString &arg6 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg7 = args ? args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap) : (const qt_gsi::Converter<QPalette::ColorRole>::target_type &)(qt_gsi::CppToQtReadAdaptor<QPalette::ColorRole>(heap, QPalette::NoRole));
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QPalette &arg4 = gsi::arg_reader<const QPalette & >() (args, heap);
+  bool arg5 = gsi::arg_reader<bool >() (args, heap);
+  const QString &arg6 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg7 = args ? gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QPalette::ColorRole>(heap, QPalette::NoRole), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->drawItemText (arg1, arg2, arg3, arg4, arg5, arg6, qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg7).cref());
 }
@@ -243,10 +243,10 @@ static void _call_f_drawPrimitive_c8501 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->drawPrimitive (qt_gsi::QtToCppAdaptor<QStyle::PrimitiveElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -270,9 +270,9 @@ static void _call_f_generatedIconPixmap_c5776 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = args.read<const qt_gsi::Converter<QIcon::Mode>::target_type & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
-  const QStyleOption *arg3 = args.read<const QStyleOption * > (heap);
+  const qt_gsi::Converter<QIcon::Mode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QIcon::Mode>::target_type & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
+  const QStyleOption *arg3 = gsi::arg_reader<const QStyleOption * >() (args, heap);
   ret.write<QPixmap > ((QPixmap)((QStyle *)cls)->generatedIconPixmap (qt_gsi::QtToCppAdaptor<QIcon::Mode>(arg1).cref(), arg2, arg3));
 }
 
@@ -297,10 +297,10 @@ static void _call_f_hitTestComplexControl_c9517 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<qt_gsi::Converter<QStyle::SubControl>::target_type > ((qt_gsi::Converter<QStyle::SubControl>::target_type)qt_gsi::CppToQtAdaptor<QStyle::SubControl>(((QStyle *)cls)->hitTestComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4)));
 }
 
@@ -323,9 +323,9 @@ static void _call_f_itemPixmapRect_c4360 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QPixmap &arg3 = args.read<const QPixmap & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg3 = gsi::arg_reader<const QPixmap & >() (args, heap);
   ret.write<QRect > ((QRect)((QStyle *)cls)->itemPixmapRect (arg1, arg2, arg3));
 }
 
@@ -352,11 +352,11 @@ static void _call_f_itemTextRect_c7544 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFontMetrics &arg1 = args.read<const QFontMetrics & > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  int arg3 = args.read<int > (heap);
-  bool arg4 = args.read<bool > (heap);
-  const QString &arg5 = args.read<const QString & > (heap);
+  const QFontMetrics &arg1 = gsi::arg_reader<const QFontMetrics & >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  bool arg4 = gsi::arg_reader<bool >() (args, heap);
+  const QString &arg5 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QRect > ((QRect)((QStyle *)cls)->itemTextRect (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -383,11 +383,11 @@ static void _call_f_layoutSpacing_c11697 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QStyleOption *arg4 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg5 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QStyleOption *arg4 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg5 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QStyle *)cls)->layoutSpacing (qt_gsi::QtToCppAdaptor<QSizePolicy::ControlType>(arg1).cref(), qt_gsi::QtToCppAdaptor<QSizePolicy::ControlType>(arg2).cref(), qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg3).cref(), arg4, arg5));
 }
 
@@ -410,9 +410,9 @@ static void _call_f_pixelMetric_c6642 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QStyle *)cls)->pixelMetric (qt_gsi::QtToCppAdaptor<QStyle::PixelMetric>(arg1).cref(), arg2, arg3));
 }
 
@@ -431,7 +431,7 @@ static void _call_f_polish_1315 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->polish (arg1);
 }
@@ -451,7 +451,7 @@ static void _call_f_polish_1843 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->polish (arg1);
 }
@@ -471,7 +471,7 @@ static void _call_f_polish_1418 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPalette &arg1 = args.read<QPalette & > (heap);
+  QPalette &arg1 = gsi::arg_reader<QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->polish (arg1);
 }
@@ -512,10 +512,10 @@ static void _call_f_sizeFromContents_c8477 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ContentsType>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QSize &arg3 = args.read<const QSize & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ContentsType>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QSize &arg3 = gsi::arg_reader<const QSize & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QSize > ((QSize)((QStyle *)cls)->sizeFromContents (qt_gsi::QtToCppAdaptor<QStyle::ContentsType>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -538,9 +538,9 @@ static void _call_f_standardIcon_c6956 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QIcon > ((QIcon)((QStyle *)cls)->standardIcon (qt_gsi::QtToCppAdaptor<QStyle::StandardPixmap>(arg1).cref(), arg2, arg3));
 }
 
@@ -578,9 +578,9 @@ static void _call_f_standardPixmap_c6956 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QPixmap > ((QPixmap)((QStyle *)cls)->standardPixmap (qt_gsi::QtToCppAdaptor<QStyle::StandardPixmap>(arg1).cref(), arg2, arg3));
 }
 
@@ -605,10 +605,10 @@ static void _call_f_styleHint_c8615 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StyleHint>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
-  QStyleHintReturn *arg4 = args ? args.read<QStyleHintReturn * > (heap) : (QStyleHintReturn *)(0);
+  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StyleHint>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
+  QStyleHintReturn *arg4 = args ? gsi::arg_reader<QStyleHintReturn * >() (args, heap) : gsi::arg_maker<QStyleHintReturn * >() (0, heap);
   ret.write<int > ((int)((QStyle *)cls)->styleHint (qt_gsi::QtToCppAdaptor<QStyle::StyleHint>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -633,10 +633,10 @@ static void _call_f_subControlRect_c9798 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = args.read<const qt_gsi::Converter<QStyle::SubControl>::target_type & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  const qt_gsi::Converter<QStyle::SubControl>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubControl>::target_type & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QRect > ((QRect)((QStyle *)cls)->subControlRect (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, qt_gsi::QtToCppAdaptor<QStyle::SubControl>(arg3).cref(), arg4));
 }
 
@@ -659,9 +659,9 @@ static void _call_f_subElementRect_c6528 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::SubElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QRect > ((QRect)((QStyle *)cls)->subElementRect (qt_gsi::QtToCppAdaptor<QStyle::SubElement>(arg1).cref(), arg2, arg3));
 }
 
@@ -680,7 +680,7 @@ static void _call_f_unpolish_1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->unpolish (arg1);
 }
@@ -700,7 +700,7 @@ static void _call_f_unpolish_1843 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyle *)cls)->unpolish (arg1);
 }
@@ -726,10 +726,10 @@ static void _call_f_alignedRect_8339 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
-  QFlags<Qt::AlignmentFlag> arg2 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
-  const QSize &arg3 = args.read<const QSize & > (heap);
-  const QRect &arg4 = args.read<const QRect & > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg2 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
+  const QSize &arg3 = gsi::arg_reader<const QSize & >() (args, heap);
+  const QRect &arg4 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)QStyle::alignedRect (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -756,11 +756,11 @@ static void _call_f_sliderPositionFromValue_3500 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  bool arg5 = args ? args.read<bool > (heap) : (bool)(false);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  bool arg5 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<int > ((int)QStyle::sliderPositionFromValue (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -787,11 +787,11 @@ static void _call_f_sliderValueFromPosition_3500 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
-  bool arg5 = args ? args.read<bool > (heap) : (bool)(false);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  bool arg5 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<int > ((int)QStyle::sliderValueFromPosition (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -812,8 +812,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStyle::tr (arg1, arg2));
 }
 
@@ -836,9 +836,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStyle::tr (arg1, arg2, arg3));
 }
 
@@ -859,8 +859,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStyle::trUtf8 (arg1, arg2));
 }
 
@@ -883,9 +883,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStyle::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -906,8 +906,8 @@ static void _call_f_visualAlignment_4958 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
-  QFlags<Qt::AlignmentFlag> arg2 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
+  QFlags<Qt::AlignmentFlag> arg2 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   ret.write<QFlags<Qt::AlignmentFlag> > ((QFlags<Qt::AlignmentFlag>)QStyle::visualAlignment (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref(), arg2));
 }
 
@@ -930,9 +930,9 @@ static void _call_f_visualPos_5808 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  const QPoint &arg3 = args.read<const QPoint & > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QPoint &arg3 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)QStyle::visualPos (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref(), arg2, arg3));
 }
 
@@ -955,9 +955,9 @@ static void _call_f_visualRect_5684 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
-  const QRect &arg2 = args.read<const QRect & > (heap);
-  const QRect &arg3 = args.read<const QRect & > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
+  const QRect &arg2 = gsi::arg_reader<const QRect & >() (args, heap);
+  const QRect &arg3 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)QStyle::visualRect (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref(), arg2, arg3));
 }
 
@@ -1607,7 +1607,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QStyle_Adaptor *)cls)->emitter_QStyle_destroyed_1302 (arg1);
 }
 
@@ -2005,11 +2005,11 @@ static void _call_fp_layoutSpacingImplementation_c11697 (const qt_gsi::GenericMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QStyleOption *arg4 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg5 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QStyleOption *arg4 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg5 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QStyle_Adaptor *)cls)->fp_QStyle_layoutSpacingImplementation_c11697 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -2128,7 +2128,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QStyle_Adaptor *)cls)->fp_QStyle_receivers_c1731 (arg1));
 }
 
@@ -2196,9 +2196,9 @@ static void _call_fp_standardIconImplementation_c6956 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QIcon > ((QIcon)((QStyle_Adaptor *)cls)->fp_QStyle_standardIconImplementation_c6956 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleFactory.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleFactory.cc
@@ -66,7 +66,7 @@ static void _call_f_create_2025 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStyle * > ((QStyle *)QStyleFactory::create (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleHintReturn.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleHintReturn.cc
@@ -52,8 +52,8 @@ static void _call_ctor_QStyleHintReturn_1426 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(QStyleOption::Version);
-  int arg2 = args ? args.read<int > (heap) : (int)(QStyleHintReturn::SH_Default);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QStyleOption::Version, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QStyleHintReturn::SH_Default, heap);
   ret.write<QStyleHintReturn *> (new QStyleHintReturn (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOption.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOption.cc
@@ -53,8 +53,8 @@ static void _call_ctor_QStyleOption_1426 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(QStyleOption::Version);
-  int arg2 = args ? args.read<int > (heap) : (int)(QStyleOption::SO_Default);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QStyleOption::Version, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QStyleOption::SO_Default, heap);
   ret.write<QStyleOption *> (new QStyleOption (arg1, arg2));
 }
 
@@ -73,7 +73,7 @@ static void _call_ctor_QStyleOption_2556 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOption &arg1 = args.read<const QStyleOption & > (heap);
+  const QStyleOption &arg1 = gsi::arg_reader<const QStyleOption & >() (args, heap);
   ret.write<QStyleOption *> (new QStyleOption (arg1));
 }
 
@@ -92,7 +92,7 @@ static void _call_f_init_2010 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyleOption *)cls)->init (arg1);
 }
@@ -112,7 +112,7 @@ static void _call_f_initFrom_2010 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyleOption *)cls)->initFrom (arg1);
 }
@@ -132,7 +132,7 @@ static void _call_f_operator_eq__2556 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOption &arg1 = args.read<const QStyleOption & > (heap);
+  const QStyleOption &arg1 = gsi::arg_reader<const QStyleOption & >() (args, heap);
   ret.write<QStyleOption & > ((QStyleOption &)((QStyleOption *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionButton.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionButton.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionButton_3192 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionButton &arg1 = args.read<const QStyleOptionButton & > (heap);
+  const QStyleOptionButton &arg1 = gsi::arg_reader<const QStyleOptionButton & >() (args, heap);
   ret.write<QStyleOptionButton *> (new QStyleOptionButton (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionComboBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionComboBox.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionComboBox_3349 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionComboBox &arg1 = args.read<const QStyleOptionComboBox & > (heap);
+  const QStyleOptionComboBox &arg1 = gsi::arg_reader<const QStyleOptionComboBox & >() (args, heap);
   ret.write<QStyleOptionComboBox *> (new QStyleOptionComboBox (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionComplex.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionComplex.cc
@@ -54,8 +54,8 @@ static void _call_ctor_QStyleOptionComplex_1426 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(QStyleOptionComplex::Version);
-  int arg2 = args ? args.read<int > (heap) : (int)(QStyleOption::SO_Complex);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QStyleOptionComplex::Version, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QStyleOption::SO_Complex, heap);
   ret.write<QStyleOptionComplex *> (new QStyleOptionComplex (arg1, arg2));
 }
 
@@ -74,7 +74,7 @@ static void _call_ctor_QStyleOptionComplex_3284 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionComplex &arg1 = args.read<const QStyleOptionComplex & > (heap);
+  const QStyleOptionComplex &arg1 = gsi::arg_reader<const QStyleOptionComplex & >() (args, heap);
   ret.write<QStyleOptionComplex *> (new QStyleOptionComplex (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionDockWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionDockWidget.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionDockWidget_3553 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionDockWidget &arg1 = args.read<const QStyleOptionDockWidget & > (heap);
+  const QStyleOptionDockWidget &arg1 = gsi::arg_reader<const QStyleOptionDockWidget & >() (args, heap);
   ret.write<QStyleOptionDockWidget *> (new QStyleOptionDockWidget (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionFocusRect.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionFocusRect.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionFocusRect_3466 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionFocusRect &arg1 = args.read<const QStyleOptionFocusRect & > (heap);
+  const QStyleOptionFocusRect &arg1 = gsi::arg_reader<const QStyleOptionFocusRect & >() (args, heap);
   ret.write<QStyleOptionFocusRect *> (new QStyleOptionFocusRect (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionFrame.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionFrame.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionFrame_3047 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionFrame &arg1 = args.read<const QStyleOptionFrame & > (heap);
+  const QStyleOptionFrame &arg1 = gsi::arg_reader<const QStyleOptionFrame & >() (args, heap);
   ret.write<QStyleOptionFrame *> (new QStyleOptionFrame (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionFrameV2.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionFrameV2.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionFrameV2_3183 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionFrameV2 &arg1 = args.read<const QStyleOptionFrameV2 & > (heap);
+  const QStyleOptionFrameV2 &arg1 = gsi::arg_reader<const QStyleOptionFrameV2 & >() (args, heap);
   ret.write<QStyleOptionFrameV2 *> (new QStyleOptionFrameV2 (arg1));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QStyleOptionFrameV2_3047 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionFrame &arg1 = args.read<const QStyleOptionFrame & > (heap);
+  const QStyleOptionFrame &arg1 = gsi::arg_reader<const QStyleOptionFrame & >() (args, heap);
   ret.write<QStyleOptionFrameV2 *> (new QStyleOptionFrameV2 (arg1));
 }
 
@@ -105,7 +105,7 @@ static void _call_f_operator_eq__3047 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionFrame &arg1 = args.read<const QStyleOptionFrame & > (heap);
+  const QStyleOptionFrame &arg1 = gsi::arg_reader<const QStyleOptionFrame & >() (args, heap);
   ret.write<QStyleOptionFrameV2 & > ((QStyleOptionFrameV2 &)((QStyleOptionFrameV2 *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionFrameV3.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionFrameV3.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionFrameV3_3184 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionFrameV3 &arg1 = args.read<const QStyleOptionFrameV3 & > (heap);
+  const QStyleOptionFrameV3 &arg1 = gsi::arg_reader<const QStyleOptionFrameV3 & >() (args, heap);
   ret.write<QStyleOptionFrameV3 *> (new QStyleOptionFrameV3 (arg1));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QStyleOptionFrameV3_3047 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionFrame &arg1 = args.read<const QStyleOptionFrame & > (heap);
+  const QStyleOptionFrame &arg1 = gsi::arg_reader<const QStyleOptionFrame & >() (args, heap);
   ret.write<QStyleOptionFrameV3 *> (new QStyleOptionFrameV3 (arg1));
 }
 
@@ -105,7 +105,7 @@ static void _call_f_operator_eq__3047 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionFrame &arg1 = args.read<const QStyleOptionFrame & > (heap);
+  const QStyleOptionFrame &arg1 = gsi::arg_reader<const QStyleOptionFrame & >() (args, heap);
   ret.write<QStyleOptionFrameV3 & > ((QStyleOptionFrameV3 &)((QStyleOptionFrameV3 *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionGraphicsItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionGraphicsItem.cc
@@ -68,7 +68,7 @@ static void _call_ctor_QStyleOptionGraphicsItem_3772 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionGraphicsItem &arg1 = args.read<const QStyleOptionGraphicsItem & > (heap);
+  const QStyleOptionGraphicsItem &arg1 = gsi::arg_reader<const QStyleOptionGraphicsItem & >() (args, heap);
   ret.write<QStyleOptionGraphicsItem *> (new QStyleOptionGraphicsItem (arg1));
 }
 
@@ -87,7 +87,7 @@ static void _call_f_levelOfDetailFromTransform_2350 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<double > ((double)QStyleOptionGraphicsItem::levelOfDetailFromTransform (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionGroupBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionGroupBox.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionGroupBox_3378 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionGroupBox &arg1 = args.read<const QStyleOptionGroupBox & > (heap);
+  const QStyleOptionGroupBox &arg1 = gsi::arg_reader<const QStyleOptionGroupBox & >() (args, heap);
   ret.write<QStyleOptionGroupBox *> (new QStyleOptionGroupBox (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionHeader.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionHeader.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionHeader_3141 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionHeader &arg1 = args.read<const QStyleOptionHeader & > (heap);
+  const QStyleOptionHeader &arg1 = gsi::arg_reader<const QStyleOptionHeader & >() (args, heap);
   ret.write<QStyleOptionHeader *> (new QStyleOptionHeader (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionMenuItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionMenuItem.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionMenuItem_3360 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionMenuItem &arg1 = args.read<const QStyleOptionMenuItem & > (heap);
+  const QStyleOptionMenuItem &arg1 = gsi::arg_reader<const QStyleOptionMenuItem & >() (args, heap);
   ret.write<QStyleOptionMenuItem *> (new QStyleOptionMenuItem (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionProgressBar.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionProgressBar.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionProgressBar_3686 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionProgressBar &arg1 = args.read<const QStyleOptionProgressBar & > (heap);
+  const QStyleOptionProgressBar &arg1 = gsi::arg_reader<const QStyleOptionProgressBar & >() (args, heap);
   ret.write<QStyleOptionProgressBar *> (new QStyleOptionProgressBar (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionProgressBarV2.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionProgressBarV2.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionProgressBarV2_3686 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionProgressBar &arg1 = args.read<const QStyleOptionProgressBar & > (heap);
+  const QStyleOptionProgressBar &arg1 = gsi::arg_reader<const QStyleOptionProgressBar & >() (args, heap);
   ret.write<QStyleOptionProgressBarV2 *> (new QStyleOptionProgressBarV2 (arg1));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QStyleOptionProgressBarV2_3822 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionProgressBarV2 &arg1 = args.read<const QStyleOptionProgressBarV2 & > (heap);
+  const QStyleOptionProgressBarV2 &arg1 = gsi::arg_reader<const QStyleOptionProgressBarV2 & >() (args, heap);
   ret.write<QStyleOptionProgressBarV2 *> (new QStyleOptionProgressBarV2 (arg1));
 }
 
@@ -105,7 +105,7 @@ static void _call_f_operator_eq__3686 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionProgressBar &arg1 = args.read<const QStyleOptionProgressBar & > (heap);
+  const QStyleOptionProgressBar &arg1 = gsi::arg_reader<const QStyleOptionProgressBar & >() (args, heap);
   ret.write<QStyleOptionProgressBarV2 & > ((QStyleOptionProgressBarV2 &)((QStyleOptionProgressBarV2 *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionQ3DockWindow.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionQ3DockWindow.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionQ3DockWindow_3705 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionQ3DockWindow &arg1 = args.read<const QStyleOptionQ3DockWindow & > (heap);
+  const QStyleOptionQ3DockWindow &arg1 = gsi::arg_reader<const QStyleOptionQ3DockWindow & >() (args, heap);
   ret.write<QStyleOptionQ3DockWindow *> (new QStyleOptionQ3DockWindow (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionQ3ListView.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionQ3ListView.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionQ3ListView_3511 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionQ3ListView &arg1 = args.read<const QStyleOptionQ3ListView & > (heap);
+  const QStyleOptionQ3ListView &arg1 = gsi::arg_reader<const QStyleOptionQ3ListView & >() (args, heap);
   ret.write<QStyleOptionQ3ListView *> (new QStyleOptionQ3ListView (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionQ3ListViewItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionQ3ListViewItem.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionQ3ListViewItem_3910 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionQ3ListViewItem &arg1 = args.read<const QStyleOptionQ3ListViewItem & > (heap);
+  const QStyleOptionQ3ListViewItem &arg1 = gsi::arg_reader<const QStyleOptionQ3ListViewItem & >() (args, heap);
   ret.write<QStyleOptionQ3ListViewItem *> (new QStyleOptionQ3ListViewItem (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionRubberBand.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionRubberBand.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionRubberBand_3539 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionRubberBand &arg1 = args.read<const QStyleOptionRubberBand & > (heap);
+  const QStyleOptionRubberBand &arg1 = gsi::arg_reader<const QStyleOptionRubberBand & >() (args, heap);
   ret.write<QStyleOptionRubberBand *> (new QStyleOptionRubberBand (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionSizeGrip.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionSizeGrip.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionSizeGrip_3369 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionSizeGrip &arg1 = args.read<const QStyleOptionSizeGrip & > (heap);
+  const QStyleOptionSizeGrip &arg1 = gsi::arg_reader<const QStyleOptionSizeGrip & >() (args, heap);
   ret.write<QStyleOptionSizeGrip *> (new QStyleOptionSizeGrip (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionSlider.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionSlider.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionSlider_3167 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionSlider &arg1 = args.read<const QStyleOptionSlider & > (heap);
+  const QStyleOptionSlider &arg1 = gsi::arg_reader<const QStyleOptionSlider & >() (args, heap);
   ret.write<QStyleOptionSlider *> (new QStyleOptionSlider (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionSpinBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionSpinBox.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionSpinBox_3263 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionSpinBox &arg1 = args.read<const QStyleOptionSpinBox & > (heap);
+  const QStyleOptionSpinBox &arg1 = gsi::arg_reader<const QStyleOptionSpinBox & >() (args, heap);
   ret.write<QStyleOptionSpinBox *> (new QStyleOptionSpinBox (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTab.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTab.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionTab_2835 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTab &arg1 = args.read<const QStyleOptionTab & > (heap);
+  const QStyleOptionTab &arg1 = gsi::arg_reader<const QStyleOptionTab & >() (args, heap);
   ret.write<QStyleOptionTab *> (new QStyleOptionTab (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabBarBase.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabBarBase.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionTabBarBase_3491 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTabBarBase &arg1 = args.read<const QStyleOptionTabBarBase & > (heap);
+  const QStyleOptionTabBarBase &arg1 = gsi::arg_reader<const QStyleOptionTabBarBase & >() (args, heap);
   ret.write<QStyleOptionTabBarBase *> (new QStyleOptionTabBarBase (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabBarBaseV2.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabBarBaseV2.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionTabBarBaseV2_3627 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTabBarBaseV2 &arg1 = args.read<const QStyleOptionTabBarBaseV2 & > (heap);
+  const QStyleOptionTabBarBaseV2 &arg1 = gsi::arg_reader<const QStyleOptionTabBarBaseV2 & >() (args, heap);
   ret.write<QStyleOptionTabBarBaseV2 *> (new QStyleOptionTabBarBaseV2 (arg1));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QStyleOptionTabBarBaseV2_3491 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTabBarBase &arg1 = args.read<const QStyleOptionTabBarBase & > (heap);
+  const QStyleOptionTabBarBase &arg1 = gsi::arg_reader<const QStyleOptionTabBarBase & >() (args, heap);
   ret.write<QStyleOptionTabBarBaseV2 *> (new QStyleOptionTabBarBaseV2 (arg1));
 }
 
@@ -105,7 +105,7 @@ static void _call_f_operator_eq__3491 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTabBarBase &arg1 = args.read<const QStyleOptionTabBarBase & > (heap);
+  const QStyleOptionTabBarBase &arg1 = gsi::arg_reader<const QStyleOptionTabBarBase & >() (args, heap);
   ret.write<QStyleOptionTabBarBaseV2 & > ((QStyleOptionTabBarBaseV2 &)((QStyleOptionTabBarBaseV2 *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabV2.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabV2.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionTabV2_2971 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTabV2 &arg1 = args.read<const QStyleOptionTabV2 & > (heap);
+  const QStyleOptionTabV2 &arg1 = gsi::arg_reader<const QStyleOptionTabV2 & >() (args, heap);
   ret.write<QStyleOptionTabV2 *> (new QStyleOptionTabV2 (arg1));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QStyleOptionTabV2_2835 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTab &arg1 = args.read<const QStyleOptionTab & > (heap);
+  const QStyleOptionTab &arg1 = gsi::arg_reader<const QStyleOptionTab & >() (args, heap);
   ret.write<QStyleOptionTabV2 *> (new QStyleOptionTabV2 (arg1));
 }
 
@@ -105,7 +105,7 @@ static void _call_f_operator_eq__2835 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTab &arg1 = args.read<const QStyleOptionTab & > (heap);
+  const QStyleOptionTab &arg1 = gsi::arg_reader<const QStyleOptionTab & >() (args, heap);
   ret.write<QStyleOptionTabV2 & > ((QStyleOptionTabV2 &)((QStyleOptionTabV2 *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabV3.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabV3.cc
@@ -68,7 +68,7 @@ static void _call_ctor_QStyleOptionTabV3_2972 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTabV3 &arg1 = args.read<const QStyleOptionTabV3 & > (heap);
+  const QStyleOptionTabV3 &arg1 = gsi::arg_reader<const QStyleOptionTabV3 & >() (args, heap);
   ret.write<QStyleOptionTabV3 *> (new QStyleOptionTabV3 (arg1));
 }
 
@@ -87,7 +87,7 @@ static void _call_ctor_QStyleOptionTabV3_2971 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTabV2 &arg1 = args.read<const QStyleOptionTabV2 & > (heap);
+  const QStyleOptionTabV2 &arg1 = gsi::arg_reader<const QStyleOptionTabV2 & >() (args, heap);
   ret.write<QStyleOptionTabV3 *> (new QStyleOptionTabV3 (arg1));
 }
 
@@ -106,7 +106,7 @@ static void _call_ctor_QStyleOptionTabV3_2835 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTab &arg1 = args.read<const QStyleOptionTab & > (heap);
+  const QStyleOptionTab &arg1 = gsi::arg_reader<const QStyleOptionTab & >() (args, heap);
   ret.write<QStyleOptionTabV3 *> (new QStyleOptionTabV3 (arg1));
 }
 
@@ -125,7 +125,7 @@ static void _call_f_operator_eq__2835 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTab &arg1 = args.read<const QStyleOptionTab & > (heap);
+  const QStyleOptionTab &arg1 = gsi::arg_reader<const QStyleOptionTab & >() (args, heap);
   ret.write<QStyleOptionTabV3 & > ((QStyleOptionTabV3 &)((QStyleOptionTabV3 *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabWidgetFrame.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTabWidgetFrame.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionTabWidgetFrame_3938 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTabWidgetFrame &arg1 = args.read<const QStyleOptionTabWidgetFrame & > (heap);
+  const QStyleOptionTabWidgetFrame &arg1 = gsi::arg_reader<const QStyleOptionTabWidgetFrame & >() (args, heap);
   ret.write<QStyleOptionTabWidgetFrame *> (new QStyleOptionTabWidgetFrame (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTitleBar.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionTitleBar.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionTitleBar_3347 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionTitleBar &arg1 = args.read<const QStyleOptionTitleBar & > (heap);
+  const QStyleOptionTitleBar &arg1 = gsi::arg_reader<const QStyleOptionTitleBar & >() (args, heap);
   ret.write<QStyleOptionTitleBar *> (new QStyleOptionTitleBar (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionToolBar.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionToolBar.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionToolBar_3247 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionToolBar &arg1 = args.read<const QStyleOptionToolBar & > (heap);
+  const QStyleOptionToolBar &arg1 = gsi::arg_reader<const QStyleOptionToolBar & >() (args, heap);
   ret.write<QStyleOptionToolBar *> (new QStyleOptionToolBar (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionToolBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionToolBox.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionToolBox_3267 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionToolBox &arg1 = args.read<const QStyleOptionToolBox & > (heap);
+  const QStyleOptionToolBox &arg1 = gsi::arg_reader<const QStyleOptionToolBox & >() (args, heap);
   ret.write<QStyleOptionToolBox *> (new QStyleOptionToolBox (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionToolBoxV2.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionToolBoxV2.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionToolBoxV2_3403 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionToolBoxV2 &arg1 = args.read<const QStyleOptionToolBoxV2 & > (heap);
+  const QStyleOptionToolBoxV2 &arg1 = gsi::arg_reader<const QStyleOptionToolBoxV2 & >() (args, heap);
   ret.write<QStyleOptionToolBoxV2 *> (new QStyleOptionToolBoxV2 (arg1));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QStyleOptionToolBoxV2_3267 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionToolBox &arg1 = args.read<const QStyleOptionToolBox & > (heap);
+  const QStyleOptionToolBox &arg1 = gsi::arg_reader<const QStyleOptionToolBox & >() (args, heap);
   ret.write<QStyleOptionToolBoxV2 *> (new QStyleOptionToolBoxV2 (arg1));
 }
 
@@ -105,7 +105,7 @@ static void _call_f_operator_eq__3267 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionToolBox &arg1 = args.read<const QStyleOptionToolBox & > (heap);
+  const QStyleOptionToolBox &arg1 = gsi::arg_reader<const QStyleOptionToolBox & >() (args, heap);
   ret.write<QStyleOptionToolBoxV2 & > ((QStyleOptionToolBoxV2 &)((QStyleOptionToolBoxV2 *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionToolButton.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionToolButton.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionToolButton_3606 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionToolButton &arg1 = args.read<const QStyleOptionToolButton & > (heap);
+  const QStyleOptionToolButton &arg1 = gsi::arg_reader<const QStyleOptionToolButton & >() (args, heap);
   ret.write<QStyleOptionToolButton *> (new QStyleOptionToolButton (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionViewItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionViewItem.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionViewItem_3366 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
   ret.write<QStyleOptionViewItem *> (new QStyleOptionViewItem (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionViewItemV2.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionViewItemV2.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QStyleOptionViewItemV2_3502 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItemV2 &arg1 = args.read<const QStyleOptionViewItemV2 & > (heap);
+  const QStyleOptionViewItemV2 &arg1 = gsi::arg_reader<const QStyleOptionViewItemV2 & >() (args, heap);
   ret.write<QStyleOptionViewItemV2 *> (new QStyleOptionViewItemV2 (arg1));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QStyleOptionViewItemV2_3366 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
   ret.write<QStyleOptionViewItemV2 *> (new QStyleOptionViewItemV2 (arg1));
 }
 
@@ -105,7 +105,7 @@ static void _call_f_operator_eq__3366 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
   ret.write<QStyleOptionViewItemV2 & > ((QStyleOptionViewItemV2 &)((QStyleOptionViewItemV2 *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionViewItemV3.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionViewItemV3.cc
@@ -68,7 +68,7 @@ static void _call_ctor_QStyleOptionViewItemV3_3503 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItemV3 &arg1 = args.read<const QStyleOptionViewItemV3 & > (heap);
+  const QStyleOptionViewItemV3 &arg1 = gsi::arg_reader<const QStyleOptionViewItemV3 & >() (args, heap);
   ret.write<QStyleOptionViewItemV3 *> (new QStyleOptionViewItemV3 (arg1));
 }
 
@@ -87,7 +87,7 @@ static void _call_ctor_QStyleOptionViewItemV3_3366 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
   ret.write<QStyleOptionViewItemV3 *> (new QStyleOptionViewItemV3 (arg1));
 }
 
@@ -106,7 +106,7 @@ static void _call_f_operator_eq__3366 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
   ret.write<QStyleOptionViewItemV3 & > ((QStyleOptionViewItemV3 &)((QStyleOptionViewItemV3 *)cls)->operator = (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionViewItemV4.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyleOptionViewItemV4.cc
@@ -68,7 +68,7 @@ static void _call_ctor_QStyleOptionViewItemV4_3504 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItemV4 &arg1 = args.read<const QStyleOptionViewItemV4 & > (heap);
+  const QStyleOptionViewItemV4 &arg1 = gsi::arg_reader<const QStyleOptionViewItemV4 & >() (args, heap);
   ret.write<QStyleOptionViewItemV4 *> (new QStyleOptionViewItemV4 (arg1));
 }
 
@@ -87,7 +87,7 @@ static void _call_ctor_QStyleOptionViewItemV4_3366 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
   ret.write<QStyleOptionViewItemV4 *> (new QStyleOptionViewItemV4 (arg1));
 }
 
@@ -106,7 +106,7 @@ static void _call_f_operator_eq__3366 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
   ret.write<QStyleOptionViewItemV4 & > ((QStyleOptionViewItemV4 &)((QStyleOptionViewItemV4 *)cls)->operator = (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStylePainter.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStylePainter.cc
@@ -95,7 +95,7 @@ static void _call_ctor_QStylePainter_1315 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QStylePainter *> (new QStylePainter (arg1));
 }
 
@@ -116,8 +116,8 @@ static void _call_ctor_QStylePainter_3010 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPaintDevice *arg1 = args.read<QPaintDevice * > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  QPaintDevice *arg1 = gsi::arg_reader<QPaintDevice * >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QStylePainter *> (new QStylePainter (arg1, arg2));
 }
 
@@ -136,7 +136,7 @@ static void _call_f_begin_1315 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<bool > ((bool)((QStylePainter *)cls)->begin (arg1));
 }
 
@@ -157,8 +157,8 @@ static void _call_f_begin_3010 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPaintDevice *arg1 = args.read<QPaintDevice * > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  QPaintDevice *arg1 = gsi::arg_reader<QPaintDevice * >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<bool > ((bool)((QStylePainter *)cls)->begin (arg1, arg2));
 }
 
@@ -179,8 +179,8 @@ static void _call_f_drawComplexControl_5803 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex &arg2 = args.read<const QStyleOptionComplex & > (heap);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex &arg2 = gsi::arg_reader<const QStyleOptionComplex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStylePainter *)cls)->drawComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2);
 }
@@ -202,8 +202,8 @@ static void _call_f_drawControl_5061 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ControlElement>::target_type & > (heap);
-  const QStyleOption &arg2 = args.read<const QStyleOption & > (heap);
+  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ControlElement>::target_type & >() (args, heap);
+  const QStyleOption &arg2 = gsi::arg_reader<const QStyleOption & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStylePainter *)cls)->drawControl (qt_gsi::QtToCppAdaptor<QStyle::ControlElement>(arg1).cref(), arg2);
 }
@@ -227,9 +227,9 @@ static void _call_f_drawItemPixmap_4360 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QPixmap &arg3 = args.read<const QPixmap & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QPixmap &arg3 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStylePainter *)cls)->drawItemPixmap (arg1, arg2, arg3);
 }
@@ -259,12 +259,12 @@ static void _call_f_drawItemText_9286 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QPalette &arg3 = args.read<const QPalette & > (heap);
-  bool arg4 = args.read<bool > (heap);
-  const QString &arg5 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg6 = args ? args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap) : (const qt_gsi::Converter<QPalette::ColorRole>::target_type &)(qt_gsi::CppToQtReadAdaptor<QPalette::ColorRole>(heap, QPalette::NoRole));
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QPalette &arg3 = gsi::arg_reader<const QPalette & >() (args, heap);
+  bool arg4 = gsi::arg_reader<bool >() (args, heap);
+  const QString &arg5 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg6 = args ? gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QPalette::ColorRole>(heap, QPalette::NoRole), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStylePainter *)cls)->drawItemText (arg1, arg2, arg3, arg4, arg5, qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg6).cref());
 }
@@ -286,8 +286,8 @@ static void _call_f_drawPrimitive_5277 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & > (heap);
-  const QStyleOption &arg2 = args.read<const QStyleOption & > (heap);
+  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & >() (args, heap);
+  const QStyleOption &arg2 = gsi::arg_reader<const QStyleOption & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStylePainter *)cls)->drawPrimitive (qt_gsi::QtToCppAdaptor<QStyle::PrimitiveElement>(arg1).cref(), arg2);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStylePlugin.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStylePlugin.cc
@@ -69,7 +69,7 @@ static void _call_f_create_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStyle * > ((QStyle *)((QStylePlugin *)cls)->create (arg1));
 }
 
@@ -105,8 +105,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStylePlugin::tr (arg1, arg2));
 }
 
@@ -129,9 +129,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStylePlugin::tr (arg1, arg2, arg3));
 }
 
@@ -152,8 +152,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStylePlugin::trUtf8 (arg1, arg2));
 }
 
@@ -176,9 +176,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStylePlugin::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -390,7 +390,7 @@ static void _call_ctor_QStylePlugin_Adaptor_1302 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QStylePlugin_Adaptor *> (new QStylePlugin_Adaptor (arg1));
 }
 
@@ -479,7 +479,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QStylePlugin_Adaptor *)cls)->emitter_QStylePlugin_destroyed_1302 (arg1);
 }
 
@@ -589,7 +589,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QStylePlugin_Adaptor *)cls)->fp_QStylePlugin_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQStyledItemDelegate.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQStyledItemDelegate.cc
@@ -83,9 +83,9 @@ static void _call_f_createEditor_c6860 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QStyledItemDelegate *)cls)->createEditor (arg1, arg2, arg3));
 }
 
@@ -106,8 +106,8 @@ static void _call_f_displayText_c3997 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
-  const QLocale &arg2 = args.read<const QLocale & > (heap);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
+  const QLocale &arg2 = gsi::arg_reader<const QLocale & >() (args, heap);
   ret.write<QString > ((QString)((QStyledItemDelegate *)cls)->displayText (arg1, arg2));
 }
 
@@ -145,9 +145,9 @@ static void _call_f_paint_c6971 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyledItemDelegate *)cls)->paint (arg1, arg2, arg3);
 }
@@ -169,8 +169,8 @@ static void _call_f_setEditorData_c3602 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyledItemDelegate *)cls)->setEditorData (arg1, arg2);
 }
@@ -190,7 +190,7 @@ static void _call_f_setItemEditorFactory_2445 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QItemEditorFactory *arg1 = args.read<QItemEditorFactory * > (heap);
+  QItemEditorFactory *arg1 = gsi::arg_reader<QItemEditorFactory * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyledItemDelegate *)cls)->setItemEditorFactory (arg1);
 }
@@ -214,9 +214,9 @@ static void _call_f_setModelData_c5913 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QAbstractItemModel *arg2 = args.read<QAbstractItemModel * > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QAbstractItemModel *arg2 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyledItemDelegate *)cls)->setModelData (arg1, arg2, arg3);
 }
@@ -238,8 +238,8 @@ static void _call_f_sizeHint_c5653 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStyleOptionViewItem &arg1 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QStyleOptionViewItem &arg1 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QSize > ((QSize)((QStyledItemDelegate *)cls)->sizeHint (arg1, arg2));
 }
 
@@ -262,9 +262,9 @@ static void _call_f_updateEditorGeometry_c6860 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QStyleOptionViewItem &arg2 = args.read<const QStyleOptionViewItem & > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QStyleOptionViewItem &arg2 = gsi::arg_reader<const QStyleOptionViewItem & >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QStyledItemDelegate *)cls)->updateEditorGeometry (arg1, arg2, arg3);
 }
@@ -286,8 +286,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStyledItemDelegate::tr (arg1, arg2));
 }
 
@@ -310,9 +310,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStyledItemDelegate::tr (arg1, arg2, arg3));
 }
 
@@ -333,8 +333,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QStyledItemDelegate::trUtf8 (arg1, arg2));
 }
 
@@ -357,9 +357,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QStyledItemDelegate::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -710,7 +710,7 @@ static void _call_ctor_QStyledItemDelegate_Adaptor_1302 (const qt_gsi::GenericSt
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QStyledItemDelegate_Adaptor *> (new QStyledItemDelegate_Adaptor (arg1));
 }
 
@@ -754,8 +754,8 @@ static void _call_emitter_closeEditor_4926 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemDelegate::EndEditHint>(heap, QAbstractItemDelegate::NoHint));
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemDelegate::EndEditHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemDelegate::EndEditHint>(heap, QAbstractItemDelegate::NoHint), heap);
   ((QStyledItemDelegate_Adaptor *)cls)->emitter_QStyledItemDelegate_closeEditor_4926 (arg1, arg2);
 }
 
@@ -773,7 +773,7 @@ static void _call_emitter_commitData_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ((QStyledItemDelegate_Adaptor *)cls)->emitter_QStyledItemDelegate_commitData_1315 (arg1);
 }
 
@@ -844,7 +844,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QStyledItemDelegate_Adaptor *)cls)->emitter_QStyledItemDelegate_destroyed_1302 (arg1);
 }
 
@@ -1050,7 +1050,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QStyledItemDelegate_Adaptor *)cls)->fp_QStyledItemDelegate_receivers_c1731 (arg1));
 }
 
@@ -1165,7 +1165,7 @@ static void _call_emitter_sizeHintChanged_2395 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QStyledItemDelegate_Adaptor *)cls)->emitter_QStyledItemDelegate_sizeHintChanged_2395 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSwipeGesture.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSwipeGesture.cc
@@ -84,7 +84,7 @@ static void _call_f_setSwipeAngle_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSwipeGesture *)cls)->setSwipeAngle (arg1);
 }
@@ -136,8 +136,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSwipeGesture::tr (arg1, arg2));
 }
 
@@ -160,9 +160,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSwipeGesture::tr (arg1, arg2, arg3));
 }
 
@@ -183,8 +183,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSwipeGesture::trUtf8 (arg1, arg2));
 }
 
@@ -207,9 +207,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSwipeGesture::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -390,7 +390,7 @@ static void _call_ctor_QSwipeGesture_Adaptor_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSwipeGesture_Adaptor *> (new QSwipeGesture_Adaptor (arg1));
 }
 
@@ -456,7 +456,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSwipeGesture_Adaptor *)cls)->emitter_QSwipeGesture_destroyed_1302 (arg1);
 }
 
@@ -547,7 +547,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSwipeGesture_Adaptor *)cls)->fp_QSwipeGesture_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSyntaxHighlighter.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSyntaxHighlighter.cc
@@ -106,7 +106,7 @@ static void _call_f_rehighlightBlock_2306 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSyntaxHighlighter *)cls)->rehighlightBlock (arg1);
 }
@@ -126,7 +126,7 @@ static void _call_f_setDocument_1955 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSyntaxHighlighter *)cls)->setDocument (arg1);
 }
@@ -148,8 +148,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSyntaxHighlighter::tr (arg1, arg2));
 }
 
@@ -172,9 +172,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSyntaxHighlighter::tr (arg1, arg2, arg3));
 }
 
@@ -195,8 +195,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSyntaxHighlighter::trUtf8 (arg1, arg2));
 }
 
@@ -219,9 +219,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSyntaxHighlighter::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -475,7 +475,7 @@ static void _call_ctor_QSyntaxHighlighter_Adaptor_1302 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QSyntaxHighlighter_Adaptor *> (new QSyntaxHighlighter_Adaptor (arg1));
 }
 
@@ -493,7 +493,7 @@ static void _call_ctor_QSyntaxHighlighter_Adaptor_1955 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   ret.write<QSyntaxHighlighter_Adaptor *> (new QSyntaxHighlighter_Adaptor (arg1));
 }
 
@@ -511,7 +511,7 @@ static void _call_ctor_QSyntaxHighlighter_Adaptor_1514 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextEdit *arg1 = args.read<QTextEdit * > (heap);
+  QTextEdit *arg1 = gsi::arg_reader<QTextEdit * >() (args, heap);
   ret.write<QSyntaxHighlighter_Adaptor *> (new QSyntaxHighlighter_Adaptor (arg1));
 }
 
@@ -619,7 +619,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSyntaxHighlighter_Adaptor *)cls)->emitter_QSyntaxHighlighter_destroyed_1302 (arg1);
 }
 
@@ -710,7 +710,7 @@ static void _call_fp_format_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextCharFormat > ((QTextCharFormat)((QSyntaxHighlighter_Adaptor *)cls)->fp_QSyntaxHighlighter_format_c767 (arg1));
 }
 
@@ -766,7 +766,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSyntaxHighlighter_Adaptor *)cls)->fp_QSyntaxHighlighter_receivers_c1731 (arg1));
 }
 
@@ -798,7 +798,7 @@ static void _call_fp_setCurrentBlockState_767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSyntaxHighlighter_Adaptor *)cls)->fp_QSyntaxHighlighter_setCurrentBlockState_767 (arg1);
 }
@@ -817,7 +817,7 @@ static void _call_fp_setCurrentBlockUserData_2408 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextBlockUserData *arg1 = args.read<QTextBlockUserData * > (heap);
+  QTextBlockUserData *arg1 = gsi::arg_reader<QTextBlockUserData * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSyntaxHighlighter_Adaptor *)cls)->fp_QSyntaxHighlighter_setCurrentBlockUserData_2408 (arg1);
 }
@@ -840,9 +840,9 @@ static void _call_fp_setFormat_4132 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QTextCharFormat &arg3 = args.read<const QTextCharFormat & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QTextCharFormat &arg3 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSyntaxHighlighter_Adaptor *)cls)->fp_QSyntaxHighlighter_setFormat_4132 (arg1, arg2, arg3);
 }
@@ -865,9 +865,9 @@ static void _call_fp_setFormat_3223 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QColor &arg3 = args.read<const QColor & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QColor &arg3 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSyntaxHighlighter_Adaptor *)cls)->fp_QSyntaxHighlighter_setFormat_3223 (arg1, arg2, arg3);
 }
@@ -890,9 +890,9 @@ static void _call_fp_setFormat_3119 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QFont &arg3 = args.read<const QFont & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QFont &arg3 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSyntaxHighlighter_Adaptor *)cls)->fp_QSyntaxHighlighter_setFormat_3119 (arg1, arg2, arg3);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQSystemTrayIcon.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQSystemTrayIcon.cc
@@ -147,7 +147,7 @@ static void _call_f_setContextMenu_1108 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMenu *arg1 = args.read<QMenu * > (heap);
+  QMenu *arg1 = gsi::arg_reader<QMenu * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSystemTrayIcon *)cls)->setContextMenu (arg1);
 }
@@ -167,7 +167,7 @@ static void _call_f_setIcon_1787 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSystemTrayIcon *)cls)->setIcon (arg1);
 }
@@ -187,7 +187,7 @@ static void _call_f_setToolTip_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSystemTrayIcon *)cls)->setToolTip (arg1);
 }
@@ -207,7 +207,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSystemTrayIcon *)cls)->setVisible (arg1);
 }
@@ -249,10 +249,10 @@ static void _call_f_showMessage_7682 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSystemTrayIcon::MessageIcon>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QSystemTrayIcon::MessageIcon>::target_type & > (heap) : (const qt_gsi::Converter<QSystemTrayIcon::MessageIcon>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSystemTrayIcon::MessageIcon>(heap, QSystemTrayIcon::Information));
-  int arg4 = args ? args.read<int > (heap) : (int)(10000);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSystemTrayIcon::MessageIcon>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QSystemTrayIcon::MessageIcon>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSystemTrayIcon::MessageIcon>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSystemTrayIcon::MessageIcon>(heap, QSystemTrayIcon::Information), heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (10000, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSystemTrayIcon *)cls)->showMessage (arg1, arg2, qt_gsi::QtToCppAdaptor<QSystemTrayIcon::MessageIcon>(arg3).cref(), arg4);
 }
@@ -319,8 +319,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSystemTrayIcon::tr (arg1, arg2));
 }
 
@@ -343,9 +343,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSystemTrayIcon::tr (arg1, arg2, arg3));
 }
 
@@ -366,8 +366,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSystemTrayIcon::trUtf8 (arg1, arg2));
 }
 
@@ -390,9 +390,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSystemTrayIcon::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -609,7 +609,7 @@ static void _call_ctor_QSystemTrayIcon_Adaptor_1302 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSystemTrayIcon_Adaptor *> (new QSystemTrayIcon_Adaptor (arg1));
 }
 
@@ -629,8 +629,8 @@ static void _call_ctor_QSystemTrayIcon_Adaptor_2981 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSystemTrayIcon_Adaptor *> (new QSystemTrayIcon_Adaptor (arg1, arg2));
 }
 
@@ -648,7 +648,7 @@ static void _call_emitter_activated_3745 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSystemTrayIcon::ActivationReason>::target_type & arg1 = args.read<const qt_gsi::Converter<QSystemTrayIcon::ActivationReason>::target_type & > (heap);
+  const qt_gsi::Converter<QSystemTrayIcon::ActivationReason>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSystemTrayIcon::ActivationReason>::target_type & >() (args, heap);
   ((QSystemTrayIcon_Adaptor *)cls)->emitter_QSystemTrayIcon_activated_3745 (arg1);
 }
 
@@ -714,7 +714,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSystemTrayIcon_Adaptor *)cls)->emitter_QSystemTrayIcon_destroyed_1302 (arg1);
 }
 
@@ -819,7 +819,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSystemTrayIcon_Adaptor *)cls)->fp_QSystemTrayIcon_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTabBar.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTabBar.cc
@@ -113,7 +113,7 @@ static void _call_f_addTab_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QTabBar *)cls)->addTab (arg1));
 }
 
@@ -134,8 +134,8 @@ static void _call_f_addTab_3704 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QTabBar *)cls)->addTab (arg1, arg2));
 }
 
@@ -261,8 +261,8 @@ static void _call_f_insertTab_2684 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QTabBar *)cls)->insertTab (arg1, arg2));
 }
 
@@ -285,9 +285,9 @@ static void _call_f_insertTab_4363 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QIcon &arg2 = args.read<const QIcon & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QIcon &arg2 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QTabBar *)cls)->insertTab (arg1, arg2, arg3));
 }
 
@@ -321,7 +321,7 @@ static void _call_f_isTabEnabled_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTabBar *)cls)->isTabEnabled (arg1));
 }
 
@@ -357,8 +357,8 @@ static void _call_f_moveTab_1426 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->moveTab (arg1, arg2);
 }
@@ -378,7 +378,7 @@ static void _call_f_removeTab_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->removeTab (arg1);
 }
@@ -413,7 +413,7 @@ static void _call_f_setCurrentIndex_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setCurrentIndex (arg1);
 }
@@ -433,7 +433,7 @@ static void _call_f_setDocumentMode_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setDocumentMode (arg1);
 }
@@ -453,7 +453,7 @@ static void _call_f_setDrawBase_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setDrawBase (arg1);
 }
@@ -473,7 +473,7 @@ static void _call_f_setElideMode_2042 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TextElideMode>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextElideMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setElideMode (qt_gsi::QtToCppAdaptor<Qt::TextElideMode>(arg1).cref());
 }
@@ -493,7 +493,7 @@ static void _call_f_setExpanding_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setExpanding (arg1);
 }
@@ -513,7 +513,7 @@ static void _call_f_setIconSize_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setIconSize (arg1);
 }
@@ -533,7 +533,7 @@ static void _call_f_setMovable_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setMovable (arg1);
 }
@@ -553,7 +553,7 @@ static void _call_f_setSelectionBehaviorOnRemove_2939 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTabBar::SelectionBehavior>::target_type & arg1 = args.read<const qt_gsi::Converter<QTabBar::SelectionBehavior>::target_type & > (heap);
+  const qt_gsi::Converter<QTabBar::SelectionBehavior>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTabBar::SelectionBehavior>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setSelectionBehaviorOnRemove (qt_gsi::QtToCppAdaptor<QTabBar::SelectionBehavior>(arg1).cref());
 }
@@ -573,7 +573,7 @@ static void _call_f_setShape_1686 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTabBar::Shape>::target_type & arg1 = args.read<const qt_gsi::Converter<QTabBar::Shape>::target_type & > (heap);
+  const qt_gsi::Converter<QTabBar::Shape>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTabBar::Shape>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setShape (qt_gsi::QtToCppAdaptor<QTabBar::Shape>(arg1).cref());
 }
@@ -597,9 +597,9 @@ static void _call_f_setTabButton_4544 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QTabBar::ButtonPosition>::target_type & arg2 = args.read<const qt_gsi::Converter<QTabBar::ButtonPosition>::target_type & > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QTabBar::ButtonPosition>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QTabBar::ButtonPosition>::target_type & >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setTabButton (arg1, qt_gsi::QtToCppAdaptor<QTabBar::ButtonPosition>(arg2).cref(), arg3);
 }
@@ -621,8 +621,8 @@ static void _call_f_setTabData_2778 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setTabData (arg1, arg2);
 }
@@ -644,8 +644,8 @@ static void _call_f_setTabEnabled_1523 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setTabEnabled (arg1, arg2);
 }
@@ -667,8 +667,8 @@ static void _call_f_setTabIcon_2446 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QIcon &arg2 = args.read<const QIcon & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QIcon &arg2 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setTabIcon (arg1, arg2);
 }
@@ -690,8 +690,8 @@ static void _call_f_setTabText_2684 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setTabText (arg1, arg2);
 }
@@ -713,8 +713,8 @@ static void _call_f_setTabTextColor_2564 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QColor &arg2 = args.read<const QColor & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QColor &arg2 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setTabTextColor (arg1, arg2);
 }
@@ -736,8 +736,8 @@ static void _call_f_setTabToolTip_2684 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setTabToolTip (arg1, arg2);
 }
@@ -759,8 +759,8 @@ static void _call_f_setTabWhatsThis_2684 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setTabWhatsThis (arg1, arg2);
 }
@@ -780,7 +780,7 @@ static void _call_f_setTabsClosable_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setTabsClosable (arg1);
 }
@@ -800,7 +800,7 @@ static void _call_f_setUsesScrollButtons_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar *)cls)->setUsesScrollButtons (arg1);
 }
@@ -850,7 +850,7 @@ static void _call_f_tabAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<int > ((int)((QTabBar *)cls)->tabAt (arg1));
 }
 
@@ -871,8 +871,8 @@ static void _call_f_tabButton_c3337 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QTabBar::ButtonPosition>::target_type & arg2 = args.read<const qt_gsi::Converter<QTabBar::ButtonPosition>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QTabBar::ButtonPosition>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QTabBar::ButtonPosition>::target_type & >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QTabBar *)cls)->tabButton (arg1, qt_gsi::QtToCppAdaptor<QTabBar::ButtonPosition>(arg2).cref()));
 }
 
@@ -891,7 +891,7 @@ static void _call_f_tabData_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QTabBar *)cls)->tabData (arg1));
 }
 
@@ -910,7 +910,7 @@ static void _call_f_tabIcon_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QIcon > ((QIcon)((QTabBar *)cls)->tabIcon (arg1));
 }
 
@@ -929,7 +929,7 @@ static void _call_f_tabRect_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QRect > ((QRect)((QTabBar *)cls)->tabRect (arg1));
 }
 
@@ -948,7 +948,7 @@ static void _call_f_tabText_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTabBar *)cls)->tabText (arg1));
 }
 
@@ -967,7 +967,7 @@ static void _call_f_tabTextColor_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QColor > ((QColor)((QTabBar *)cls)->tabTextColor (arg1));
 }
 
@@ -986,7 +986,7 @@ static void _call_f_tabToolTip_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTabBar *)cls)->tabToolTip (arg1));
 }
 
@@ -1005,7 +1005,7 @@ static void _call_f_tabWhatsThis_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTabBar *)cls)->tabWhatsThis (arg1));
 }
 
@@ -1056,8 +1056,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTabBar::tr (arg1, arg2));
 }
 
@@ -1080,9 +1080,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTabBar::tr (arg1, arg2, arg3));
 }
 
@@ -1103,8 +1103,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTabBar::trUtf8 (arg1, arg2));
 }
 
@@ -1127,9 +1127,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTabBar::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2122,7 +2122,7 @@ static void _call_ctor_QTabBar_Adaptor_1315 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTabBar_Adaptor *> (new QTabBar_Adaptor (arg1));
 }
 
@@ -2264,9 +2264,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar_Adaptor *)cls)->fp_QTabBar_create_2208 (arg1, arg2, arg3);
 }
@@ -2285,7 +2285,7 @@ static void _call_emitter_currentChanged_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QTabBar_Adaptor *)cls)->emitter_QTabBar_currentChanged_767 (arg1);
 }
 
@@ -2303,7 +2303,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QTabBar_Adaptor *)cls)->emitter_QTabBar_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2347,8 +2347,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar_Adaptor *)cls)->fp_QTabBar_destroy_1620 (arg1, arg2);
 }
@@ -2367,7 +2367,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTabBar_Adaptor *)cls)->emitter_QTabBar_destroyed_1302 (arg1);
 }
 
@@ -2774,8 +2774,8 @@ static void _call_fp_initStyleOption_c2803 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionTab *arg1 = args.read<QStyleOptionTab * > (heap);
-  int arg2 = args.read<int > (heap);
+  QStyleOptionTab *arg1 = gsi::arg_reader<QStyleOptionTab * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabBar_Adaptor *)cls)->fp_QTabBar_initStyleOption_c2803 (arg1, arg2);
 }
@@ -3162,7 +3162,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTabBar_Adaptor *)cls)->fp_QTabBar_receivers_c1731 (arg1));
 }
 
@@ -3324,7 +3324,7 @@ static void _call_emitter_tabCloseRequested_767 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QTabBar_Adaptor *)cls)->emitter_QTabBar_tabCloseRequested_767 (arg1);
 }
 
@@ -3388,8 +3388,8 @@ static void _call_emitter_tabMoved_1426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTabBar_Adaptor *)cls)->emitter_QTabBar_tabMoved_1426 (arg1, arg2);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTabWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTabWidget.cc
@@ -115,8 +115,8 @@ static void _call_f_addTab_3232 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QTabWidget *)cls)->addTab (arg1, arg2));
 }
 
@@ -139,9 +139,9 @@ static void _call_f_addTab_4911 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QIcon &arg2 = args.read<const QIcon & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QIcon &arg2 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QTabWidget *)cls)->addTab (arg1, arg2, arg3));
 }
 
@@ -176,7 +176,7 @@ static void _call_f_cornerWidget_c1366 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<Qt::Corner>::target_type & > (heap) : (const qt_gsi::Converter<Qt::Corner>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::Corner>(heap, Qt::TopRightCorner));
+  const qt_gsi::Converter<Qt::Corner>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::Corner>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::Corner>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::Corner>(heap, Qt::TopRightCorner), heap);
   ret.write<QWidget * > ((QWidget *)((QTabWidget *)cls)->cornerWidget (qt_gsi::QtToCppAdaptor<Qt::Corner>(arg1).cref()));
 }
 
@@ -285,7 +285,7 @@ static void _call_f_indexOf_c1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QTabWidget *)cls)->indexOf (arg1));
 }
 
@@ -308,9 +308,9 @@ static void _call_f_insertTab_3891 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QTabWidget *)cls)->insertTab (arg1, arg2, arg3));
 }
 
@@ -335,10 +335,10 @@ static void _call_f_insertTab_5570 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  const QIcon &arg3 = args.read<const QIcon & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QIcon &arg3 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QTabWidget *)cls)->insertTab (arg1, arg2, arg3, arg4));
 }
 
@@ -372,7 +372,7 @@ static void _call_f_isTabEnabled_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTabWidget *)cls)->isTabEnabled (arg1));
 }
 
@@ -406,7 +406,7 @@ static void _call_f_removeTab_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->removeTab (arg1);
 }
@@ -428,8 +428,8 @@ static void _call_f_setCornerWidget_2573 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const qt_gsi::Converter<Qt::Corner>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::Corner>::target_type & > (heap) : (const qt_gsi::Converter<Qt::Corner>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::Corner>(heap, Qt::TopRightCorner));
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const qt_gsi::Converter<Qt::Corner>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::Corner>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::Corner>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::Corner>(heap, Qt::TopRightCorner), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setCornerWidget (arg1, qt_gsi::QtToCppAdaptor<Qt::Corner>(arg2).cref());
 }
@@ -449,7 +449,7 @@ static void _call_f_setCurrentIndex_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setCurrentIndex (arg1);
 }
@@ -469,7 +469,7 @@ static void _call_f_setCurrentWidget_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setCurrentWidget (arg1);
 }
@@ -489,7 +489,7 @@ static void _call_f_setDocumentMode_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setDocumentMode (arg1);
 }
@@ -509,7 +509,7 @@ static void _call_f_setElideMode_2042 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TextElideMode>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TextElideMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextElideMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setElideMode (qt_gsi::QtToCppAdaptor<Qt::TextElideMode>(arg1).cref());
 }
@@ -529,7 +529,7 @@ static void _call_f_setIconSize_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setIconSize (arg1);
 }
@@ -549,7 +549,7 @@ static void _call_f_setMovable_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setMovable (arg1);
 }
@@ -571,8 +571,8 @@ static void _call_f_setTabEnabled_1523 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setTabEnabled (arg1, arg2);
 }
@@ -594,8 +594,8 @@ static void _call_f_setTabIcon_2446 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QIcon &arg2 = args.read<const QIcon & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QIcon &arg2 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setTabIcon (arg1, arg2);
 }
@@ -615,7 +615,7 @@ static void _call_f_setTabPosition_2656 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & arg1 = args.read<const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & > (heap);
+  const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTabWidget::TabPosition>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setTabPosition (qt_gsi::QtToCppAdaptor<QTabWidget::TabPosition>(arg1).cref());
 }
@@ -635,7 +635,7 @@ static void _call_f_setTabShape_2300 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTabWidget::TabShape>::target_type & arg1 = args.read<const qt_gsi::Converter<QTabWidget::TabShape>::target_type & > (heap);
+  const qt_gsi::Converter<QTabWidget::TabShape>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTabWidget::TabShape>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setTabShape (qt_gsi::QtToCppAdaptor<QTabWidget::TabShape>(arg1).cref());
 }
@@ -657,8 +657,8 @@ static void _call_f_setTabText_2684 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setTabText (arg1, arg2);
 }
@@ -680,8 +680,8 @@ static void _call_f_setTabToolTip_2684 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setTabToolTip (arg1, arg2);
 }
@@ -703,8 +703,8 @@ static void _call_f_setTabWhatsThis_2684 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setTabWhatsThis (arg1, arg2);
 }
@@ -724,7 +724,7 @@ static void _call_f_setTabsClosable_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setTabsClosable (arg1);
 }
@@ -744,7 +744,7 @@ static void _call_f_setUsesScrollButtons_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget *)cls)->setUsesScrollButtons (arg1);
 }
@@ -779,7 +779,7 @@ static void _call_f_tabIcon_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QIcon > ((QIcon)((QTabWidget *)cls)->tabIcon (arg1));
 }
 
@@ -828,7 +828,7 @@ static void _call_f_tabText_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTabWidget *)cls)->tabText (arg1));
 }
 
@@ -847,7 +847,7 @@ static void _call_f_tabToolTip_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTabWidget *)cls)->tabToolTip (arg1));
 }
 
@@ -866,7 +866,7 @@ static void _call_f_tabWhatsThis_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTabWidget *)cls)->tabWhatsThis (arg1));
 }
 
@@ -915,7 +915,7 @@ static void _call_f_widget_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QTabWidget *)cls)->widget (arg1));
 }
 
@@ -936,8 +936,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTabWidget::tr (arg1, arg2));
 }
 
@@ -960,9 +960,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTabWidget::tr (arg1, arg2, arg3));
 }
 
@@ -983,8 +983,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTabWidget::trUtf8 (arg1, arg2));
 }
 
@@ -1007,9 +1007,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTabWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1967,7 +1967,7 @@ static void _call_ctor_QTabWidget_Adaptor_1315 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTabWidget_Adaptor *> (new QTabWidget_Adaptor (arg1));
 }
 
@@ -2109,9 +2109,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget_Adaptor *)cls)->fp_QTabWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -2130,7 +2130,7 @@ static void _call_emitter_currentChanged_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QTabWidget_Adaptor *)cls)->emitter_QTabWidget_currentChanged_767 (arg1);
 }
 
@@ -2148,7 +2148,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QTabWidget_Adaptor *)cls)->emitter_QTabWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2192,8 +2192,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget_Adaptor *)cls)->fp_QTabWidget_destroy_1620 (arg1, arg2);
 }
@@ -2212,7 +2212,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTabWidget_Adaptor *)cls)->emitter_QTabWidget_destroyed_1302 (arg1);
 }
 
@@ -2617,7 +2617,7 @@ static void _call_fp_initStyleOption_c3247 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionTabWidgetFrame *arg1 = args.read<QStyleOptionTabWidgetFrame * > (heap);
+  QStyleOptionTabWidgetFrame *arg1 = gsi::arg_reader<QStyleOptionTabWidgetFrame * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget_Adaptor *)cls)->fp_QTabWidget_initStyleOption_c3247 (arg1);
 }
@@ -3004,7 +3004,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTabWidget_Adaptor *)cls)->fp_QTabWidget_receivers_c1731 (arg1));
 }
 
@@ -3075,7 +3075,7 @@ static void _call_fp_setTabBar_1259 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTabBar *arg1 = args.read<QTabBar * > (heap);
+  QTabBar *arg1 = gsi::arg_reader<QTabBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTabWidget_Adaptor *)cls)->fp_QTabWidget_setTabBar_1259 (arg1);
 }
@@ -3199,7 +3199,7 @@ static void _call_emitter_tabCloseRequested_767 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QTabWidget_Adaptor *)cls)->emitter_QTabWidget_tabCloseRequested_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTableView.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTableView.cc
@@ -135,7 +135,7 @@ static void _call_f_columnAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableView *)cls)->columnAt (arg1));
 }
 
@@ -156,8 +156,8 @@ static void _call_f_columnSpan_c1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableView *)cls)->columnSpan (arg1, arg2));
 }
 
@@ -176,7 +176,7 @@ static void _call_f_columnViewportPosition_c767 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableView *)cls)->columnViewportPosition (arg1));
 }
 
@@ -195,7 +195,7 @@ static void _call_f_columnWidth_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableView *)cls)->columnWidth (arg1));
 }
 
@@ -229,7 +229,7 @@ static void _call_f_hideColumn_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->hideColumn (arg1);
 }
@@ -249,7 +249,7 @@ static void _call_f_hideRow_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->hideRow (arg1);
 }
@@ -284,7 +284,7 @@ static void _call_f_indexAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QTableView *)cls)->indexAt (arg1));
 }
 
@@ -303,7 +303,7 @@ static void _call_f_isColumnHidden_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTableView *)cls)->isColumnHidden (arg1));
 }
 
@@ -337,7 +337,7 @@ static void _call_f_isRowHidden_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTableView *)cls)->isRowHidden (arg1));
 }
 
@@ -371,7 +371,7 @@ static void _call_f_resizeColumnToContents_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->resizeColumnToContents (arg1);
 }
@@ -407,7 +407,7 @@ static void _call_f_resizeRowToContents_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->resizeRowToContents (arg1);
 }
@@ -443,7 +443,7 @@ static void _call_f_rowAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableView *)cls)->rowAt (arg1));
 }
 
@@ -462,7 +462,7 @@ static void _call_f_rowHeight_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableView *)cls)->rowHeight (arg1));
 }
 
@@ -483,8 +483,8 @@ static void _call_f_rowSpan_c1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableView *)cls)->rowSpan (arg1, arg2));
 }
 
@@ -503,7 +503,7 @@ static void _call_f_rowViewportPosition_c767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableView *)cls)->rowViewportPosition (arg1));
 }
 
@@ -524,8 +524,8 @@ static void _call_f_scrollTo_5576 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible));
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->scrollTo (arg1, qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollHint>(arg2).cref());
 }
@@ -545,7 +545,7 @@ static void _call_f_selectColumn_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->selectColumn (arg1);
 }
@@ -565,7 +565,7 @@ static void _call_f_selectRow_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->selectRow (arg1);
 }
@@ -587,8 +587,8 @@ static void _call_f_setColumnHidden_1523 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setColumnHidden (arg1, arg2);
 }
@@ -610,8 +610,8 @@ static void _call_f_setColumnWidth_1426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setColumnWidth (arg1, arg2);
 }
@@ -631,7 +631,7 @@ static void _call_f_setCornerButtonEnabled_864 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setCornerButtonEnabled (arg1);
 }
@@ -651,7 +651,7 @@ static void _call_f_setGridStyle_1569 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::PenStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::PenStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::PenStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setGridStyle (qt_gsi::QtToCppAdaptor<Qt::PenStyle>(arg1).cref());
 }
@@ -671,7 +671,7 @@ static void _call_f_setHorizontalHeader_1699 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QHeaderView *arg1 = args.read<QHeaderView * > (heap);
+  QHeaderView *arg1 = gsi::arg_reader<QHeaderView * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setHorizontalHeader (arg1);
 }
@@ -691,7 +691,7 @@ static void _call_f_setModel_2419 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setModel (arg1);
 }
@@ -711,7 +711,7 @@ static void _call_f_setRootIndex_2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setRootIndex (arg1);
 }
@@ -733,8 +733,8 @@ static void _call_f_setRowHeight_1426 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setRowHeight (arg1, arg2);
 }
@@ -756,8 +756,8 @@ static void _call_f_setRowHidden_1523 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setRowHidden (arg1, arg2);
 }
@@ -777,7 +777,7 @@ static void _call_f_setSelectionModel_2533 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QItemSelectionModel *arg1 = args.read<QItemSelectionModel * > (heap);
+  QItemSelectionModel *arg1 = gsi::arg_reader<QItemSelectionModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setSelectionModel (arg1);
 }
@@ -797,7 +797,7 @@ static void _call_f_setShowGrid_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setShowGrid (arg1);
 }
@@ -817,7 +817,7 @@ static void _call_f_setSortingEnabled_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setSortingEnabled (arg1);
 }
@@ -843,10 +843,10 @@ static void _call_f_setSpan_2744 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setSpan (arg1, arg2, arg3, arg4);
 }
@@ -866,7 +866,7 @@ static void _call_f_setVerticalHeader_1699 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QHeaderView *arg1 = args.read<QHeaderView * > (heap);
+  QHeaderView *arg1 = gsi::arg_reader<QHeaderView * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setVerticalHeader (arg1);
 }
@@ -886,7 +886,7 @@ static void _call_f_setWordWrap_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->setWordWrap (arg1);
 }
@@ -906,7 +906,7 @@ static void _call_f_showColumn_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->showColumn (arg1);
 }
@@ -941,7 +941,7 @@ static void _call_f_showRow_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->showRow (arg1);
 }
@@ -963,8 +963,8 @@ static void _call_f_sortByColumn_2340 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->sortByColumn (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -984,7 +984,7 @@ static void _call_f_sortByColumn_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView *)cls)->sortByColumn (arg1);
 }
@@ -1019,7 +1019,7 @@ static void _call_f_visualRect_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QRect > ((QRect)((QTableView *)cls)->visualRect (arg1));
 }
 
@@ -1055,8 +1055,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTableView::tr (arg1, arg2));
 }
 
@@ -1079,9 +1079,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTableView::tr (arg1, arg2, arg3));
 }
 
@@ -1102,8 +1102,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTableView::trUtf8 (arg1, arg2));
 }
 
@@ -1126,9 +1126,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTableView::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2837,7 +2837,7 @@ static void _call_ctor_QTableView_Adaptor_1315 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTableView_Adaptor *> (new QTableView_Adaptor (arg1));
 }
 
@@ -2879,7 +2879,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableView_Adaptor *)cls)->emitter_QTableView_activated_2395 (arg1);
 }
 
@@ -2945,7 +2945,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableView_Adaptor *)cls)->emitter_QTableView_clicked_2395 (arg1);
 }
 
@@ -3016,8 +3016,8 @@ static void _call_fp_columnCountChanged_1426 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_columnCountChanged_1426 (arg1, arg2);
 }
@@ -3040,9 +3040,9 @@ static void _call_fp_columnMoved_2085 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_columnMoved_2085 (arg1, arg2, arg3);
 }
@@ -3065,9 +3065,9 @@ static void _call_fp_columnResized_2085 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_columnResized_2085 (arg1, arg2, arg3);
 }
@@ -3138,9 +3138,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_create_2208 (arg1, arg2, arg3);
 }
@@ -3186,7 +3186,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QTableView_Adaptor *)cls)->emitter_QTableView_customContextMenuRequested_1916 (arg1);
 }
 
@@ -3257,8 +3257,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_destroy_1620 (arg1, arg2);
 }
@@ -3277,7 +3277,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTableView_Adaptor *)cls)->emitter_QTableView_destroyed_1302 (arg1);
 }
 
@@ -3368,7 +3368,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableView_Adaptor *)cls)->emitter_QTableView_doubleClicked_2395 (arg1);
 }
 
@@ -3458,7 +3458,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_drawFrame_1426 (arg1);
 }
@@ -3616,7 +3616,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableView_Adaptor *)cls)->emitter_QTableView_entered_2395 (arg1);
 }
 
@@ -4413,7 +4413,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableView_Adaptor *)cls)->emitter_QTableView_pressed_2395 (arg1);
 }
 
@@ -4431,7 +4431,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTableView_Adaptor *)cls)->fp_QTableView_receivers_c1731 (arg1));
 }
 
@@ -4510,8 +4510,8 @@ static void _call_fp_rowCountChanged_1426 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_rowCountChanged_1426 (arg1, arg2);
 }
@@ -4534,9 +4534,9 @@ static void _call_fp_rowMoved_2085 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_rowMoved_2085 (arg1, arg2, arg3);
 }
@@ -4559,9 +4559,9 @@ static void _call_fp_rowResized_2085 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_rowResized_2085 (arg1, arg2, arg3);
 }
@@ -4684,8 +4684,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -4837,7 +4837,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_setDirtyRegion_2006 (arg1);
 }
@@ -4856,7 +4856,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -4974,7 +4974,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_setState_2776 (arg1);
 }
@@ -4993,7 +4993,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_setVerticalStepsPerItem_767 (arg1);
 }
@@ -5018,10 +5018,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -5040,7 +5040,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_setViewportMargins_2115 (arg1);
 }
@@ -5083,7 +5083,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableView_Adaptor *)cls)->fp_QTableView_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTableWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTableWidget.cc
@@ -124,8 +124,8 @@ static void _call_f_cellWidget_c1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QTableWidget *)cls)->cellWidget (arg1, arg2));
 }
 
@@ -176,7 +176,7 @@ static void _call_f_closePersistentEditor_2202 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->closePersistentEditor (arg1);
 }
@@ -196,7 +196,7 @@ static void _call_f_column_c2897 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem *arg1 = args.read<const QTableWidgetItem * > (heap);
+  const QTableWidgetItem *arg1 = gsi::arg_reader<const QTableWidgetItem * >() (args, heap);
   ret.write<int > ((int)((QTableWidget *)cls)->column (arg1));
 }
 
@@ -275,7 +275,7 @@ static void _call_f_editItem_2202 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->editItem (arg1);
 }
@@ -297,8 +297,8 @@ static void _call_f_findItems_c4233 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<Qt::MatchFlag> arg2 = args.read<QFlags<Qt::MatchFlag> > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<Qt::MatchFlag> arg2 = gsi::arg_reader<QFlags<Qt::MatchFlag> >() (args, heap);
   ret.write<QList<QTableWidgetItem*> > ((QList<QTableWidgetItem*>)((QTableWidget *)cls)->findItems (arg1, arg2));
 }
 
@@ -317,7 +317,7 @@ static void _call_f_horizontalHeaderItem_c767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTableWidgetItem * > ((QTableWidgetItem *)((QTableWidget *)cls)->horizontalHeaderItem (arg1));
 }
 
@@ -336,7 +336,7 @@ static void _call_f_insertColumn_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->insertColumn (arg1);
 }
@@ -356,7 +356,7 @@ static void _call_f_insertRow_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->insertRow (arg1);
 }
@@ -376,7 +376,7 @@ static void _call_f_isItemSelected_c2897 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem *arg1 = args.read<const QTableWidgetItem * > (heap);
+  const QTableWidgetItem *arg1 = gsi::arg_reader<const QTableWidgetItem * >() (args, heap);
   ret.write<bool > ((bool)((QTableWidget *)cls)->isItemSelected (arg1));
 }
 
@@ -412,8 +412,8 @@ static void _call_f_item_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTableWidgetItem * > ((QTableWidgetItem *)((QTableWidget *)cls)->item (arg1, arg2));
 }
 
@@ -432,7 +432,7 @@ static void _call_f_itemAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QTableWidgetItem * > ((QTableWidgetItem *)((QTableWidget *)cls)->itemAt (arg1));
 }
 
@@ -453,8 +453,8 @@ static void _call_f_itemAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTableWidgetItem * > ((QTableWidgetItem *)((QTableWidget *)cls)->itemAt (arg1, arg2));
 }
 
@@ -488,7 +488,7 @@ static void _call_f_openPersistentEditor_2202 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->openPersistentEditor (arg1);
 }
@@ -510,8 +510,8 @@ static void _call_f_removeCellWidget_1426 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->removeCellWidget (arg1, arg2);
 }
@@ -531,7 +531,7 @@ static void _call_f_removeColumn_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->removeColumn (arg1);
 }
@@ -551,7 +551,7 @@ static void _call_f_removeRow_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->removeRow (arg1);
 }
@@ -571,7 +571,7 @@ static void _call_f_row_c2897 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem *arg1 = args.read<const QTableWidgetItem * > (heap);
+  const QTableWidgetItem *arg1 = gsi::arg_reader<const QTableWidgetItem * >() (args, heap);
   ret.write<int > ((int)((QTableWidget *)cls)->row (arg1));
 }
 
@@ -607,8 +607,8 @@ static void _call_f_scrollToItem_6078 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem *arg1 = args.read<const QTableWidgetItem * > (heap);
-  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible));
+  const QTableWidgetItem *arg1 = gsi::arg_reader<const QTableWidgetItem * >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->scrollToItem (arg1, qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollHint>(arg2).cref());
 }
@@ -662,9 +662,9 @@ static void _call_f_setCellWidget_2633 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setCellWidget (arg1, arg2, arg3);
 }
@@ -684,7 +684,7 @@ static void _call_f_setColumnCount_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setColumnCount (arg1);
 }
@@ -706,8 +706,8 @@ static void _call_f_setCurrentCell_1426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setCurrentCell (arg1, arg2);
 }
@@ -731,9 +731,9 @@ static void _call_f_setCurrentCell_5789 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  QFlags<QItemSelectionModel::SelectionFlag> arg3 = args.read<QFlags<QItemSelectionModel::SelectionFlag> > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QFlags<QItemSelectionModel::SelectionFlag> arg3 = gsi::arg_reader<QFlags<QItemSelectionModel::SelectionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setCurrentCell (arg1, arg2, arg3);
 }
@@ -753,7 +753,7 @@ static void _call_f_setCurrentItem_2202 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setCurrentItem (arg1);
 }
@@ -775,8 +775,8 @@ static void _call_f_setCurrentItem_6565 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
-  QFlags<QItemSelectionModel::SelectionFlag> arg2 = args.read<QFlags<QItemSelectionModel::SelectionFlag> > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
+  QFlags<QItemSelectionModel::SelectionFlag> arg2 = gsi::arg_reader<QFlags<QItemSelectionModel::SelectionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setCurrentItem (arg1, arg2);
 }
@@ -798,8 +798,8 @@ static void _call_f_setHorizontalHeaderItem_2861 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QTableWidgetItem *arg2 = args.read<QTableWidgetItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QTableWidgetItem *arg2 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setHorizontalHeaderItem (arg1, arg2);
 }
@@ -819,7 +819,7 @@ static void _call_f_setHorizontalHeaderLabels_2437 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setHorizontalHeaderLabels (arg1);
 }
@@ -843,9 +843,9 @@ static void _call_f_setItem_3520 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  QTableWidgetItem *arg3 = args.read<QTableWidgetItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QTableWidgetItem *arg3 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   qt_gsi::qt_keep (arg3);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setItem (arg1, arg2, arg3);
@@ -866,7 +866,7 @@ static void _call_f_setItemPrototype_2897 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem *arg1 = args.read<const QTableWidgetItem * > (heap);
+  const QTableWidgetItem *arg1 = gsi::arg_reader<const QTableWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setItemPrototype (arg1);
 }
@@ -888,8 +888,8 @@ static void _call_f_setItemSelected_3653 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem *arg1 = args.read<const QTableWidgetItem * > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QTableWidgetItem *arg1 = gsi::arg_reader<const QTableWidgetItem * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setItemSelected (arg1, arg2);
 }
@@ -911,8 +911,8 @@ static void _call_f_setRangeSelected_4677 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetSelectionRange &arg1 = args.read<const QTableWidgetSelectionRange & > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QTableWidgetSelectionRange &arg1 = gsi::arg_reader<const QTableWidgetSelectionRange & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setRangeSelected (arg1, arg2);
 }
@@ -932,7 +932,7 @@ static void _call_f_setRowCount_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setRowCount (arg1);
 }
@@ -952,7 +952,7 @@ static void _call_f_setSortingEnabled_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setSortingEnabled (arg1);
 }
@@ -974,8 +974,8 @@ static void _call_f_setVerticalHeaderItem_2861 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QTableWidgetItem *arg2 = args.read<QTableWidgetItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QTableWidgetItem *arg2 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setVerticalHeaderItem (arg1, arg2);
 }
@@ -995,7 +995,7 @@ static void _call_f_setVerticalHeaderLabels_2437 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->setVerticalHeaderLabels (arg1);
 }
@@ -1017,8 +1017,8 @@ static void _call_f_sortItems_2340 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap) : (const qt_gsi::Converter<Qt::SortOrder>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::SortOrder>(heap, Qt::AscendingOrder), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget *)cls)->sortItems (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -1038,7 +1038,7 @@ static void _call_f_takeHorizontalHeaderItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTableWidgetItem * > ((QTableWidgetItem *)((QTableWidget *)cls)->takeHorizontalHeaderItem (arg1));
 }
 
@@ -1059,8 +1059,8 @@ static void _call_f_takeItem_1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTableWidgetItem * > ((QTableWidgetItem *)((QTableWidget *)cls)->takeItem (arg1, arg2));
 }
 
@@ -1079,7 +1079,7 @@ static void _call_f_takeVerticalHeaderItem_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTableWidgetItem * > ((QTableWidgetItem *)((QTableWidget *)cls)->takeVerticalHeaderItem (arg1));
 }
 
@@ -1098,7 +1098,7 @@ static void _call_f_verticalHeaderItem_c767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTableWidgetItem * > ((QTableWidgetItem *)((QTableWidget *)cls)->verticalHeaderItem (arg1));
 }
 
@@ -1117,7 +1117,7 @@ static void _call_f_visualColumn_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableWidget *)cls)->visualColumn (arg1));
 }
 
@@ -1136,7 +1136,7 @@ static void _call_f_visualItemRect_c2897 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem *arg1 = args.read<const QTableWidgetItem * > (heap);
+  const QTableWidgetItem *arg1 = gsi::arg_reader<const QTableWidgetItem * >() (args, heap);
   ret.write<QRect > ((QRect)((QTableWidget *)cls)->visualItemRect (arg1));
 }
 
@@ -1155,7 +1155,7 @@ static void _call_f_visualRow_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTableWidget *)cls)->visualRow (arg1));
 }
 
@@ -1176,8 +1176,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTableWidget::tr (arg1, arg2));
 }
 
@@ -1200,9 +1200,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTableWidget::tr (arg1, arg2, arg3));
 }
 
@@ -1223,8 +1223,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTableWidget::trUtf8 (arg1, arg2));
 }
 
@@ -1247,9 +1247,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTableWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -3143,7 +3143,7 @@ static void _call_ctor_QTableWidget_Adaptor_1315 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTableWidget_Adaptor *> (new QTableWidget_Adaptor (arg1));
 }
 
@@ -3165,9 +3165,9 @@ static void _call_ctor_QTableWidget_Adaptor_2633 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTableWidget_Adaptor *> (new QTableWidget_Adaptor (arg1, arg2, arg3));
 }
 
@@ -3209,7 +3209,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_activated_2395 (arg1);
 }
 
@@ -3229,8 +3229,8 @@ static void _call_emitter_cellActivated_1426 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_cellActivated_1426 (arg1, arg2);
 }
 
@@ -3250,8 +3250,8 @@ static void _call_emitter_cellChanged_1426 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_cellChanged_1426 (arg1, arg2);
 }
 
@@ -3271,8 +3271,8 @@ static void _call_emitter_cellClicked_1426 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_cellClicked_1426 (arg1, arg2);
 }
 
@@ -3292,8 +3292,8 @@ static void _call_emitter_cellDoubleClicked_1426 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_cellDoubleClicked_1426 (arg1, arg2);
 }
 
@@ -3313,8 +3313,8 @@ static void _call_emitter_cellEntered_1426 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_cellEntered_1426 (arg1, arg2);
 }
 
@@ -3334,8 +3334,8 @@ static void _call_emitter_cellPressed_1426 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_cellPressed_1426 (arg1, arg2);
 }
 
@@ -3401,7 +3401,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_clicked_2395 (arg1);
 }
 
@@ -3472,8 +3472,8 @@ static void _call_fp_columnCountChanged_1426 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_columnCountChanged_1426 (arg1, arg2);
 }
@@ -3496,9 +3496,9 @@ static void _call_fp_columnMoved_2085 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_columnMoved_2085 (arg1, arg2, arg3);
 }
@@ -3521,9 +3521,9 @@ static void _call_fp_columnResized_2085 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_columnResized_2085 (arg1, arg2, arg3);
 }
@@ -3594,9 +3594,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -3621,10 +3621,10 @@ static void _call_emitter_currentCellChanged_2744 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_currentCellChanged_2744 (arg1, arg2, arg3, arg4);
 }
 
@@ -3671,8 +3671,8 @@ static void _call_emitter_currentItemChanged_4296 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
-  QTableWidgetItem *arg2 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
+  QTableWidgetItem *arg2 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_currentItemChanged_4296 (arg1, arg2);
 }
 
@@ -3690,7 +3690,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -3761,8 +3761,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_destroy_1620 (arg1, arg2);
 }
@@ -3781,7 +3781,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_destroyed_1302 (arg1);
 }
 
@@ -3872,7 +3872,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_doubleClicked_2395 (arg1);
 }
 
@@ -3962,7 +3962,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_drawFrame_1426 (arg1);
 }
@@ -4152,7 +4152,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_entered_2395 (arg1);
 }
 
@@ -4508,7 +4508,7 @@ static void _call_fp_indexFromItem_c2202 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QTableWidget_Adaptor *)cls)->fp_QTableWidget_indexFromItem_c2202 (arg1));
 }
 
@@ -4596,7 +4596,7 @@ static void _call_emitter_itemActivated_2202 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_itemActivated_2202 (arg1);
 }
 
@@ -4614,7 +4614,7 @@ static void _call_emitter_itemChanged_2202 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_itemChanged_2202 (arg1);
 }
 
@@ -4632,7 +4632,7 @@ static void _call_emitter_itemClicked_2202 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_itemClicked_2202 (arg1);
 }
 
@@ -4650,7 +4650,7 @@ static void _call_emitter_itemDoubleClicked_2202 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_itemDoubleClicked_2202 (arg1);
 }
 
@@ -4668,7 +4668,7 @@ static void _call_emitter_itemEntered_2202 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_itemEntered_2202 (arg1);
 }
 
@@ -4686,7 +4686,7 @@ static void _call_fp_itemFromIndex_c2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QTableWidgetItem * > ((QTableWidgetItem *)((QTableWidget_Adaptor *)cls)->fp_QTableWidget_itemFromIndex_c2395 (arg1));
 }
 
@@ -4704,7 +4704,7 @@ static void _call_emitter_itemPressed_2202 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTableWidgetItem *arg1 = args.read<QTableWidgetItem * > (heap);
+  QTableWidgetItem *arg1 = gsi::arg_reader<QTableWidgetItem * >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_itemPressed_2202 (arg1);
 }
 
@@ -4736,7 +4736,7 @@ static void _call_fp_items_c2168 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
   ret.write<QList<QTableWidgetItem*> > ((QList<QTableWidgetItem*>)((QTableWidget_Adaptor *)cls)->fp_QTableWidget_items_c2168 (arg1));
 }
 
@@ -5167,7 +5167,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTableWidget_Adaptor *)cls)->emitter_QTableWidget_pressed_2395 (arg1);
 }
 
@@ -5185,7 +5185,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTableWidget_Adaptor *)cls)->fp_QTableWidget_receivers_c1731 (arg1));
 }
 
@@ -5264,8 +5264,8 @@ static void _call_fp_rowCountChanged_1426 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_rowCountChanged_1426 (arg1, arg2);
 }
@@ -5288,9 +5288,9 @@ static void _call_fp_rowMoved_2085 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_rowMoved_2085 (arg1, arg2, arg3);
 }
@@ -5313,9 +5313,9 @@ static void _call_fp_rowResized_2085 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_rowResized_2085 (arg1, arg2, arg3);
 }
@@ -5438,8 +5438,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -5591,7 +5591,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_setDirtyRegion_2006 (arg1);
 }
@@ -5610,7 +5610,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -5704,7 +5704,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_setState_2776 (arg1);
 }
@@ -5723,7 +5723,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_setVerticalStepsPerItem_767 (arg1);
 }
@@ -5748,10 +5748,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -5770,7 +5770,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_setViewportMargins_2115 (arg1);
 }
@@ -5813,7 +5813,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidget_Adaptor *)cls)->fp_QTableWidget_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTableWidgetItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTableWidgetItem.cc
@@ -132,7 +132,7 @@ static void _call_f_data_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QTableWidgetItem *)cls)->data (arg1));
 }
 
@@ -226,7 +226,7 @@ static void _call_f_operator_lt__c2893 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem &arg1 = args.read<const QTableWidgetItem & > (heap);
+  const QTableWidgetItem &arg1 = gsi::arg_reader<const QTableWidgetItem & >() (args, heap);
   ret.write<bool > ((bool)((QTableWidgetItem *)cls)->operator< (arg1));
 }
 
@@ -245,7 +245,7 @@ static void _call_f_operator_eq__2893 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem &arg1 = args.read<const QTableWidgetItem & > (heap);
+  const QTableWidgetItem &arg1 = gsi::arg_reader<const QTableWidgetItem & >() (args, heap);
   ret.write<QTableWidgetItem & > ((QTableWidgetItem &)((QTableWidgetItem *)cls)->operator= (arg1));
 }
 
@@ -264,7 +264,7 @@ static void _call_f_read_1697 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->read (arg1);
 }
@@ -299,7 +299,7 @@ static void _call_f_setBackground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setBackground (arg1);
 }
@@ -319,7 +319,7 @@ static void _call_f_setBackgroundColor_1905 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setBackgroundColor (arg1);
 }
@@ -339,7 +339,7 @@ static void _call_f_setCheckState_1740 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::CheckState>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::CheckState>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::CheckState>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::CheckState>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setCheckState (qt_gsi::QtToCppAdaptor<Qt::CheckState>(arg1).cref());
 }
@@ -361,8 +361,8 @@ static void _call_f_setData_2778 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setData (arg1, arg2);
 }
@@ -382,7 +382,7 @@ static void _call_f_setFlags_2222 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::ItemFlag> arg1 = args.read<QFlags<Qt::ItemFlag> > (heap);
+  QFlags<Qt::ItemFlag> arg1 = gsi::arg_reader<QFlags<Qt::ItemFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setFlags (arg1);
 }
@@ -402,7 +402,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setFont (arg1);
 }
@@ -422,7 +422,7 @@ static void _call_f_setForeground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setForeground (arg1);
 }
@@ -442,7 +442,7 @@ static void _call_f_setIcon_1787 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setIcon (arg1);
 }
@@ -462,7 +462,7 @@ static void _call_f_setSelected_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setSelected (arg1);
 }
@@ -482,7 +482,7 @@ static void _call_f_setSizeHint_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setSizeHint (arg1);
 }
@@ -502,7 +502,7 @@ static void _call_f_setStatusTip_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setStatusTip (arg1);
 }
@@ -522,7 +522,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setText (arg1);
 }
@@ -542,7 +542,7 @@ static void _call_f_setTextAlignment_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setTextAlignment (arg1);
 }
@@ -562,7 +562,7 @@ static void _call_f_setTextColor_1905 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setTextColor (arg1);
 }
@@ -582,7 +582,7 @@ static void _call_f_setToolTip_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setToolTip (arg1);
 }
@@ -602,7 +602,7 @@ static void _call_f_setWhatsThis_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->setWhatsThis (arg1);
 }
@@ -757,7 +757,7 @@ static void _call_f_write_c1697 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTableWidgetItem *)cls)->write (arg1);
 }
@@ -982,7 +982,7 @@ static void _call_ctor_QTableWidgetItem_Adaptor_767 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(QTableWidgetItem::Type);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTableWidgetItem::Type, heap);
   ret.write<QTableWidgetItem_Adaptor *> (new QTableWidgetItem_Adaptor (arg1));
 }
 
@@ -1002,8 +1002,8 @@ static void _call_ctor_QTableWidgetItem_Adaptor_2684 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(QTableWidgetItem::Type);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTableWidgetItem::Type, heap);
   ret.write<QTableWidgetItem_Adaptor *> (new QTableWidgetItem_Adaptor (arg1, arg2));
 }
 
@@ -1025,9 +1025,9 @@ static void _call_ctor_QTableWidgetItem_Adaptor_4363 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(QTableWidgetItem::Type);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTableWidgetItem::Type, heap);
   ret.write<QTableWidgetItem_Adaptor *> (new QTableWidgetItem_Adaptor (arg1, arg2, arg3));
 }
 
@@ -1045,7 +1045,7 @@ static void _call_ctor_QTableWidgetItem_Adaptor_2893 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetItem &arg1 = args.read<const QTableWidgetItem & > (heap);
+  const QTableWidgetItem &arg1 = gsi::arg_reader<const QTableWidgetItem & >() (args, heap);
   ret.write<QTableWidgetItem_Adaptor *> (new QTableWidgetItem_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTableWidgetSelectionRange.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTableWidgetSelectionRange.cc
@@ -71,10 +71,10 @@ static void _call_ctor_QTableWidgetSelectionRange_2744 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTableWidgetSelectionRange *> (new QTableWidgetSelectionRange (arg1, arg2, arg3, arg4));
 }
 
@@ -93,7 +93,7 @@ static void _call_ctor_QTableWidgetSelectionRange_3921 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTableWidgetSelectionRange &arg1 = args.read<const QTableWidgetSelectionRange & > (heap);
+  const QTableWidgetSelectionRange &arg1 = gsi::arg_reader<const QTableWidgetSelectionRange & >() (args, heap);
   ret.write<QTableWidgetSelectionRange *> (new QTableWidgetSelectionRange (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTapAndHoldGesture.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTapAndHoldGesture.cc
@@ -84,7 +84,7 @@ static void _call_f_setPosition_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTapAndHoldGesture *)cls)->setPosition (arg1);
 }
@@ -106,8 +106,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTapAndHoldGesture::tr (arg1, arg2));
 }
 
@@ -130,9 +130,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTapAndHoldGesture::tr (arg1, arg2, arg3));
 }
 
@@ -153,8 +153,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTapAndHoldGesture::trUtf8 (arg1, arg2));
 }
 
@@ -177,9 +177,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTapAndHoldGesture::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -358,7 +358,7 @@ static void _call_ctor_QTapAndHoldGesture_Adaptor_1302 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTapAndHoldGesture_Adaptor *> (new QTapAndHoldGesture_Adaptor (arg1));
 }
 
@@ -424,7 +424,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTapAndHoldGesture_Adaptor *)cls)->emitter_QTapAndHoldGesture_destroyed_1302 (arg1);
 }
 
@@ -515,7 +515,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTapAndHoldGesture_Adaptor *)cls)->fp_QTapAndHoldGesture_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTapGesture.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTapGesture.cc
@@ -84,7 +84,7 @@ static void _call_f_setPosition_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTapGesture *)cls)->setPosition (arg1);
 }
@@ -106,8 +106,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTapGesture::tr (arg1, arg2));
 }
 
@@ -130,9 +130,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTapGesture::tr (arg1, arg2, arg3));
 }
 
@@ -153,8 +153,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTapGesture::trUtf8 (arg1, arg2));
 }
 
@@ -177,9 +177,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTapGesture::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -358,7 +358,7 @@ static void _call_ctor_QTapGesture_Adaptor_1302 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTapGesture_Adaptor *> (new QTapGesture_Adaptor (arg1));
 }
 
@@ -424,7 +424,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTapGesture_Adaptor *)cls)->emitter_QTapGesture_destroyed_1302 (arg1);
 }
 
@@ -515,7 +515,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTapGesture_Adaptor *)cls)->fp_QTapGesture_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextBlock.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextBlock.cc
@@ -71,7 +71,7 @@ static void _call_ctor_QTextBlock_2306 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<QTextBlock *> (new QTextBlock (arg1));
 }
 
@@ -196,7 +196,7 @@ static void _call_f_contains_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTextBlock *)cls)->contains (arg1));
 }
 
@@ -365,7 +365,7 @@ static void _call_f_operator_excl__eq__c2306 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<bool > ((bool)((QTextBlock *)cls)->operator!= (arg1));
 }
 
@@ -384,7 +384,7 @@ static void _call_f_operator_lt__c2306 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<bool > ((bool)((QTextBlock *)cls)->operator< (arg1));
 }
 
@@ -403,7 +403,7 @@ static void _call_f_operator_eq__2306 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<QTextBlock & > ((QTextBlock &)((QTextBlock *)cls)->operator= (arg1));
 }
 
@@ -422,7 +422,7 @@ static void _call_f_operator_eq__eq__c2306 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<bool > ((bool)((QTextBlock *)cls)->operator== (arg1));
 }
 
@@ -486,7 +486,7 @@ static void _call_f_setLineCount_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlock *)cls)->setLineCount (arg1);
 }
@@ -506,7 +506,7 @@ static void _call_f_setRevision_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlock *)cls)->setRevision (arg1);
 }
@@ -526,7 +526,7 @@ static void _call_f_setUserData_2408 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextBlockUserData *arg1 = args.read<QTextBlockUserData * > (heap);
+  QTextBlockUserData *arg1 = gsi::arg_reader<QTextBlockUserData * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlock *)cls)->setUserData (arg1);
 }
@@ -546,7 +546,7 @@ static void _call_f_setUserState_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlock *)cls)->setUserState (arg1);
 }
@@ -566,7 +566,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlock *)cls)->setVisible (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextBlockFormat.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextBlockFormat.cc
@@ -196,7 +196,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setAlignment (arg1);
 }
@@ -216,7 +216,7 @@ static void _call_f_setBottomMargin_1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setBottomMargin (arg1);
 }
@@ -236,7 +236,7 @@ static void _call_f_setIndent_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setIndent (arg1);
 }
@@ -256,7 +256,7 @@ static void _call_f_setLeftMargin_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setLeftMargin (arg1);
 }
@@ -276,7 +276,7 @@ static void _call_f_setNonBreakableLines_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setNonBreakableLines (arg1);
 }
@@ -296,7 +296,7 @@ static void _call_f_setPageBreakPolicy_3611 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QTextFormat::PageBreakFlag> arg1 = args.read<QFlags<QTextFormat::PageBreakFlag> > (heap);
+  QFlags<QTextFormat::PageBreakFlag> arg1 = gsi::arg_reader<QFlags<QTextFormat::PageBreakFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setPageBreakPolicy (arg1);
 }
@@ -316,7 +316,7 @@ static void _call_f_setRightMargin_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setRightMargin (arg1);
 }
@@ -336,7 +336,7 @@ static void _call_f_setTabPositions_3458 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QTextOption::Tab> &arg1 = args.read<const QList<QTextOption::Tab> & > (heap);
+  const QList<QTextOption::Tab> &arg1 = gsi::arg_reader<const QList<QTextOption::Tab> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setTabPositions (arg1);
 }
@@ -356,7 +356,7 @@ static void _call_f_setTextIndent_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setTextIndent (arg1);
 }
@@ -376,7 +376,7 @@ static void _call_f_setTopMargin_1071 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockFormat *)cls)->setTopMargin (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextBlockGroup.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextBlockGroup.cc
@@ -73,8 +73,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextBlockGroup::tr (arg1, arg2));
 }
 
@@ -97,9 +97,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextBlockGroup::tr (arg1, arg2, arg3));
 }
 
@@ -120,8 +120,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextBlockGroup::trUtf8 (arg1, arg2));
 }
 
@@ -144,9 +144,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextBlockGroup::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -503,7 +503,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTextBlockGroup_Adaptor *)cls)->emitter_QTextBlockGroup_destroyed_1302 (arg1);
 }
 
@@ -594,7 +594,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTextBlockGroup_Adaptor *)cls)->fp_QTextBlockGroup_receivers_c1731 (arg1));
 }
 
@@ -626,7 +626,7 @@ static void _call_fp_setFormat_2432 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFormat &arg1 = args.read<const QTextFormat & > (heap);
+  const QTextFormat &arg1 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBlockGroup_Adaptor *)cls)->fp_QTextBlockGroup_setFormat_2432 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextBlock_Iterator.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextBlock_Iterator.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QTextBlock_Iterator_3296 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock::iterator &arg1 = args.read<const QTextBlock::iterator & > (heap);
+  const QTextBlock::iterator &arg1 = gsi::arg_reader<const QTextBlock::iterator & >() (args, heap);
   ret.write<QTextBlock::iterator *> (new QTextBlock::iterator (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_operator_excl__eq__c3296 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock::iterator &arg1 = args.read<const QTextBlock::iterator & > (heap);
+  const QTextBlock::iterator &arg1 = gsi::arg_reader<const QTextBlock::iterator & >() (args, heap);
   ret.write<bool > ((bool)((QTextBlock::iterator *)cls)->operator!= (arg1));
 }
 
@@ -149,7 +149,7 @@ static void _call_f_operator_plus__plus__767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextBlock::iterator > ((QTextBlock::iterator)((QTextBlock::iterator *)cls)->operator++ (arg1));
 }
 
@@ -183,7 +183,7 @@ static void _call_f_operator_minus__minus__767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextBlock::iterator > ((QTextBlock::iterator)((QTextBlock::iterator *)cls)->operator-- (arg1));
 }
 
@@ -202,7 +202,7 @@ static void _call_f_operator_eq__eq__c3296 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock::iterator &arg1 = args.read<const QTextBlock::iterator & > (heap);
+  const QTextBlock::iterator &arg1 = gsi::arg_reader<const QTextBlock::iterator & >() (args, heap);
   ret.write<bool > ((bool)((QTextBlock::iterator *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextBrowser.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextBrowser.cc
@@ -198,7 +198,7 @@ static void _call_f_historyTitle_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTextBrowser *)cls)->historyTitle (arg1));
 }
 
@@ -217,7 +217,7 @@ static void _call_f_historyUrl_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QUrl > ((QUrl)((QTextBrowser *)cls)->historyUrl (arg1));
 }
 
@@ -284,8 +284,8 @@ static void _call_f_loadResource_2360 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QUrl &arg2 = args.read<const QUrl & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QUrl &arg2 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QTextBrowser *)cls)->loadResource (arg1, arg2));
 }
 
@@ -365,7 +365,7 @@ static void _call_f_setOpenExternalLinks_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser *)cls)->setOpenExternalLinks (arg1);
 }
@@ -385,7 +385,7 @@ static void _call_f_setOpenLinks_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser *)cls)->setOpenLinks (arg1);
 }
@@ -405,7 +405,7 @@ static void _call_f_setSearchPaths_2437 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser *)cls)->setSearchPaths (arg1);
 }
@@ -425,7 +425,7 @@ static void _call_f_setSource_1701 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser *)cls)->setSource (arg1);
 }
@@ -462,8 +462,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextBrowser::tr (arg1, arg2));
 }
 
@@ -486,9 +486,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextBrowser::tr (arg1, arg2, arg3));
 }
 
@@ -509,8 +509,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextBrowser::trUtf8 (arg1, arg2));
 }
 
@@ -533,9 +533,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextBrowser::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1703,7 +1703,7 @@ static void _call_ctor_QTextBrowser_Adaptor_1315 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTextBrowser_Adaptor *> (new QTextBrowser_Adaptor (arg1));
 }
 
@@ -1745,7 +1745,7 @@ static void _call_emitter_anchorClicked_1701 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_anchorClicked_1701 (arg1);
 }
 
@@ -1783,7 +1783,7 @@ static void _call_emitter_backwardAvailable_864 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_backwardAvailable_864 (arg1);
 }
 
@@ -1920,7 +1920,7 @@ static void _call_emitter_copyAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_copyAvailable_864 (arg1);
 }
 
@@ -1942,9 +1942,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser_Adaptor *)cls)->fp_QTextBrowser_create_2208 (arg1, arg2, arg3);
 }
@@ -1982,7 +1982,7 @@ static void _call_emitter_currentCharFormatChanged_2814 (const qt_gsi::GenericMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_currentCharFormatChanged_2814 (arg1);
 }
 
@@ -2014,7 +2014,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2058,8 +2058,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser_Adaptor *)cls)->fp_QTextBrowser_destroy_1620 (arg1, arg2);
 }
@@ -2078,7 +2078,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_destroyed_1302 (arg1);
 }
 
@@ -2192,7 +2192,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser_Adaptor *)cls)->fp_QTextBrowser_drawFrame_1426 (arg1);
 }
@@ -2475,7 +2475,7 @@ static void _call_emitter_forwardAvailable_864 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_forwardAvailable_864 (arg1);
 }
 
@@ -2540,7 +2540,7 @@ static void _call_emitter_highlighted_1701 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_highlighted_1701 (arg1);
 }
 
@@ -2558,7 +2558,7 @@ static void _call_emitter_highlighted_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_highlighted_2025 (arg1);
 }
 
@@ -3028,7 +3028,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTextBrowser_Adaptor *)cls)->fp_QTextBrowser_receivers_c1731 (arg1));
 }
 
@@ -3046,7 +3046,7 @@ static void _call_emitter_redoAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_redoAvailable_864 (arg1);
 }
 
@@ -3208,10 +3208,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser_Adaptor *)cls)->fp_QTextBrowser_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -3230,7 +3230,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser_Adaptor *)cls)->fp_QTextBrowser_setViewportMargins_2115 (arg1);
 }
@@ -3273,7 +3273,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextBrowser_Adaptor *)cls)->fp_QTextBrowser_setupViewport_1315 (arg1);
 }
@@ -3335,7 +3335,7 @@ static void _call_emitter_sourceChanged_1701 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_sourceChanged_1701 (arg1);
 }
 
@@ -3439,7 +3439,7 @@ static void _call_emitter_undoAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextBrowser_Adaptor *)cls)->emitter_QTextBrowser_undoAvailable_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextCharFormat.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextCharFormat.cc
@@ -377,7 +377,7 @@ static void _call_f_setAnchor_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setAnchor (arg1);
 }
@@ -397,7 +397,7 @@ static void _call_f_setAnchorHref_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setAnchorHref (arg1);
 }
@@ -417,7 +417,7 @@ static void _call_f_setAnchorName_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setAnchorName (arg1);
 }
@@ -437,7 +437,7 @@ static void _call_f_setAnchorNames_2437 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setAnchorNames (arg1);
 }
@@ -457,7 +457,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFont (arg1);
 }
@@ -477,7 +477,7 @@ static void _call_f_setFontCapitalization_2508 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFont::Capitalization>::target_type & arg1 = args.read<const qt_gsi::Converter<QFont::Capitalization>::target_type & > (heap);
+  const qt_gsi::Converter<QFont::Capitalization>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFont::Capitalization>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontCapitalization (qt_gsi::QtToCppAdaptor<QFont::Capitalization>(arg1).cref());
 }
@@ -497,7 +497,7 @@ static void _call_f_setFontFamily_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontFamily (arg1);
 }
@@ -517,7 +517,7 @@ static void _call_f_setFontFixedPitch_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontFixedPitch (arg1);
 }
@@ -537,7 +537,7 @@ static void _call_f_setFontItalic_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontItalic (arg1);
 }
@@ -557,7 +557,7 @@ static void _call_f_setFontKerning_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontKerning (arg1);
 }
@@ -577,7 +577,7 @@ static void _call_f_setFontLetterSpacing_1071 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontLetterSpacing (arg1);
 }
@@ -597,7 +597,7 @@ static void _call_f_setFontOverline_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontOverline (arg1);
 }
@@ -617,7 +617,7 @@ static void _call_f_setFontPointSize_1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontPointSize (arg1);
 }
@@ -637,7 +637,7 @@ static void _call_f_setFontStrikeOut_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontStrikeOut (arg1);
 }
@@ -659,8 +659,8 @@ static void _call_f_setFontStyleHint_4284 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFont::StyleHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QFont::StyleHint>::target_type & > (heap);
-  const qt_gsi::Converter<QFont::StyleStrategy>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & > (heap) : (const qt_gsi::Converter<QFont::StyleStrategy>::target_type &)(qt_gsi::CppToQtReadAdaptor<QFont::StyleStrategy>(heap, QFont::PreferDefault));
+  const qt_gsi::Converter<QFont::StyleHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFont::StyleHint>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QFont::StyleStrategy>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QFont::StyleStrategy>(heap, QFont::PreferDefault), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontStyleHint (qt_gsi::QtToCppAdaptor<QFont::StyleHint>(arg1).cref(), qt_gsi::QtToCppAdaptor<QFont::StyleStrategy>(arg2).cref());
 }
@@ -680,7 +680,7 @@ static void _call_f_setFontStyleStrategy_2420 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFont::StyleStrategy>::target_type & arg1 = args.read<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & > (heap);
+  const qt_gsi::Converter<QFont::StyleStrategy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFont::StyleStrategy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontStyleStrategy (qt_gsi::QtToCppAdaptor<QFont::StyleStrategy>(arg1).cref());
 }
@@ -700,7 +700,7 @@ static void _call_f_setFontUnderline_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontUnderline (arg1);
 }
@@ -720,7 +720,7 @@ static void _call_f_setFontWeight_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontWeight (arg1);
 }
@@ -740,7 +740,7 @@ static void _call_f_setFontWordSpacing_1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setFontWordSpacing (arg1);
 }
@@ -760,7 +760,7 @@ static void _call_f_setTableCellColumnSpan_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setTableCellColumnSpan (arg1);
 }
@@ -780,7 +780,7 @@ static void _call_f_setTableCellRowSpan_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setTableCellRowSpan (arg1);
 }
@@ -800,7 +800,7 @@ static void _call_f_setTextOutline_1685 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPen &arg1 = args.read<const QPen & > (heap);
+  const QPen &arg1 = gsi::arg_reader<const QPen & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setTextOutline (arg1);
 }
@@ -820,7 +820,7 @@ static void _call_f_setToolTip_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setToolTip (arg1);
 }
@@ -840,7 +840,7 @@ static void _call_f_setUnderlineColor_1905 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setUnderlineColor (arg1);
 }
@@ -860,7 +860,7 @@ static void _call_f_setUnderlineStyle_3516 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextCharFormat::UnderlineStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextCharFormat::UnderlineStyle>::target_type & > (heap);
+  const qt_gsi::Converter<QTextCharFormat::UnderlineStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextCharFormat::UnderlineStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setUnderlineStyle (qt_gsi::QtToCppAdaptor<QTextCharFormat::UnderlineStyle>(arg1).cref());
 }
@@ -880,7 +880,7 @@ static void _call_f_setVerticalAlignment_3806 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextCharFormat::VerticalAlignment>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextCharFormat::VerticalAlignment>::target_type & > (heap);
+  const qt_gsi::Converter<QTextCharFormat::VerticalAlignment>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextCharFormat::VerticalAlignment>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCharFormat *)cls)->setVerticalAlignment (qt_gsi::QtToCppAdaptor<QTextCharFormat::VerticalAlignment>(arg1).cref());
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextCursor.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextCursor.cc
@@ -78,7 +78,7 @@ static void _call_ctor_QTextCursor_1955 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   ret.write<QTextCursor *> (new QTextCursor (arg1));
 }
 
@@ -97,7 +97,7 @@ static void _call_ctor_QTextCursor_1615 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextFrame *arg1 = args.read<QTextFrame * > (heap);
+  QTextFrame *arg1 = gsi::arg_reader<QTextFrame * >() (args, heap);
   ret.write<QTextCursor *> (new QTextCursor (arg1));
 }
 
@@ -116,7 +116,7 @@ static void _call_ctor_QTextCursor_2306 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<QTextCursor *> (new QTextCursor (arg1));
 }
 
@@ -135,7 +135,7 @@ static void _call_ctor_QTextCursor_2453 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<QTextCursor *> (new QTextCursor (arg1));
 }
 
@@ -351,7 +351,7 @@ static void _call_f_createList_2844 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextListFormat &arg1 = args.read<const QTextListFormat & > (heap);
+  const QTextListFormat &arg1 = gsi::arg_reader<const QTextListFormat & >() (args, heap);
   ret.write<QTextList * > ((QTextList *)((QTextCursor *)cls)->createList (arg1));
 }
 
@@ -370,7 +370,7 @@ static void _call_f_createList_2612 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextListFormat::Style>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextListFormat::Style>::target_type & > (heap);
+  const qt_gsi::Converter<QTextListFormat::Style>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextListFormat::Style>::target_type & >() (args, heap);
   ret.write<QTextList * > ((QTextList *)((QTextCursor *)cls)->createList (qt_gsi::QtToCppAdaptor<QTextListFormat::Style>(arg1).cref()));
 }
 
@@ -543,7 +543,7 @@ static void _call_f_insertBlock_2923 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlockFormat &arg1 = args.read<const QTextBlockFormat & > (heap);
+  const QTextBlockFormat &arg1 = gsi::arg_reader<const QTextBlockFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertBlock (arg1);
 }
@@ -565,8 +565,8 @@ static void _call_f_insertBlock_5629 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlockFormat &arg1 = args.read<const QTextBlockFormat & > (heap);
-  const QTextCharFormat &arg2 = args.read<const QTextCharFormat & > (heap);
+  const QTextBlockFormat &arg1 = gsi::arg_reader<const QTextBlockFormat & >() (args, heap);
+  const QTextCharFormat &arg2 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertBlock (arg1, arg2);
 }
@@ -586,7 +586,7 @@ static void _call_f_insertFragment_3466 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextDocumentFragment &arg1 = args.read<const QTextDocumentFragment & > (heap);
+  const QTextDocumentFragment &arg1 = gsi::arg_reader<const QTextDocumentFragment & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertFragment (arg1);
 }
@@ -606,7 +606,7 @@ static void _call_f_insertFrame_2923 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFrameFormat &arg1 = args.read<const QTextFrameFormat & > (heap);
+  const QTextFrameFormat &arg1 = gsi::arg_reader<const QTextFrameFormat & >() (args, heap);
   ret.write<QTextFrame * > ((QTextFrame *)((QTextCursor *)cls)->insertFrame (arg1));
 }
 
@@ -625,7 +625,7 @@ static void _call_f_insertHtml_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertHtml (arg1);
 }
@@ -647,8 +647,8 @@ static void _call_f_insertImage_5822 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextImageFormat &arg1 = args.read<const QTextImageFormat & > (heap);
-  const qt_gsi::Converter<QTextFrameFormat::Position>::target_type & arg2 = args.read<const qt_gsi::Converter<QTextFrameFormat::Position>::target_type & > (heap);
+  const QTextImageFormat &arg1 = gsi::arg_reader<const QTextImageFormat & >() (args, heap);
+  const qt_gsi::Converter<QTextFrameFormat::Position>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QTextFrameFormat::Position>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertImage (arg1, qt_gsi::QtToCppAdaptor<QTextFrameFormat::Position>(arg2).cref());
 }
@@ -668,7 +668,7 @@ static void _call_f_insertImage_2915 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextImageFormat &arg1 = args.read<const QTextImageFormat & > (heap);
+  const QTextImageFormat &arg1 = gsi::arg_reader<const QTextImageFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertImage (arg1);
 }
@@ -688,7 +688,7 @@ static void _call_f_insertImage_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertImage (arg1);
 }
@@ -710,8 +710,8 @@ static void _call_f_insertImage_3794 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QImage &arg1 = args.read<const QImage & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QImage &arg1 = gsi::arg_reader<const QImage & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertImage (arg1, arg2);
 }
@@ -731,7 +731,7 @@ static void _call_f_insertList_2844 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextListFormat &arg1 = args.read<const QTextListFormat & > (heap);
+  const QTextListFormat &arg1 = gsi::arg_reader<const QTextListFormat & >() (args, heap);
   ret.write<QTextList * > ((QTextList *)((QTextCursor *)cls)->insertList (arg1));
 }
 
@@ -750,7 +750,7 @@ static void _call_f_insertList_2612 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextListFormat::Style>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextListFormat::Style>::target_type & > (heap);
+  const qt_gsi::Converter<QTextListFormat::Style>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextListFormat::Style>::target_type & >() (args, heap);
   ret.write<QTextList * > ((QTextList *)((QTextCursor *)cls)->insertList (qt_gsi::QtToCppAdaptor<QTextListFormat::Style>(arg1).cref()));
 }
 
@@ -773,9 +773,9 @@ static void _call_f_insertTable_4238 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QTextTableFormat &arg3 = args.read<const QTextTableFormat & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QTextTableFormat &arg3 = gsi::arg_reader<const QTextTableFormat & >() (args, heap);
   ret.write<QTextTable * > ((QTextTable *)((QTextCursor *)cls)->insertTable (arg1, arg2, arg3));
 }
 
@@ -796,8 +796,8 @@ static void _call_f_insertTable_1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextTable * > ((QTextTable *)((QTextCursor *)cls)->insertTable (arg1, arg2));
 }
 
@@ -816,7 +816,7 @@ static void _call_f_insertText_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertText (arg1);
 }
@@ -838,8 +838,8 @@ static void _call_f_insertText_4731 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QTextCharFormat &arg2 = args.read<const QTextCharFormat & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QTextCharFormat &arg2 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->insertText (arg1, arg2);
 }
@@ -859,7 +859,7 @@ static void _call_f_isCopyOf_c2453 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<bool > ((bool)((QTextCursor *)cls)->isCopyOf (arg1));
 }
 
@@ -909,7 +909,7 @@ static void _call_f_mergeBlockCharFormat_2814 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->mergeBlockCharFormat (arg1);
 }
@@ -929,7 +929,7 @@ static void _call_f_mergeBlockFormat_2923 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlockFormat &arg1 = args.read<const QTextBlockFormat & > (heap);
+  const QTextBlockFormat &arg1 = gsi::arg_reader<const QTextBlockFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->mergeBlockFormat (arg1);
 }
@@ -949,7 +949,7 @@ static void _call_f_mergeCharFormat_2814 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->mergeCharFormat (arg1);
 }
@@ -973,9 +973,9 @@ static void _call_f_movePosition_6083 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & > (heap);
-  const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & > (heap) : (const qt_gsi::Converter<QTextCursor::MoveMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTextCursor::MoveMode>(heap, QTextCursor::MoveAnchor));
-  int arg3 = args ? args.read<int > (heap) : (int)(1);
+  const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTextCursor::MoveMode>(heap, QTextCursor::MoveAnchor), heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   ret.write<bool > ((bool)((QTextCursor *)cls)->movePosition (qt_gsi::QtToCppAdaptor<QTextCursor::MoveOperation>(arg1).cref(), qt_gsi::QtToCppAdaptor<QTextCursor::MoveMode>(arg2).cref(), arg3));
 }
 
@@ -994,7 +994,7 @@ static void _call_f_operator_excl__eq__c2453 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<bool > ((bool)((QTextCursor *)cls)->operator!= (arg1));
 }
 
@@ -1013,7 +1013,7 @@ static void _call_f_operator_lt__c2453 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<bool > ((bool)((QTextCursor *)cls)->operator< (arg1));
 }
 
@@ -1032,7 +1032,7 @@ static void _call_f_operator_lt__eq__c2453 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<bool > ((bool)((QTextCursor *)cls)->operator<= (arg1));
 }
 
@@ -1051,7 +1051,7 @@ static void _call_f_operator_eq__2453 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<QTextCursor & > ((QTextCursor &)((QTextCursor *)cls)->operator= (arg1));
 }
 
@@ -1070,7 +1070,7 @@ static void _call_f_operator_eq__eq__c2453 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<bool > ((bool)((QTextCursor *)cls)->operator== (arg1));
 }
 
@@ -1089,7 +1089,7 @@ static void _call_f_operator_gt__c2453 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<bool > ((bool)((QTextCursor *)cls)->operator> (arg1));
 }
 
@@ -1108,7 +1108,7 @@ static void _call_f_operator_gt__eq__c2453 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<bool > ((bool)((QTextCursor *)cls)->operator>= (arg1));
 }
 
@@ -1158,7 +1158,7 @@ static void _call_f_select_3044 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextCursor::SelectionType>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextCursor::SelectionType>::target_type & > (heap);
+  const qt_gsi::Converter<QTextCursor::SelectionType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextCursor::SelectionType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->select (qt_gsi::QtToCppAdaptor<QTextCursor::SelectionType>(arg1).cref());
 }
@@ -1184,10 +1184,10 @@ static void _call_f_selectedTableCells_c3488 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->selectedTableCells (arg1, arg2, arg3, arg4);
 }
@@ -1267,7 +1267,7 @@ static void _call_f_setBlockCharFormat_2814 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->setBlockCharFormat (arg1);
 }
@@ -1287,7 +1287,7 @@ static void _call_f_setBlockFormat_2923 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlockFormat &arg1 = args.read<const QTextBlockFormat & > (heap);
+  const QTextBlockFormat &arg1 = gsi::arg_reader<const QTextBlockFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->setBlockFormat (arg1);
 }
@@ -1307,7 +1307,7 @@ static void _call_f_setCharFormat_2814 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->setCharFormat (arg1);
 }
@@ -1329,8 +1329,8 @@ static void _call_f_setPosition_3147 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & > (heap) : (const qt_gsi::Converter<QTextCursor::MoveMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTextCursor::MoveMode>(heap, QTextCursor::MoveAnchor));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTextCursor::MoveMode>(heap, QTextCursor::MoveAnchor), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->setPosition (arg1, qt_gsi::QtToCppAdaptor<QTextCursor::MoveMode>(arg2).cref());
 }
@@ -1350,7 +1350,7 @@ static void _call_f_setVisualNavigation_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextCursor *)cls)->setVisualNavigation (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextDocument.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextDocument.cc
@@ -86,9 +86,9 @@ static void _call_f_addResource_4371 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QUrl &arg2 = args.read<const QUrl & > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QUrl &arg2 = gsi::arg_reader<const QUrl & >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->addResource (arg1, arg2, arg3);
 }
@@ -199,7 +199,7 @@ static void _call_f_characterAt_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<qt_gsi::Converter<QChar>::target_type > ((qt_gsi::Converter<QChar>::target_type)qt_gsi::CppToQtAdaptor<QChar>(((QTextDocument *)cls)->characterAt (arg1)));
 }
 
@@ -249,7 +249,7 @@ static void _call_f_clone_c1302 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTextDocument * > ((QTextDocument *)((QTextDocument *)cls)->clone (arg1));
 }
 
@@ -345,8 +345,8 @@ static void _call_f_drawContents_3180 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRectF &arg2 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRectF &arg2 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->drawContents (arg1, arg2);
 }
@@ -385,9 +385,9 @@ static void _call_f_find_c5920 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  QFlags<QTextDocument::FindFlag> arg3 = args ? args.read<QFlags<QTextDocument::FindFlag> > (heap) : (QFlags<QTextDocument::FindFlag>)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  QFlags<QTextDocument::FindFlag> arg3 = args ? gsi::arg_reader<QFlags<QTextDocument::FindFlag> >() (args, heap) : gsi::arg_maker<QFlags<QTextDocument::FindFlag> >() (0, heap);
   ret.write<QTextCursor > ((QTextCursor)((QTextDocument *)cls)->find (arg1, arg2, arg3));
 }
 
@@ -410,9 +410,9 @@ static void _call_f_find_c7606 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QTextCursor &arg2 = args.read<const QTextCursor & > (heap);
-  QFlags<QTextDocument::FindFlag> arg3 = args ? args.read<QFlags<QTextDocument::FindFlag> > (heap) : (QFlags<QTextDocument::FindFlag>)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QTextCursor &arg2 = gsi::arg_reader<const QTextCursor & >() (args, heap);
+  QFlags<QTextDocument::FindFlag> arg3 = args ? gsi::arg_reader<QFlags<QTextDocument::FindFlag> >() (args, heap) : gsi::arg_maker<QFlags<QTextDocument::FindFlag> >() (0, heap);
   ret.write<QTextCursor > ((QTextCursor)((QTextDocument *)cls)->find (arg1, arg2, arg3));
 }
 
@@ -435,9 +435,9 @@ static void _call_f_find_c5876 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegExp &arg1 = args.read<const QRegExp & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
-  QFlags<QTextDocument::FindFlag> arg3 = args ? args.read<QFlags<QTextDocument::FindFlag> > (heap) : (QFlags<QTextDocument::FindFlag>)(0);
+  const QRegExp &arg1 = gsi::arg_reader<const QRegExp & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  QFlags<QTextDocument::FindFlag> arg3 = args ? gsi::arg_reader<QFlags<QTextDocument::FindFlag> >() (args, heap) : gsi::arg_maker<QFlags<QTextDocument::FindFlag> >() (0, heap);
   ret.write<QTextCursor > ((QTextCursor)((QTextDocument *)cls)->find (arg1, arg2, arg3));
 }
 
@@ -460,9 +460,9 @@ static void _call_f_find_c7562 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegExp &arg1 = args.read<const QRegExp & > (heap);
-  const QTextCursor &arg2 = args.read<const QTextCursor & > (heap);
-  QFlags<QTextDocument::FindFlag> arg3 = args ? args.read<QFlags<QTextDocument::FindFlag> > (heap) : (QFlags<QTextDocument::FindFlag>)(0);
+  const QRegExp &arg1 = gsi::arg_reader<const QRegExp & >() (args, heap);
+  const QTextCursor &arg2 = gsi::arg_reader<const QTextCursor & >() (args, heap);
+  QFlags<QTextDocument::FindFlag> arg3 = args ? gsi::arg_reader<QFlags<QTextDocument::FindFlag> >() (args, heap) : gsi::arg_maker<QFlags<QTextDocument::FindFlag> >() (0, heap);
   ret.write<QTextCursor > ((QTextCursor)((QTextDocument *)cls)->find (arg1, arg2, arg3));
 }
 
@@ -481,7 +481,7 @@ static void _call_f_findBlock_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextBlock > ((QTextBlock)((QTextDocument *)cls)->findBlock (arg1));
 }
 
@@ -500,7 +500,7 @@ static void _call_f_findBlockByLineNumber_c767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextBlock > ((QTextBlock)((QTextDocument *)cls)->findBlockByLineNumber (arg1));
 }
 
@@ -519,7 +519,7 @@ static void _call_f_findBlockByNumber_c767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextBlock > ((QTextBlock)((QTextDocument *)cls)->findBlockByNumber (arg1));
 }
 
@@ -553,7 +553,7 @@ static void _call_f_frameAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextFrame * > ((QTextFrame *)((QTextDocument *)cls)->frameAt (arg1));
 }
 
@@ -709,8 +709,8 @@ static void _call_f_markContentsDirty_1426 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->markContentsDirty (arg1, arg2);
 }
@@ -745,7 +745,7 @@ static void _call_f_metaInformation_c3434 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextDocument::MetaInformation>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextDocument::MetaInformation>::target_type & > (heap);
+  const qt_gsi::Converter<QTextDocument::MetaInformation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextDocument::MetaInformation>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QTextDocument *)cls)->metaInformation (qt_gsi::QtToCppAdaptor<QTextDocument::MetaInformation>(arg1).cref()));
 }
 
@@ -764,7 +764,7 @@ static void _call_f_object_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextObject * > ((QTextObject *)((QTextDocument *)cls)->object (arg1));
 }
 
@@ -783,7 +783,7 @@ static void _call_f_objectForFormat_c2432 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFormat &arg1 = args.read<const QTextFormat & > (heap);
+  const QTextFormat &arg1 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   ret.write<QTextObject * > ((QTextObject *)((QTextDocument *)cls)->objectForFormat (arg1));
 }
 
@@ -832,7 +832,7 @@ static void _call_f_print_c1443 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->print (arg1);
 }
@@ -852,7 +852,7 @@ static void _call_f_redo_1762 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextCursor *arg1 = args.read<QTextCursor * > (heap);
+  QTextCursor *arg1 = gsi::arg_reader<QTextCursor * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->redo (arg1);
 }
@@ -890,8 +890,8 @@ static void _call_f_resource_c2360 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QUrl &arg2 = args.read<const QUrl & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QUrl &arg2 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QTextDocument *)cls)->resource (arg1, arg2));
 }
 
@@ -940,7 +940,7 @@ static void _call_f_setDefaultFont_1801 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setDefaultFont (arg1);
 }
@@ -960,7 +960,7 @@ static void _call_f_setDefaultStyleSheet_2025 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setDefaultStyleSheet (arg1);
 }
@@ -980,7 +980,7 @@ static void _call_f_setDefaultTextOption_2448 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextOption &arg1 = args.read<const QTextOption & > (heap);
+  const QTextOption &arg1 = gsi::arg_reader<const QTextOption & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setDefaultTextOption (arg1);
 }
@@ -1000,7 +1000,7 @@ static void _call_f_setDocumentLayout_3413 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractTextDocumentLayout *arg1 = args.read<QAbstractTextDocumentLayout * > (heap);
+  QAbstractTextDocumentLayout *arg1 = gsi::arg_reader<QAbstractTextDocumentLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setDocumentLayout (arg1);
 }
@@ -1020,7 +1020,7 @@ static void _call_f_setDocumentMargin_1071 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setDocumentMargin (arg1);
 }
@@ -1040,7 +1040,7 @@ static void _call_f_setHtml_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setHtml (arg1);
 }
@@ -1060,7 +1060,7 @@ static void _call_f_setIndentWidth_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setIndentWidth (arg1);
 }
@@ -1080,7 +1080,7 @@ static void _call_f_setMaximumBlockCount_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setMaximumBlockCount (arg1);
 }
@@ -1102,8 +1102,8 @@ static void _call_f_setMetaInformation_5351 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextDocument::MetaInformation>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextDocument::MetaInformation>::target_type & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const qt_gsi::Converter<QTextDocument::MetaInformation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextDocument::MetaInformation>::target_type & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setMetaInformation (qt_gsi::QtToCppAdaptor<QTextDocument::MetaInformation>(arg1).cref(), arg2);
 }
@@ -1123,7 +1123,7 @@ static void _call_f_setModified_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setModified (arg1);
 }
@@ -1143,7 +1143,7 @@ static void _call_f_setPageSize_1875 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSizeF &arg1 = args.read<const QSizeF & > (heap);
+  const QSizeF &arg1 = gsi::arg_reader<const QSizeF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setPageSize (arg1);
 }
@@ -1163,7 +1163,7 @@ static void _call_f_setPlainText_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setPlainText (arg1);
 }
@@ -1183,7 +1183,7 @@ static void _call_f_setTextWidth_1071 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setTextWidth (arg1);
 }
@@ -1203,7 +1203,7 @@ static void _call_f_setUndoRedoEnabled_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setUndoRedoEnabled (arg1);
 }
@@ -1223,7 +1223,7 @@ static void _call_f_setUseDesignMetrics_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->setUseDesignMetrics (arg1);
 }
@@ -1273,7 +1273,7 @@ static void _call_f_toHtml_c2309 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QByteArray &arg1 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QString > ((QString)((QTextDocument *)cls)->toHtml (arg1));
 }
 
@@ -1307,7 +1307,7 @@ static void _call_f_undo_1762 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextCursor *arg1 = args.read<QTextCursor * > (heap);
+  QTextCursor *arg1 = gsi::arg_reader<QTextCursor * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocument *)cls)->undo (arg1);
 }
@@ -1360,8 +1360,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextDocument::tr (arg1, arg2));
 }
 
@@ -1384,9 +1384,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextDocument::tr (arg1, arg2, arg3));
 }
 
@@ -1407,8 +1407,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextDocument::trUtf8 (arg1, arg2));
 }
 
@@ -1431,9 +1431,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextDocument::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1804,7 +1804,7 @@ static void _call_ctor_QTextDocument_Adaptor_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTextDocument_Adaptor *> (new QTextDocument_Adaptor (arg1));
 }
 
@@ -1824,8 +1824,8 @@ static void _call_ctor_QTextDocument_Adaptor_3219 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTextDocument_Adaptor *> (new QTextDocument_Adaptor (arg1, arg2));
 }
 
@@ -1843,7 +1843,7 @@ static void _call_emitter_blockCountChanged_767 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QTextDocument_Adaptor *)cls)->emitter_QTextDocument_blockCountChanged_767 (arg1);
 }
 
@@ -1909,9 +1909,9 @@ static void _call_emitter_contentsChange_2085 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QTextDocument_Adaptor *)cls)->emitter_QTextDocument_contentsChange_2085 (arg1, arg2, arg3);
 }
 
@@ -1966,7 +1966,7 @@ static void _call_emitter_cursorPositionChanged_2453 (const qt_gsi::GenericMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ((QTextDocument_Adaptor *)cls)->emitter_QTextDocument_cursorPositionChanged_2453 (arg1);
 }
 
@@ -2008,7 +2008,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTextDocument_Adaptor *)cls)->emitter_QTextDocument_destroyed_1302 (arg1);
 }
 
@@ -2139,7 +2139,7 @@ static void _call_emitter_modificationChanged_864 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextDocument_Adaptor *)cls)->emitter_QTextDocument_modificationChanged_864 (arg1);
 }
 
@@ -2157,7 +2157,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTextDocument_Adaptor *)cls)->fp_QTextDocument_receivers_c1731 (arg1));
 }
 
@@ -2175,7 +2175,7 @@ static void _call_emitter_redoAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextDocument_Adaptor *)cls)->emitter_QTextDocument_redoAvailable_864 (arg1);
 }
 
@@ -2231,7 +2231,7 @@ static void _call_emitter_undoAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextDocument_Adaptor *)cls)->emitter_QTextDocument_undoAvailable_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextDocumentFragment.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextDocumentFragment.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QTextDocumentFragment_2650 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextDocument *arg1 = args.read<const QTextDocument * > (heap);
+  const QTextDocument *arg1 = gsi::arg_reader<const QTextDocument * >() (args, heap);
   ret.write<QTextDocumentFragment *> (new QTextDocumentFragment (arg1));
 }
 
@@ -86,7 +86,7 @@ static void _call_ctor_QTextDocumentFragment_2453 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<QTextDocumentFragment *> (new QTextDocumentFragment (arg1));
 }
 
@@ -105,7 +105,7 @@ static void _call_ctor_QTextDocumentFragment_3466 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextDocumentFragment &arg1 = args.read<const QTextDocumentFragment & > (heap);
+  const QTextDocumentFragment &arg1 = gsi::arg_reader<const QTextDocumentFragment & >() (args, heap);
   ret.write<QTextDocumentFragment *> (new QTextDocumentFragment (arg1));
 }
 
@@ -139,7 +139,7 @@ static void _call_f_operator_eq__3466 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextDocumentFragment &arg1 = args.read<const QTextDocumentFragment & > (heap);
+  const QTextDocumentFragment &arg1 = gsi::arg_reader<const QTextDocumentFragment & >() (args, heap);
   ret.write<QTextDocumentFragment & > ((QTextDocumentFragment &)((QTextDocumentFragment *)cls)->operator= (arg1));
 }
 
@@ -173,7 +173,7 @@ static void _call_f_toHtml_c2309 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QString > ((QString)((QTextDocumentFragment *)cls)->toHtml (arg1));
 }
 
@@ -207,7 +207,7 @@ static void _call_f_fromHtml_2025 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QTextDocumentFragment > ((QTextDocumentFragment)QTextDocumentFragment::fromHtml (arg1));
 }
 
@@ -228,8 +228,8 @@ static void _call_f_fromHtml_4567 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QTextDocument *arg2 = args.read<const QTextDocument * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QTextDocument *arg2 = gsi::arg_reader<const QTextDocument * >() (args, heap);
   ret.write<QTextDocumentFragment > ((QTextDocumentFragment)QTextDocumentFragment::fromHtml (arg1, arg2));
 }
 
@@ -248,7 +248,7 @@ static void _call_f_fromPlainText_2025 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QTextDocumentFragment > ((QTextDocumentFragment)QTextDocumentFragment::fromPlainText (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextDocumentWriter.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextDocumentWriter.cc
@@ -71,8 +71,8 @@ static void _call_ctor_QTextDocumentWriter_3648 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const QByteArray &arg2 = args.read<const QByteArray & > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const QByteArray &arg2 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QTextDocumentWriter *> (new QTextDocumentWriter (arg1, arg2));
 }
 
@@ -93,8 +93,8 @@ static void _call_ctor_QTextDocumentWriter_4226 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QByteArray &arg2 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QByteArray &arg2 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QTextDocumentWriter *> (new QTextDocumentWriter (arg1, arg2));
 }
 
@@ -173,7 +173,7 @@ static void _call_f_setCodec_1602 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextCodec *arg1 = args.read<QTextCodec * > (heap);
+  QTextCodec *arg1 = gsi::arg_reader<QTextCodec * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocumentWriter *)cls)->setCodec (arg1);
 }
@@ -193,7 +193,7 @@ static void _call_f_setDevice_1447 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocumentWriter *)cls)->setDevice (arg1);
 }
@@ -213,7 +213,7 @@ static void _call_f_setFileName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocumentWriter *)cls)->setFileName (arg1);
 }
@@ -233,7 +233,7 @@ static void _call_f_setFormat_2309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextDocumentWriter *)cls)->setFormat (arg1);
 }
@@ -253,7 +253,7 @@ static void _call_f_write_2650 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextDocument *arg1 = args.read<const QTextDocument * > (heap);
+  const QTextDocument *arg1 = gsi::arg_reader<const QTextDocument * >() (args, heap);
   ret.write<bool > ((bool)((QTextDocumentWriter *)cls)->write (arg1));
 }
 
@@ -272,7 +272,7 @@ static void _call_f_write_3466 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextDocumentFragment &arg1 = args.read<const QTextDocumentFragment & > (heap);
+  const QTextDocumentFragment &arg1 = gsi::arg_reader<const QTextDocumentFragment & >() (args, heap);
   ret.write<bool > ((bool)((QTextDocumentWriter *)cls)->write (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextEdit.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextEdit.cc
@@ -150,7 +150,7 @@ static void _call_f_anchorAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QString > ((QString)((QTextEdit *)cls)->anchorAt (arg1));
 }
 
@@ -169,7 +169,7 @@ static void _call_f_append_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->append (arg1);
 }
@@ -266,7 +266,7 @@ static void _call_f_createStandardContextMenu_1916 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QMenu * > ((QMenu *)((QTextEdit *)cls)->createStandardContextMenu (arg1));
 }
 
@@ -315,7 +315,7 @@ static void _call_f_cursorForPosition_c1916 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QTextCursor > ((QTextCursor)((QTextEdit *)cls)->cursorForPosition (arg1));
 }
 
@@ -334,7 +334,7 @@ static void _call_f_cursorRect_c2453 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<QRect > ((QRect)((QTextEdit *)cls)->cursorRect (arg1));
 }
 
@@ -462,8 +462,8 @@ static void _call_f_find_5261 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<QTextDocument::FindFlag> arg2 = args ? args.read<QFlags<QTextDocument::FindFlag> > (heap) : (QFlags<QTextDocument::FindFlag>)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QTextDocument::FindFlag> arg2 = args ? gsi::arg_reader<QFlags<QTextDocument::FindFlag> >() (args, heap) : gsi::arg_maker<QFlags<QTextDocument::FindFlag> >() (0, heap);
   ret.write<bool > ((bool)((QTextEdit *)cls)->find (arg1, arg2));
 }
 
@@ -557,7 +557,7 @@ static void _call_f_insertHtml_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->insertHtml (arg1);
 }
@@ -577,7 +577,7 @@ static void _call_f_insertPlainText_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->insertPlainText (arg1);
 }
@@ -659,8 +659,8 @@ static void _call_f_loadResource_2360 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QUrl &arg2 = args.read<const QUrl & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QUrl &arg2 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QTextEdit *)cls)->loadResource (arg1, arg2));
 }
 
@@ -679,7 +679,7 @@ static void _call_f_mergeCurrentCharFormat_2814 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->mergeCurrentCharFormat (arg1);
 }
@@ -701,8 +701,8 @@ static void _call_f_moveCursor_5424 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & > (heap);
-  const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & > (heap) : (const qt_gsi::Converter<QTextCursor::MoveMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTextCursor::MoveMode>(heap, QTextCursor::MoveAnchor));
+  const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextCursor::MoveOperation>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTextCursor::MoveMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTextCursor::MoveMode>(heap, QTextCursor::MoveAnchor), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->moveCursor (qt_gsi::QtToCppAdaptor<QTextCursor::MoveOperation>(arg1).cref(), qt_gsi::QtToCppAdaptor<QTextCursor::MoveMode>(arg2).cref());
 }
@@ -753,7 +753,7 @@ static void _call_f_print_c1443 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->print (arg1);
 }
@@ -789,7 +789,7 @@ static void _call_f_scrollToAnchor_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->scrollToAnchor (arg1);
 }
@@ -825,7 +825,7 @@ static void _call_f_setAcceptRichText_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setAcceptRichText (arg1);
 }
@@ -845,7 +845,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setAlignment (arg1);
 }
@@ -865,7 +865,7 @@ static void _call_f_setAutoFormatting_3978 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QTextEdit::AutoFormattingFlag> arg1 = args.read<QFlags<QTextEdit::AutoFormattingFlag> > (heap);
+  QFlags<QTextEdit::AutoFormattingFlag> arg1 = gsi::arg_reader<QFlags<QTextEdit::AutoFormattingFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setAutoFormatting (arg1);
 }
@@ -885,7 +885,7 @@ static void _call_f_setCurrentCharFormat_2814 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setCurrentCharFormat (arg1);
 }
@@ -905,7 +905,7 @@ static void _call_f_setCurrentFont_1801 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setCurrentFont (arg1);
 }
@@ -925,7 +925,7 @@ static void _call_f_setCursorWidth_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setCursorWidth (arg1);
 }
@@ -945,7 +945,7 @@ static void _call_f_setDocument_1955 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setDocument (arg1);
 }
@@ -965,7 +965,7 @@ static void _call_f_setDocumentTitle_2025 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setDocumentTitle (arg1);
 }
@@ -985,7 +985,7 @@ static void _call_f_setExtraSelections_4386 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QTextEdit::ExtraSelection> &arg1 = args.read<const QList<QTextEdit::ExtraSelection> & > (heap);
+  const QList<QTextEdit::ExtraSelection> &arg1 = gsi::arg_reader<const QList<QTextEdit::ExtraSelection> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setExtraSelections (arg1);
 }
@@ -1005,7 +1005,7 @@ static void _call_f_setFontFamily_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setFontFamily (arg1);
 }
@@ -1025,7 +1025,7 @@ static void _call_f_setFontItalic_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setFontItalic (arg1);
 }
@@ -1045,7 +1045,7 @@ static void _call_f_setFontPointSize_1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setFontPointSize (arg1);
 }
@@ -1065,7 +1065,7 @@ static void _call_f_setFontUnderline_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setFontUnderline (arg1);
 }
@@ -1085,7 +1085,7 @@ static void _call_f_setFontWeight_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setFontWeight (arg1);
 }
@@ -1105,7 +1105,7 @@ static void _call_f_setHtml_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setHtml (arg1);
 }
@@ -1125,7 +1125,7 @@ static void _call_f_setLineWrapColumnOrWidth_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setLineWrapColumnOrWidth (arg1);
 }
@@ -1145,7 +1145,7 @@ static void _call_f_setLineWrapMode_2635 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextEdit::LineWrapMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextEdit::LineWrapMode>::target_type & > (heap);
+  const qt_gsi::Converter<QTextEdit::LineWrapMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextEdit::LineWrapMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setLineWrapMode (qt_gsi::QtToCppAdaptor<QTextEdit::LineWrapMode>(arg1).cref());
 }
@@ -1165,7 +1165,7 @@ static void _call_f_setOverwriteMode_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setOverwriteMode (arg1);
 }
@@ -1185,7 +1185,7 @@ static void _call_f_setPlainText_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setPlainText (arg1);
 }
@@ -1205,7 +1205,7 @@ static void _call_f_setReadOnly_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setReadOnly (arg1);
 }
@@ -1225,7 +1225,7 @@ static void _call_f_setTabChangesFocus_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setTabChangesFocus (arg1);
 }
@@ -1245,7 +1245,7 @@ static void _call_f_setTabStopWidth_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setTabStopWidth (arg1);
 }
@@ -1265,7 +1265,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setText (arg1);
 }
@@ -1285,7 +1285,7 @@ static void _call_f_setTextBackgroundColor_1905 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setTextBackgroundColor (arg1);
 }
@@ -1305,7 +1305,7 @@ static void _call_f_setTextColor_1905 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QColor &arg1 = args.read<const QColor & > (heap);
+  const QColor &arg1 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setTextColor (arg1);
 }
@@ -1325,7 +1325,7 @@ static void _call_f_setTextCursor_2453 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setTextCursor (arg1);
 }
@@ -1345,7 +1345,7 @@ static void _call_f_setTextInteractionFlags_3396 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::TextInteractionFlag> arg1 = args.read<QFlags<Qt::TextInteractionFlag> > (heap);
+  QFlags<Qt::TextInteractionFlag> arg1 = gsi::arg_reader<QFlags<Qt::TextInteractionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setTextInteractionFlags (arg1);
 }
@@ -1365,7 +1365,7 @@ static void _call_f_setUndoRedoEnabled_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setUndoRedoEnabled (arg1);
 }
@@ -1385,7 +1385,7 @@ static void _call_f_setWordWrapMode_2486 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextOption::WrapMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextOption::WrapMode>::target_type & > (heap);
+  const qt_gsi::Converter<QTextOption::WrapMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextOption::WrapMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->setWordWrapMode (qt_gsi::QtToCppAdaptor<QTextOption::WrapMode>(arg1).cref());
 }
@@ -1556,7 +1556,7 @@ static void _call_f_zoomIn_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->zoomIn (arg1);
 }
@@ -1576,7 +1576,7 @@ static void _call_f_zoomOut_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit *)cls)->zoomOut (arg1);
 }
@@ -1598,8 +1598,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextEdit::tr (arg1, arg2));
 }
 
@@ -1622,9 +1622,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextEdit::tr (arg1, arg2, arg3));
 }
 
@@ -1645,8 +1645,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextEdit::trUtf8 (arg1, arg2));
 }
 
@@ -1669,9 +1669,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextEdit::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2785,7 +2785,7 @@ static void _call_ctor_QTextEdit_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTextEdit_Adaptor *> (new QTextEdit_Adaptor (arg1));
 }
 
@@ -2805,8 +2805,8 @@ static void _call_ctor_QTextEdit_Adaptor_3232 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTextEdit_Adaptor *> (new QTextEdit_Adaptor (arg1, arg2));
 }
 
@@ -2967,7 +2967,7 @@ static void _call_emitter_copyAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextEdit_Adaptor *)cls)->emitter_QTextEdit_copyAvailable_864 (arg1);
 }
 
@@ -2989,9 +2989,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit_Adaptor *)cls)->fp_QTextEdit_create_2208 (arg1, arg2, arg3);
 }
@@ -3029,7 +3029,7 @@ static void _call_emitter_currentCharFormatChanged_2814 (const qt_gsi::GenericMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   ((QTextEdit_Adaptor *)cls)->emitter_QTextEdit_currentCharFormatChanged_2814 (arg1);
 }
 
@@ -3061,7 +3061,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QTextEdit_Adaptor *)cls)->emitter_QTextEdit_customContextMenuRequested_1916 (arg1);
 }
 
@@ -3105,8 +3105,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit_Adaptor *)cls)->fp_QTextEdit_destroy_1620 (arg1, arg2);
 }
@@ -3125,7 +3125,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTextEdit_Adaptor *)cls)->emitter_QTextEdit_destroyed_1302 (arg1);
 }
 
@@ -3239,7 +3239,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit_Adaptor *)cls)->fp_QTextEdit_drawFrame_1426 (arg1);
 }
@@ -3967,7 +3967,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTextEdit_Adaptor *)cls)->fp_QTextEdit_receivers_c1731 (arg1));
 }
 
@@ -3985,7 +3985,7 @@ static void _call_emitter_redoAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextEdit_Adaptor *)cls)->emitter_QTextEdit_redoAvailable_864 (arg1);
 }
 
@@ -4103,10 +4103,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit_Adaptor *)cls)->fp_QTextEdit_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -4125,7 +4125,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit_Adaptor *)cls)->fp_QTextEdit_setViewportMargins_2115 (arg1);
 }
@@ -4168,7 +4168,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextEdit_Adaptor *)cls)->fp_QTextEdit_setupViewport_1315 (arg1);
 }
@@ -4316,7 +4316,7 @@ static void _call_emitter_undoAvailable_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QTextEdit_Adaptor *)cls)->emitter_QTextEdit_undoAvailable_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextFormat.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextFormat.cc
@@ -76,7 +76,7 @@ static void _call_ctor_QTextFormat_767 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextFormat *> (new QTextFormat (arg1));
 }
 
@@ -95,7 +95,7 @@ static void _call_ctor_QTextFormat_2432 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFormat &arg1 = args.read<const QTextFormat & > (heap);
+  const QTextFormat &arg1 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   ret.write<QTextFormat *> (new QTextFormat (arg1));
 }
 
@@ -129,7 +129,7 @@ static void _call_f_boolProperty_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTextFormat *)cls)->boolProperty (arg1));
 }
 
@@ -148,7 +148,7 @@ static void _call_f_brushProperty_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QBrush > ((QBrush)((QTextFormat *)cls)->brushProperty (arg1));
 }
 
@@ -199,7 +199,7 @@ static void _call_f_clearProperty_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFormat *)cls)->clearProperty (arg1);
 }
@@ -219,7 +219,7 @@ static void _call_f_colorProperty_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QColor > ((QColor)((QTextFormat *)cls)->colorProperty (arg1));
 }
 
@@ -238,7 +238,7 @@ static void _call_f_doubleProperty_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<double > ((double)((QTextFormat *)cls)->doubleProperty (arg1));
 }
 
@@ -272,7 +272,7 @@ static void _call_f_hasProperty_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTextFormat *)cls)->hasProperty (arg1));
 }
 
@@ -291,7 +291,7 @@ static void _call_f_intProperty_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTextFormat *)cls)->intProperty (arg1));
 }
 
@@ -445,7 +445,7 @@ static void _call_f_lengthProperty_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextLength > ((QTextLength)((QTextFormat *)cls)->lengthProperty (arg1));
 }
 
@@ -464,7 +464,7 @@ static void _call_f_lengthVectorProperty_c767 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVector<QTextLength> > ((QVector<QTextLength>)((QTextFormat *)cls)->lengthVectorProperty (arg1));
 }
 
@@ -483,7 +483,7 @@ static void _call_f_merge_2432 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFormat &arg1 = args.read<const QTextFormat & > (heap);
+  const QTextFormat &arg1 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFormat *)cls)->merge (arg1);
 }
@@ -533,7 +533,7 @@ static void _call_f_operator_excl__eq__c2432 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFormat &arg1 = args.read<const QTextFormat & > (heap);
+  const QTextFormat &arg1 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   ret.write<bool > ((bool)((QTextFormat *)cls)->operator!= (arg1));
 }
 
@@ -552,7 +552,7 @@ static void _call_f_operator_eq__2432 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFormat &arg1 = args.read<const QTextFormat & > (heap);
+  const QTextFormat &arg1 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   ret.write<QTextFormat & > ((QTextFormat &)((QTextFormat *)cls)->operator= (arg1));
 }
 
@@ -571,7 +571,7 @@ static void _call_f_operator_eq__eq__c2432 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFormat &arg1 = args.read<const QTextFormat & > (heap);
+  const QTextFormat &arg1 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   ret.write<bool > ((bool)((QTextFormat *)cls)->operator== (arg1));
 }
 
@@ -590,7 +590,7 @@ static void _call_f_penProperty_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QPen > ((QPen)((QTextFormat *)cls)->penProperty (arg1));
 }
 
@@ -624,7 +624,7 @@ static void _call_f_property_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QTextFormat *)cls)->property (arg1));
 }
 
@@ -658,7 +658,7 @@ static void _call_f_setBackground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFormat *)cls)->setBackground (arg1);
 }
@@ -678,7 +678,7 @@ static void _call_f_setForeground_1910 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFormat *)cls)->setForeground (arg1);
 }
@@ -698,7 +698,7 @@ static void _call_f_setLayoutDirection_2316 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFormat *)cls)->setLayoutDirection (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref());
 }
@@ -718,7 +718,7 @@ static void _call_f_setObjectIndex_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFormat *)cls)->setObjectIndex (arg1);
 }
@@ -738,7 +738,7 @@ static void _call_f_setObjectType_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFormat *)cls)->setObjectType (arg1);
 }
@@ -760,8 +760,8 @@ static void _call_f_setProperty_2778 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFormat *)cls)->setProperty (arg1, arg2);
 }
@@ -783,8 +783,8 @@ static void _call_f_setProperty_3914 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVector<QTextLength> &arg2 = args.read<const QVector<QTextLength> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVector<QTextLength> &arg2 = gsi::arg_reader<const QVector<QTextLength> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFormat *)cls)->setProperty (arg1, arg2);
 }
@@ -804,7 +804,7 @@ static void _call_f_stringProperty_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTextFormat *)cls)->stringProperty (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextFragment.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextFragment.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QTextFragment_2635 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFragment &arg1 = args.read<const QTextFragment & > (heap);
+  const QTextFragment &arg1 = gsi::arg_reader<const QTextFragment & >() (args, heap);
   ret.write<QTextFragment *> (new QTextFragment (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_contains_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTextFragment *)cls)->contains (arg1));
 }
 
@@ -164,7 +164,7 @@ static void _call_f_operator_excl__eq__c2635 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFragment &arg1 = args.read<const QTextFragment & > (heap);
+  const QTextFragment &arg1 = gsi::arg_reader<const QTextFragment & >() (args, heap);
   ret.write<bool > ((bool)((QTextFragment *)cls)->operator!= (arg1));
 }
 
@@ -183,7 +183,7 @@ static void _call_f_operator_lt__c2635 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFragment &arg1 = args.read<const QTextFragment & > (heap);
+  const QTextFragment &arg1 = gsi::arg_reader<const QTextFragment & >() (args, heap);
   ret.write<bool > ((bool)((QTextFragment *)cls)->operator< (arg1));
 }
 
@@ -202,7 +202,7 @@ static void _call_f_operator_eq__2635 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFragment &arg1 = args.read<const QTextFragment & > (heap);
+  const QTextFragment &arg1 = gsi::arg_reader<const QTextFragment & >() (args, heap);
   ret.write<QTextFragment & > ((QTextFragment &)((QTextFragment *)cls)->operator= (arg1));
 }
 
@@ -221,7 +221,7 @@ static void _call_f_operator_eq__eq__c2635 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFragment &arg1 = args.read<const QTextFragment & > (heap);
+  const QTextFragment &arg1 = gsi::arg_reader<const QTextFragment & >() (args, heap);
   ret.write<bool > ((bool)((QTextFragment *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextFrame.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextFrame.cc
@@ -177,7 +177,7 @@ static void _call_f_setFrameFormat_2923 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFrameFormat &arg1 = args.read<const QTextFrameFormat & > (heap);
+  const QTextFrameFormat &arg1 = gsi::arg_reader<const QTextFrameFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrame *)cls)->setFrameFormat (arg1);
 }
@@ -199,8 +199,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextFrame::tr (arg1, arg2));
 }
 
@@ -223,9 +223,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextFrame::tr (arg1, arg2, arg3));
 }
 
@@ -246,8 +246,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextFrame::trUtf8 (arg1, arg2));
 }
 
@@ -270,9 +270,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextFrame::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -456,7 +456,7 @@ static void _call_ctor_QTextFrame_Adaptor_1955 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   ret.write<QTextFrame_Adaptor *> (new QTextFrame_Adaptor (arg1));
 }
 
@@ -522,7 +522,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTextFrame_Adaptor *)cls)->emitter_QTextFrame_destroyed_1302 (arg1);
 }
 
@@ -613,7 +613,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTextFrame_Adaptor *)cls)->fp_QTextFrame_receivers_c1731 (arg1));
 }
 
@@ -645,7 +645,7 @@ static void _call_fp_setFormat_2432 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFormat &arg1 = args.read<const QTextFormat & > (heap);
+  const QTextFormat &arg1 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrame_Adaptor *)cls)->fp_QTextFrame_setFormat_2432 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextFrameFormat.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextFrameFormat.cc
@@ -256,7 +256,7 @@ static void _call_f_setBorder_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setBorder (arg1);
 }
@@ -276,7 +276,7 @@ static void _call_f_setBorderBrush_1910 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBrush &arg1 = args.read<const QBrush & > (heap);
+  const QBrush &arg1 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setBorderBrush (arg1);
 }
@@ -296,7 +296,7 @@ static void _call_f_setBorderStyle_3297 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextFrameFormat::BorderStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextFrameFormat::BorderStyle>::target_type & > (heap);
+  const qt_gsi::Converter<QTextFrameFormat::BorderStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextFrameFormat::BorderStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setBorderStyle (qt_gsi::QtToCppAdaptor<QTextFrameFormat::BorderStyle>(arg1).cref());
 }
@@ -316,7 +316,7 @@ static void _call_f_setBottomMargin_1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setBottomMargin (arg1);
 }
@@ -336,7 +336,7 @@ static void _call_f_setHeight_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setHeight (arg1);
 }
@@ -356,7 +356,7 @@ static void _call_f_setHeight_2425 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextLength &arg1 = args.read<const QTextLength & > (heap);
+  const QTextLength &arg1 = gsi::arg_reader<const QTextLength & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setHeight (arg1);
 }
@@ -376,7 +376,7 @@ static void _call_f_setLeftMargin_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setLeftMargin (arg1);
 }
@@ -396,7 +396,7 @@ static void _call_f_setMargin_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setMargin (arg1);
 }
@@ -416,7 +416,7 @@ static void _call_f_setPadding_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setPadding (arg1);
 }
@@ -436,7 +436,7 @@ static void _call_f_setPageBreakPolicy_3611 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QTextFormat::PageBreakFlag> arg1 = args.read<QFlags<QTextFormat::PageBreakFlag> > (heap);
+  QFlags<QTextFormat::PageBreakFlag> arg1 = gsi::arg_reader<QFlags<QTextFormat::PageBreakFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setPageBreakPolicy (arg1);
 }
@@ -456,7 +456,7 @@ static void _call_f_setPosition_3015 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextFrameFormat::Position>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextFrameFormat::Position>::target_type & > (heap);
+  const qt_gsi::Converter<QTextFrameFormat::Position>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextFrameFormat::Position>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setPosition (qt_gsi::QtToCppAdaptor<QTextFrameFormat::Position>(arg1).cref());
 }
@@ -476,7 +476,7 @@ static void _call_f_setRightMargin_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setRightMargin (arg1);
 }
@@ -496,7 +496,7 @@ static void _call_f_setTopMargin_1071 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setTopMargin (arg1);
 }
@@ -516,7 +516,7 @@ static void _call_f_setWidth_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setWidth (arg1);
 }
@@ -536,7 +536,7 @@ static void _call_f_setWidth_2425 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextLength &arg1 = args.read<const QTextLength & > (heap);
+  const QTextLength &arg1 = gsi::arg_reader<const QTextLength & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextFrameFormat *)cls)->setWidth (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextFrame_Iterator.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextFrame_Iterator.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QTextFrame_Iterator_3296u1 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFrame::iterator &arg1 = args.read<const QTextFrame::iterator & > (heap);
+  const QTextFrame::iterator &arg1 = gsi::arg_reader<const QTextFrame::iterator & >() (args, heap);
   ret.write<QTextFrame::iterator *> (new QTextFrame::iterator (arg1));
 }
 
@@ -131,7 +131,7 @@ static void _call_f_operator_excl__eq__c3296u1 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFrame::iterator &arg1 = args.read<const QTextFrame::iterator & > (heap);
+  const QTextFrame::iterator &arg1 = gsi::arg_reader<const QTextFrame::iterator & >() (args, heap);
   ret.write<bool > ((bool)((QTextFrame::iterator *)cls)->operator!= (arg1));
 }
 
@@ -165,7 +165,7 @@ static void _call_f_operator_plus__plus__767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextFrame::iterator > ((QTextFrame::iterator)((QTextFrame::iterator *)cls)->operator++ (arg1));
 }
 
@@ -199,7 +199,7 @@ static void _call_f_operator_minus__minus__767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextFrame::iterator > ((QTextFrame::iterator)((QTextFrame::iterator *)cls)->operator-- (arg1));
 }
 
@@ -218,7 +218,7 @@ static void _call_f_operator_eq__3296 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFrame::iterator &arg1 = args.read<const QTextFrame::iterator & > (heap);
+  const QTextFrame::iterator &arg1 = gsi::arg_reader<const QTextFrame::iterator & >() (args, heap);
   ret.write<QTextFrame::iterator & > ((QTextFrame::iterator &)((QTextFrame::iterator *)cls)->operator= (arg1));
 }
 
@@ -237,7 +237,7 @@ static void _call_f_operator_eq__eq__c3296u1 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFrame::iterator &arg1 = args.read<const QTextFrame::iterator & > (heap);
+  const QTextFrame::iterator &arg1 = gsi::arg_reader<const QTextFrame::iterator & >() (args, heap);
   ret.write<bool > ((bool)((QTextFrame::iterator *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextImageFormat.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextImageFormat.cc
@@ -122,7 +122,7 @@ static void _call_f_setHeight_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextImageFormat *)cls)->setHeight (arg1);
 }
@@ -142,7 +142,7 @@ static void _call_f_setName_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextImageFormat *)cls)->setName (arg1);
 }
@@ -162,7 +162,7 @@ static void _call_f_setWidth_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextImageFormat *)cls)->setWidth (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextInlineObject.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextInlineObject.cc
@@ -172,7 +172,7 @@ static void _call_f_setAscent_1071 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextInlineObject *)cls)->setAscent (arg1);
 }
@@ -192,7 +192,7 @@ static void _call_f_setDescent_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextInlineObject *)cls)->setDescent (arg1);
 }
@@ -212,7 +212,7 @@ static void _call_f_setWidth_1071 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextInlineObject *)cls)->setWidth (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextLayout.cc
@@ -73,7 +73,7 @@ static void _call_ctor_QTextLayout_2025 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QTextLayout *> (new QTextLayout (arg1));
 }
 
@@ -96,9 +96,9 @@ static void _call_ctor_QTextLayout_5413 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QFont &arg2 = args.read<const QFont & > (heap);
-  QPaintDevice *arg3 = args ? args.read<QPaintDevice * > (heap) : (QPaintDevice *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QFont &arg2 = gsi::arg_reader<const QFont & >() (args, heap);
+  QPaintDevice *arg3 = args ? gsi::arg_reader<QPaintDevice * >() (args, heap) : gsi::arg_maker<QPaintDevice * >() (0, heap);
   ret.write<QTextLayout *> (new QTextLayout (arg1, arg2, arg3));
 }
 
@@ -117,7 +117,7 @@ static void _call_ctor_QTextLayout_2306 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<QTextLayout *> (new QTextLayout (arg1));
 }
 
@@ -250,10 +250,10 @@ static void _call_f_draw_c9459 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
-  const QVector<QTextLayout::FormatRange> &arg3 = args ? args.read<const QVector<QTextLayout::FormatRange> & > (heap) : (const QVector<QTextLayout::FormatRange> &)(QVector<QTextLayout::FormatRange>());
-  const QRectF &arg4 = args ? args.read<const QRectF & > (heap) : (const QRectF &)(QRectF());
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QVector<QTextLayout::FormatRange> &arg3 = args ? gsi::arg_reader<const QVector<QTextLayout::FormatRange> & >() (args, heap) : gsi::arg_maker<const QVector<QTextLayout::FormatRange> & >() (QVector<QTextLayout::FormatRange>(), heap);
+  const QRectF &arg4 = args ? gsi::arg_reader<const QRectF & >() (args, heap) : gsi::arg_maker<const QRectF & >() (QRectF(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->draw (arg1, arg2, arg3, arg4);
 }
@@ -277,9 +277,9 @@ static void _call_f_drawCursor_c3963 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
-  int arg3 = args.read<int > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->drawCursor (arg1, arg2, arg3);
 }
@@ -305,10 +305,10 @@ static void _call_f_drawCursor_c4622 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->drawCursor (arg1, arg2, arg3, arg4);
 }
@@ -359,7 +359,7 @@ static void _call_f_isValidCursorPosition_c767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTextLayout *)cls)->isValidCursorPosition (arg1));
 }
 
@@ -378,7 +378,7 @@ static void _call_f_lineAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextLine > ((QTextLine)((QTextLayout *)cls)->lineAt (arg1));
 }
 
@@ -412,7 +412,7 @@ static void _call_f_lineForTextPosition_c767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextLine > ((QTextLine)((QTextLayout *)cls)->lineForTextPosition (arg1));
 }
 
@@ -463,8 +463,8 @@ static void _call_f_nextCursorPosition_c3378 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & > (heap) : (const qt_gsi::Converter<QTextLayout::CursorMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTextLayout::CursorMode>(heap, QTextLayout::SkipCharacters));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTextLayout::CursorMode>(heap, QTextLayout::SkipCharacters), heap);
   ret.write<int > ((int)((QTextLayout *)cls)->nextCursorPosition (arg1, qt_gsi::QtToCppAdaptor<QTextLayout::CursorMode>(arg2).cref()));
 }
 
@@ -530,8 +530,8 @@ static void _call_f_previousCursorPosition_c3378 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & > (heap) : (const qt_gsi::Converter<QTextLayout::CursorMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTextLayout::CursorMode>(heap, QTextLayout::SkipCharacters));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTextLayout::CursorMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTextLayout::CursorMode>(heap, QTextLayout::SkipCharacters), heap);
   ret.write<int > ((int)((QTextLayout *)cls)->previousCursorPosition (arg1, qt_gsi::QtToCppAdaptor<QTextLayout::CursorMode>(arg2).cref()));
 }
 
@@ -550,7 +550,7 @@ static void _call_f_setAdditionalFormats_4294 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QTextLayout::FormatRange> &arg1 = args.read<const QList<QTextLayout::FormatRange> & > (heap);
+  const QList<QTextLayout::FormatRange> &arg1 = gsi::arg_reader<const QList<QTextLayout::FormatRange> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->setAdditionalFormats (arg1);
 }
@@ -570,7 +570,7 @@ static void _call_f_setCacheEnabled_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->setCacheEnabled (arg1);
 }
@@ -590,7 +590,7 @@ static void _call_f_setFlags_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->setFlags (arg1);
 }
@@ -610,7 +610,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->setFont (arg1);
 }
@@ -630,7 +630,7 @@ static void _call_f_setPosition_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->setPosition (arg1);
 }
@@ -652,8 +652,8 @@ static void _call_f_setPreeditArea_2684 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->setPreeditArea (arg1, arg2);
 }
@@ -673,7 +673,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->setText (arg1);
 }
@@ -693,7 +693,7 @@ static void _call_f_setTextOption_2448 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextOption &arg1 = args.read<const QTextOption & > (heap);
+  const QTextOption &arg1 = gsi::arg_reader<const QTextOption & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLayout *)cls)->setTextOption (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextLength.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextLength.cc
@@ -67,8 +67,8 @@ static void _call_ctor_QTextLength_3045 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextLength::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextLength::Type>::target_type & > (heap);
-  double arg2 = args.read<double > (heap);
+  const qt_gsi::Converter<QTextLength::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextLength::Type>::target_type & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTextLength *> (new QTextLength (qt_gsi::QtToCppAdaptor<QTextLength::Type>(arg1).cref(), arg2));
 }
 
@@ -87,7 +87,7 @@ static void _call_f_operator_excl__eq__c2425 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextLength &arg1 = args.read<const QTextLength & > (heap);
+  const QTextLength &arg1 = gsi::arg_reader<const QTextLength & >() (args, heap);
   ret.write<bool > ((bool)((QTextLength *)cls)->operator!= (arg1));
 }
 
@@ -106,7 +106,7 @@ static void _call_f_operator_eq__eq__c2425 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextLength &arg1 = args.read<const QTextLength & > (heap);
+  const QTextLength &arg1 = gsi::arg_reader<const QTextLength & >() (args, heap);
   ret.write<bool > ((bool)((QTextLength *)cls)->operator== (arg1));
 }
 
@@ -155,7 +155,7 @@ static void _call_f_value_c1071 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<double > ((double)((QTextLength *)cls)->value (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextLine.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextLine.cc
@@ -85,8 +85,8 @@ static void _call_f_cursorToX_c2664 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  const qt_gsi::Converter<QTextLine::Edge>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTextLine::Edge>::target_type & > (heap) : (const qt_gsi::Converter<QTextLine::Edge>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTextLine::Edge>(heap, QTextLine::Leading));
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  const qt_gsi::Converter<QTextLine::Edge>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTextLine::Edge>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTextLine::Edge>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTextLine::Edge>(heap, QTextLine::Leading), heap);
   ret.write<double > ((double)((QTextLine *)cls)->cursorToX (arg1, qt_gsi::QtToCppAdaptor<QTextLine::Edge>(arg2).cref()));
 }
 
@@ -107,8 +107,8 @@ static void _call_f_cursorToX_c2478 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QTextLine::Edge>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTextLine::Edge>::target_type & > (heap) : (const qt_gsi::Converter<QTextLine::Edge>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTextLine::Edge>(heap, QTextLine::Leading));
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QTextLine::Edge>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTextLine::Edge>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTextLine::Edge>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTextLine::Edge>(heap, QTextLine::Leading), heap);
   ret.write<double > ((double)((QTextLine *)cls)->cursorToX (arg1, qt_gsi::QtToCppAdaptor<QTextLine::Edge>(arg2).cref()));
 }
 
@@ -146,9 +146,9 @@ static void _call_f_draw_c6879 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QPointF &arg2 = args.read<const QPointF & > (heap);
-  const QTextLayout::FormatRange *arg3 = args ? args.read<const QTextLayout::FormatRange * > (heap) : (const QTextLayout::FormatRange *)(0);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QPointF &arg2 = gsi::arg_reader<const QPointF & >() (args, heap);
+  const QTextLayout::FormatRange *arg3 = args ? gsi::arg_reader<const QTextLayout::FormatRange * >() (args, heap) : gsi::arg_maker<const QTextLayout::FormatRange * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLine *)cls)->draw (arg1, arg2, arg3);
 }
@@ -303,7 +303,7 @@ static void _call_f_setLeadingIncluded_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLine *)cls)->setLeadingIncluded (arg1);
 }
@@ -323,7 +323,7 @@ static void _call_f_setLineWidth_1071 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLine *)cls)->setLineWidth (arg1);
 }
@@ -343,7 +343,7 @@ static void _call_f_setNumColumns_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLine *)cls)->setNumColumns (arg1);
 }
@@ -365,8 +365,8 @@ static void _call_f_setNumColumns_1730 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  double arg2 = args.read<double > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLine *)cls)->setNumColumns (arg1, arg2);
 }
@@ -386,7 +386,7 @@ static void _call_f_setPosition_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextLine *)cls)->setPosition (arg1);
 }
@@ -468,8 +468,8 @@ static void _call_f_xToCursor_c3900 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  const qt_gsi::Converter<QTextLine::CursorPosition>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTextLine::CursorPosition>::target_type & > (heap) : (const qt_gsi::Converter<QTextLine::CursorPosition>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTextLine::CursorPosition>(heap, QTextLine::CursorBetweenCharacters));
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<QTextLine::CursorPosition>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTextLine::CursorPosition>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTextLine::CursorPosition>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTextLine::CursorPosition>(heap, QTextLine::CursorBetweenCharacters), heap);
   ret.write<int > ((int)((QTextLine *)cls)->xToCursor (arg1, qt_gsi::QtToCppAdaptor<QTextLine::CursorPosition>(arg2).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextList.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextList.cc
@@ -71,7 +71,7 @@ static void _call_f_add_2306 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextList *)cls)->add (arg1);
 }
@@ -136,7 +136,7 @@ static void _call_f_item_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextBlock > ((QTextBlock)((QTextList *)cls)->item (arg1));
 }
 
@@ -155,7 +155,7 @@ static void _call_f_itemNumber_c2306 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<int > ((int)((QTextList *)cls)->itemNumber (arg1));
 }
 
@@ -174,7 +174,7 @@ static void _call_f_itemText_c2306 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   ret.write<QString > ((QString)((QTextList *)cls)->itemText (arg1));
 }
 
@@ -193,7 +193,7 @@ static void _call_f_remove_2306 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextBlock &arg1 = args.read<const QTextBlock & > (heap);
+  const QTextBlock &arg1 = gsi::arg_reader<const QTextBlock & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextList *)cls)->remove (arg1);
 }
@@ -213,7 +213,7 @@ static void _call_f_removeItem_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextList *)cls)->removeItem (arg1);
 }
@@ -233,7 +233,7 @@ static void _call_f_setFormat_2844 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextListFormat &arg1 = args.read<const QTextListFormat & > (heap);
+  const QTextListFormat &arg1 = gsi::arg_reader<const QTextListFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextList *)cls)->setFormat (arg1);
 }
@@ -255,8 +255,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextList::tr (arg1, arg2));
 }
 
@@ -279,9 +279,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextList::tr (arg1, arg2, arg3));
 }
 
@@ -302,8 +302,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextList::trUtf8 (arg1, arg2));
 }
 
@@ -326,9 +326,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextList::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -562,7 +562,7 @@ static void _call_ctor_QTextList_Adaptor_1955 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   ret.write<QTextList_Adaptor *> (new QTextList_Adaptor (arg1));
 }
 
@@ -714,7 +714,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTextList_Adaptor *)cls)->emitter_QTextList_destroyed_1302 (arg1);
 }
 
@@ -805,7 +805,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTextList_Adaptor *)cls)->fp_QTextList_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextListFormat.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextListFormat.cc
@@ -106,7 +106,7 @@ static void _call_f_setIndent_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextListFormat *)cls)->setIndent (arg1);
 }
@@ -126,7 +126,7 @@ static void _call_f_setStyle_2612 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextListFormat::Style>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextListFormat::Style>::target_type & > (heap);
+  const qt_gsi::Converter<QTextListFormat::Style>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextListFormat::Style>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextListFormat *)cls)->setStyle (qt_gsi::QtToCppAdaptor<QTextListFormat::Style>(arg1).cref());
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextObject.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextObject.cc
@@ -132,8 +132,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextObject::tr (arg1, arg2));
 }
 
@@ -156,9 +156,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextObject::tr (arg1, arg2, arg3));
 }
 
@@ -179,8 +179,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextObject::trUtf8 (arg1, arg2));
 }
 
@@ -203,9 +203,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextObject::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -427,7 +427,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTextObject_Adaptor *)cls)->emitter_QTextObject_destroyed_1302 (arg1);
 }
 
@@ -518,7 +518,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTextObject_Adaptor *)cls)->fp_QTextObject_receivers_c1731 (arg1));
 }
 
@@ -550,7 +550,7 @@ static void _call_fp_setFormat_2432 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextFormat &arg1 = args.read<const QTextFormat & > (heap);
+  const QTextFormat &arg1 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextObject_Adaptor *)cls)->fp_QTextObject_setFormat_2432 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextObjectInterface.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextObjectInterface.cc
@@ -63,11 +63,11 @@ static void _call_f_drawObject_8010 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRectF &arg2 = args.read<const QRectF & > (heap);
-  QTextDocument *arg3 = args.read<QTextDocument * > (heap);
-  int arg4 = args.read<int > (heap);
-  const QTextFormat &arg5 = args.read<const QTextFormat & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRectF &arg2 = gsi::arg_reader<const QRectF & >() (args, heap);
+  QTextDocument *arg3 = gsi::arg_reader<QTextDocument * >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
+  const QTextFormat &arg5 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextObjectInterface *)cls)->drawObject (arg1, arg2, arg3, arg4, arg5);
 }
@@ -91,9 +91,9 @@ static void _call_f_intrinsicSize_4938 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
-  int arg2 = args.read<int > (heap);
-  const QTextFormat &arg3 = args.read<const QTextFormat & > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QTextFormat &arg3 = gsi::arg_reader<const QTextFormat & >() (args, heap);
   ret.write<QSizeF > ((QSizeF)((QTextObjectInterface *)cls)->intrinsicSize (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextOption.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextOption.cc
@@ -65,7 +65,7 @@ static void _call_ctor_QTextOption_2750 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   ret.write<QTextOption *> (new QTextOption (arg1));
 }
 
@@ -84,7 +84,7 @@ static void _call_ctor_QTextOption_2448 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextOption &arg1 = args.read<const QTextOption & > (heap);
+  const QTextOption &arg1 = gsi::arg_reader<const QTextOption & >() (args, heap);
   ret.write<QTextOption *> (new QTextOption (arg1));
 }
 
@@ -133,7 +133,7 @@ static void _call_f_operator_eq__2448 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextOption &arg1 = args.read<const QTextOption & > (heap);
+  const QTextOption &arg1 = gsi::arg_reader<const QTextOption & >() (args, heap);
   ret.write<QTextOption & > ((QTextOption &)((QTextOption *)cls)->operator= (arg1));
 }
 
@@ -152,7 +152,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextOption *)cls)->setAlignment (arg1);
 }
@@ -172,7 +172,7 @@ static void _call_f_setFlags_2761 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QTextOption::Flag> arg1 = args.read<QFlags<QTextOption::Flag> > (heap);
+  QFlags<QTextOption::Flag> arg1 = gsi::arg_reader<QFlags<QTextOption::Flag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextOption *)cls)->setFlags (arg1);
 }
@@ -192,7 +192,7 @@ static void _call_f_setTabArray_1584 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QList<qreal> arg1 = args.read<QList<qreal> > (heap);
+  QList<qreal> arg1 = gsi::arg_reader<QList<qreal> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextOption *)cls)->setTabArray (arg1);
 }
@@ -212,7 +212,7 @@ static void _call_f_setTabStop_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextOption *)cls)->setTabStop (arg1);
 }
@@ -232,7 +232,7 @@ static void _call_f_setTabs_2581 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QList<QTextOption::Tab> arg1 = args.read<QList<QTextOption::Tab> > (heap);
+  QList<QTextOption::Tab> arg1 = gsi::arg_reader<QList<QTextOption::Tab> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextOption *)cls)->setTabs (arg1);
 }
@@ -252,7 +252,7 @@ static void _call_f_setTextDirection_2316 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextOption *)cls)->setTextDirection (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref());
 }
@@ -272,7 +272,7 @@ static void _call_f_setUseDesignMetrics_864 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextOption *)cls)->setUseDesignMetrics (arg1);
 }
@@ -292,7 +292,7 @@ static void _call_f_setWrapMode_2486 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTextOption::WrapMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QTextOption::WrapMode>::target_type & > (heap);
+  const qt_gsi::Converter<QTextOption::WrapMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTextOption::WrapMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextOption *)cls)->setWrapMode (qt_gsi::QtToCppAdaptor<QTextOption::WrapMode>(arg1).cref());
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextOption_Tab.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextOption_Tab.cc
@@ -65,7 +65,7 @@ static void _call_f_operator_excl__eq__c2843 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextOption::Tab &arg1 = args.read<const QTextOption::Tab & > (heap);
+  const QTextOption::Tab &arg1 = gsi::arg_reader<const QTextOption::Tab & >() (args, heap);
   ret.write<bool > ((bool)((QTextOption::Tab *)cls)->operator!= (arg1));
 }
 
@@ -84,7 +84,7 @@ static void _call_f_operator_eq__eq__c2843 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextOption::Tab &arg1 = args.read<const QTextOption::Tab & > (heap);
+  const QTextOption::Tab &arg1 = gsi::arg_reader<const QTextOption::Tab & >() (args, heap);
   ret.write<bool > ((bool)((QTextOption::Tab *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextTable.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextTable.cc
@@ -74,7 +74,7 @@ static void _call_f_appendColumns_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->appendColumns (arg1);
 }
@@ -94,7 +94,7 @@ static void _call_f_appendRows_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->appendRows (arg1);
 }
@@ -116,8 +116,8 @@ static void _call_f_cellAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextTableCell > ((QTextTableCell)((QTextTable *)cls)->cellAt (arg1, arg2));
 }
 
@@ -136,7 +136,7 @@ static void _call_f_cellAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTextTableCell > ((QTextTableCell)((QTextTable *)cls)->cellAt (arg1));
 }
 
@@ -155,7 +155,7 @@ static void _call_f_cellAt_c2453 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<QTextTableCell > ((QTextTableCell)((QTextTable *)cls)->cellAt (arg1));
 }
 
@@ -206,8 +206,8 @@ static void _call_f_insertColumns_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->insertColumns (arg1, arg2);
 }
@@ -229,8 +229,8 @@ static void _call_f_insertRows_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->insertRows (arg1, arg2);
 }
@@ -256,10 +256,10 @@ static void _call_f_mergeCells_2744 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->mergeCells (arg1, arg2, arg3, arg4);
 }
@@ -279,7 +279,7 @@ static void _call_f_mergeCells_2453 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->mergeCells (arg1);
 }
@@ -301,8 +301,8 @@ static void _call_f_removeColumns_1426 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->removeColumns (arg1, arg2);
 }
@@ -324,8 +324,8 @@ static void _call_f_removeRows_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->removeRows (arg1, arg2);
 }
@@ -347,8 +347,8 @@ static void _call_f_resize_1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->resize (arg1, arg2);
 }
@@ -368,7 +368,7 @@ static void _call_f_rowEnd_c2453 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<QTextCursor > ((QTextCursor)((QTextTable *)cls)->rowEnd (arg1));
 }
 
@@ -387,7 +387,7 @@ static void _call_f_rowStart_c2453 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCursor &arg1 = args.read<const QTextCursor & > (heap);
+  const QTextCursor &arg1 = gsi::arg_reader<const QTextCursor & >() (args, heap);
   ret.write<QTextCursor > ((QTextCursor)((QTextTable *)cls)->rowStart (arg1));
 }
 
@@ -421,7 +421,7 @@ static void _call_f_setFormat_2920 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextTableFormat &arg1 = args.read<const QTextTableFormat & > (heap);
+  const QTextTableFormat &arg1 = gsi::arg_reader<const QTextTableFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->setFormat (arg1);
 }
@@ -447,10 +447,10 @@ static void _call_f_splitCell_2744 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTable *)cls)->splitCell (arg1, arg2, arg3, arg4);
 }
@@ -472,8 +472,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextTable::tr (arg1, arg2));
 }
 
@@ -496,9 +496,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextTable::tr (arg1, arg2, arg3));
 }
 
@@ -519,8 +519,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTextTable::trUtf8 (arg1, arg2));
 }
 
@@ -543,9 +543,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTextTable::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -735,7 +735,7 @@ static void _call_ctor_QTextTable_Adaptor_1955 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextDocument *arg1 = args.read<QTextDocument * > (heap);
+  QTextDocument *arg1 = gsi::arg_reader<QTextDocument * >() (args, heap);
   ret.write<QTextTable_Adaptor *> (new QTextTable_Adaptor (arg1));
 }
 
@@ -801,7 +801,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTextTable_Adaptor *)cls)->emitter_QTextTable_destroyed_1302 (arg1);
 }
 
@@ -892,7 +892,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTextTable_Adaptor *)cls)->fp_QTextTable_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextTableCell.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextTableCell.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QTextTableCell_2687 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextTableCell &arg1 = args.read<const QTextTableCell & > (heap);
+  const QTextTableCell &arg1 = gsi::arg_reader<const QTextTableCell & >() (args, heap);
   ret.write<QTextTableCell *> (new QTextTableCell (arg1));
 }
 
@@ -206,7 +206,7 @@ static void _call_f_operator_excl__eq__c2687 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextTableCell &arg1 = args.read<const QTextTableCell & > (heap);
+  const QTextTableCell &arg1 = gsi::arg_reader<const QTextTableCell & >() (args, heap);
   ret.write<bool > ((bool)((QTextTableCell *)cls)->operator!= (arg1));
 }
 
@@ -225,7 +225,7 @@ static void _call_f_operator_eq__2687 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextTableCell &arg1 = args.read<const QTextTableCell & > (heap);
+  const QTextTableCell &arg1 = gsi::arg_reader<const QTextTableCell & >() (args, heap);
   ret.write<QTextTableCell & > ((QTextTableCell &)((QTextTableCell *)cls)->operator= (arg1));
 }
 
@@ -244,7 +244,7 @@ static void _call_f_operator_eq__eq__c2687 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextTableCell &arg1 = args.read<const QTextTableCell & > (heap);
+  const QTextTableCell &arg1 = gsi::arg_reader<const QTextTableCell & >() (args, heap);
   ret.write<bool > ((bool)((QTextTableCell *)cls)->operator== (arg1));
 }
 
@@ -293,7 +293,7 @@ static void _call_f_setFormat_2814 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTextCharFormat &arg1 = args.read<const QTextCharFormat & > (heap);
+  const QTextCharFormat &arg1 = gsi::arg_reader<const QTextCharFormat & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableCell *)cls)->setFormat (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextTableCellFormat.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextTableCellFormat.cc
@@ -137,7 +137,7 @@ static void _call_f_setBottomPadding_1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableCellFormat *)cls)->setBottomPadding (arg1);
 }
@@ -157,7 +157,7 @@ static void _call_f_setLeftPadding_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableCellFormat *)cls)->setLeftPadding (arg1);
 }
@@ -177,7 +177,7 @@ static void _call_f_setPadding_1071 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableCellFormat *)cls)->setPadding (arg1);
 }
@@ -197,7 +197,7 @@ static void _call_f_setRightPadding_1071 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableCellFormat *)cls)->setRightPadding (arg1);
 }
@@ -217,7 +217,7 @@ static void _call_f_setTopPadding_1071 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableCellFormat *)cls)->setTopPadding (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTextTableFormat.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTextTableFormat.cc
@@ -197,7 +197,7 @@ static void _call_f_setAlignment_2750 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::AlignmentFlag> arg1 = args.read<QFlags<Qt::AlignmentFlag> > (heap);
+  QFlags<Qt::AlignmentFlag> arg1 = gsi::arg_reader<QFlags<Qt::AlignmentFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableFormat *)cls)->setAlignment (arg1);
 }
@@ -217,7 +217,7 @@ static void _call_f_setCellPadding_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableFormat *)cls)->setCellPadding (arg1);
 }
@@ -237,7 +237,7 @@ static void _call_f_setCellSpacing_1071 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableFormat *)cls)->setCellSpacing (arg1);
 }
@@ -257,7 +257,7 @@ static void _call_f_setColumnWidthConstraints_3255 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector<QTextLength> &arg1 = args.read<const QVector<QTextLength> & > (heap);
+  const QVector<QTextLength> &arg1 = gsi::arg_reader<const QVector<QTextLength> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableFormat *)cls)->setColumnWidthConstraints (arg1);
 }
@@ -277,7 +277,7 @@ static void _call_f_setColumns_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableFormat *)cls)->setColumns (arg1);
 }
@@ -297,7 +297,7 @@ static void _call_f_setHeaderRowCount_767 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTextTableFormat *)cls)->setHeaderRowCount (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTimeEdit.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTimeEdit.cc
@@ -119,8 +119,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTimeEdit::tr (arg1, arg2));
 }
 
@@ -143,9 +143,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTimeEdit::tr (arg1, arg2, arg3));
 }
 
@@ -166,8 +166,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTimeEdit::trUtf8 (arg1, arg2));
 }
 
@@ -190,9 +190,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTimeEdit::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1213,7 +1213,7 @@ static void _call_ctor_QTimeEdit_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTimeEdit_Adaptor *> (new QTimeEdit_Adaptor (arg1));
 }
 
@@ -1233,8 +1233,8 @@ static void _call_ctor_QTimeEdit_Adaptor_3000 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTimeEdit_Adaptor *> (new QTimeEdit_Adaptor (arg1, arg2));
 }
 
@@ -1396,9 +1396,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeEdit_Adaptor *)cls)->fp_QTimeEdit_create_2208 (arg1, arg2, arg3);
 }
@@ -1417,7 +1417,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QTimeEdit_Adaptor *)cls)->emitter_QTimeEdit_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1459,7 +1459,7 @@ static void _call_emitter_dateChanged_1776 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDate &arg1 = args.read<const QDate & > (heap);
+  const QDate &arg1 = gsi::arg_reader<const QDate & >() (args, heap);
   ((QTimeEdit_Adaptor *)cls)->emitter_QTimeEdit_dateChanged_1776 (arg1);
 }
 
@@ -1477,7 +1477,7 @@ static void _call_emitter_dateTimeChanged_2175 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   ((QTimeEdit_Adaptor *)cls)->emitter_QTimeEdit_dateTimeChanged_2175 (arg1);
 }
 
@@ -1520,8 +1520,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeEdit_Adaptor *)cls)->fp_QTimeEdit_destroy_1620 (arg1, arg2);
 }
@@ -1540,7 +1540,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTimeEdit_Adaptor *)cls)->emitter_QTimeEdit_destroyed_1302 (arg1);
 }
 
@@ -1983,7 +1983,7 @@ static void _call_fp_initStyleOption_c2572 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionSpinBox *arg1 = args.read<QStyleOptionSpinBox * > (heap);
+  QStyleOptionSpinBox *arg1 = gsi::arg_reader<QStyleOptionSpinBox * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeEdit_Adaptor *)cls)->fp_QTimeEdit_initStyleOption_c2572 (arg1);
 }
@@ -2384,7 +2384,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTimeEdit_Adaptor *)cls)->fp_QTimeEdit_receivers_c1731 (arg1));
 }
 
@@ -2455,7 +2455,7 @@ static void _call_fp_setLineEdit_1485 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLineEdit *arg1 = args.read<QLineEdit * > (heap);
+  QLineEdit *arg1 = gsi::arg_reader<QLineEdit * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTimeEdit_Adaptor *)cls)->fp_QTimeEdit_setLineEdit_1485 (arg1);
 }
@@ -2655,7 +2655,7 @@ static void _call_emitter_timeChanged_1793 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTime &arg1 = args.read<const QTime & > (heap);
+  const QTime &arg1 = gsi::arg_reader<const QTime & >() (args, heap);
   ((QTimeEdit_Adaptor *)cls)->emitter_QTimeEdit_timeChanged_1793 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQToolBar.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQToolBar.cc
@@ -112,7 +112,7 @@ static void _call_f_actionAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QToolBar *)cls)->actionAt (arg1));
 }
 
@@ -133,8 +133,8 @@ static void _call_f_actionAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QAction * > ((QAction *)((QToolBar *)cls)->actionAt (arg1, arg2));
 }
 
@@ -153,7 +153,7 @@ static void _call_f_actionGeometry_c1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ret.write<QRect > ((QRect)((QToolBar *)cls)->actionGeometry (arg1));
 }
 
@@ -172,7 +172,7 @@ static void _call_f_addAction_1309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar *)cls)->addAction (arg1);
 }
@@ -192,7 +192,7 @@ static void _call_f_addAction_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QToolBar *)cls)->addAction (arg1));
 }
 
@@ -213,8 +213,8 @@ static void _call_f_addAction_3704 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QAction * > ((QAction *)((QToolBar *)cls)->addAction (arg1, arg2));
 }
 
@@ -237,9 +237,9 @@ static void _call_f_addAction_5537 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QObject *arg2 = args.read<const QObject * > (heap);
-  const char *arg3 = args.read<const char * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QObject *arg2 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QToolBar *)cls)->addAction (arg1, arg2, arg3));
 }
 
@@ -264,10 +264,10 @@ static void _call_f_addAction_7216 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QObject *arg3 = args.read<const QObject * > (heap);
-  const char *arg4 = args.read<const char * > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QObject *arg3 = gsi::arg_reader<const QObject * >() (args, heap);
+  const char *arg4 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QToolBar *)cls)->addAction (arg1, arg2, arg3, arg4));
 }
 
@@ -301,7 +301,7 @@ static void _call_f_addWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QToolBar *)cls)->addWidget (arg1));
 }
 
@@ -366,7 +366,7 @@ static void _call_f_insertSeparator_1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QToolBar *)cls)->insertSeparator (arg1));
 }
 
@@ -387,8 +387,8 @@ static void _call_f_insertWidget_2516 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QAction * > ((QAction *)((QToolBar *)cls)->insertWidget (arg1, arg2));
 }
 
@@ -407,7 +407,7 @@ static void _call_f_isAreaAllowed_c1817 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ToolBarArea>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ToolBarArea>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ToolBarArea>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ToolBarArea>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QToolBar *)cls)->isAreaAllowed (qt_gsi::QtToCppAdaptor<Qt::ToolBarArea>(arg1).cref()));
 }
 
@@ -486,7 +486,7 @@ static void _call_f_setAllowedAreas_2513 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::ToolBarArea> arg1 = args.read<QFlags<Qt::ToolBarArea> > (heap);
+  QFlags<Qt::ToolBarArea> arg1 = gsi::arg_reader<QFlags<Qt::ToolBarArea> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar *)cls)->setAllowedAreas (arg1);
 }
@@ -506,7 +506,7 @@ static void _call_f_setFloatable_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar *)cls)->setFloatable (arg1);
 }
@@ -526,7 +526,7 @@ static void _call_f_setIconSize_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar *)cls)->setIconSize (arg1);
 }
@@ -546,7 +546,7 @@ static void _call_f_setMovable_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar *)cls)->setMovable (arg1);
 }
@@ -566,7 +566,7 @@ static void _call_f_setOrientation_1913 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar *)cls)->setOrientation (qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg1).cref());
 }
@@ -586,7 +586,7 @@ static void _call_f_setToolButtonStyle_2328 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar *)cls)->setToolButtonStyle (qt_gsi::QtToCppAdaptor<Qt::ToolButtonStyle>(arg1).cref());
 }
@@ -636,7 +636,7 @@ static void _call_f_widgetForAction_c1309 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QToolBar *)cls)->widgetForAction (arg1));
 }
 
@@ -657,8 +657,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QToolBar::tr (arg1, arg2));
 }
 
@@ -681,9 +681,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QToolBar::tr (arg1, arg2, arg3));
 }
 
@@ -704,8 +704,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QToolBar::trUtf8 (arg1, arg2));
 }
 
@@ -728,9 +728,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QToolBar::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1681,8 +1681,8 @@ static void _call_ctor_QToolBar_Adaptor_3232 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QToolBar_Adaptor *> (new QToolBar_Adaptor (arg1, arg2));
 }
 
@@ -1700,7 +1700,7 @@ static void _call_ctor_QToolBar_Adaptor_1315 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QToolBar_Adaptor *> (new QToolBar_Adaptor (arg1));
 }
 
@@ -1742,7 +1742,7 @@ static void _call_emitter_actionTriggered_1309 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ((QToolBar_Adaptor *)cls)->emitter_QToolBar_actionTriggered_1309 (arg1);
 }
 
@@ -1760,7 +1760,7 @@ static void _call_emitter_allowedAreasChanged_2513 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::ToolBarArea> arg1 = args.read<QFlags<Qt::ToolBarArea> > (heap);
+  QFlags<Qt::ToolBarArea> arg1 = gsi::arg_reader<QFlags<Qt::ToolBarArea> >() (args, heap);
   ((QToolBar_Adaptor *)cls)->emitter_QToolBar_allowedAreasChanged_2513 (arg1);
 }
 
@@ -1878,9 +1878,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar_Adaptor *)cls)->fp_QToolBar_create_2208 (arg1, arg2, arg3);
 }
@@ -1899,7 +1899,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QToolBar_Adaptor *)cls)->emitter_QToolBar_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1943,8 +1943,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar_Adaptor *)cls)->fp_QToolBar_destroy_1620 (arg1, arg2);
 }
@@ -1963,7 +1963,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QToolBar_Adaptor *)cls)->emitter_QToolBar_destroyed_1302 (arg1);
 }
 
@@ -2368,7 +2368,7 @@ static void _call_emitter_iconSizeChanged_1805 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   ((QToolBar_Adaptor *)cls)->emitter_QToolBar_iconSizeChanged_1805 (arg1);
 }
 
@@ -2386,7 +2386,7 @@ static void _call_fp_initStyleOption_c2556 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionToolBar *arg1 = args.read<QStyleOptionToolBar * > (heap);
+  QStyleOptionToolBar *arg1 = gsi::arg_reader<QStyleOptionToolBar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBar_Adaptor *)cls)->fp_QToolBar_initStyleOption_c2556 (arg1);
 }
@@ -2682,7 +2682,7 @@ static void _call_emitter_movableChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QToolBar_Adaptor *)cls)->emitter_QToolBar_movableChanged_864 (arg1);
 }
 
@@ -2724,7 +2724,7 @@ static void _call_emitter_orientationChanged_1913 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
   ((QToolBar_Adaptor *)cls)->emitter_QToolBar_orientationChanged_1913 (arg1);
 }
 
@@ -2809,7 +2809,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QToolBar_Adaptor *)cls)->fp_QToolBar_receivers_c1731 (arg1));
 }
 
@@ -3019,7 +3019,7 @@ static void _call_emitter_toolButtonStyleChanged_2328 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & >() (args, heap);
   ((QToolBar_Adaptor *)cls)->emitter_QToolBar_toolButtonStyleChanged_2328 (arg1);
 }
 
@@ -3037,7 +3037,7 @@ static void _call_emitter_topLevelChanged_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QToolBar_Adaptor *)cls)->emitter_QToolBar_topLevelChanged_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQToolBarChangeEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQToolBarChangeEvent.cc
@@ -101,7 +101,7 @@ static void _call_ctor_QToolBarChangeEvent_Adaptor_864 (const qt_gsi::GenericSta
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ret.write<QToolBarChangeEvent_Adaptor *> (new QToolBarChangeEvent_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQToolBox.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQToolBox.cc
@@ -113,8 +113,8 @@ static void _call_f_addItem_3232 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QToolBox *)cls)->addItem (arg1, arg2));
 }
 
@@ -137,9 +137,9 @@ static void _call_f_addItem_4911 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QIcon &arg2 = args.read<const QIcon & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QIcon &arg2 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QToolBox *)cls)->addItem (arg1, arg2, arg3));
 }
 
@@ -203,7 +203,7 @@ static void _call_f_indexOf_c1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<int > ((int)((QToolBox *)cls)->indexOf (arg1));
 }
 
@@ -226,9 +226,9 @@ static void _call_f_insertItem_3891 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QToolBox *)cls)->insertItem (arg1, arg2, arg3));
 }
 
@@ -253,10 +253,10 @@ static void _call_f_insertItem_5570 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  const QIcon &arg3 = args.read<const QIcon & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QIcon &arg3 = gsi::arg_reader<const QIcon & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QToolBox *)cls)->insertItem (arg1, arg2, arg3, arg4));
 }
 
@@ -275,7 +275,7 @@ static void _call_f_isItemEnabled_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QToolBox *)cls)->isItemEnabled (arg1));
 }
 
@@ -294,7 +294,7 @@ static void _call_f_itemIcon_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QIcon > ((QIcon)((QToolBox *)cls)->itemIcon (arg1));
 }
 
@@ -313,7 +313,7 @@ static void _call_f_itemText_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QToolBox *)cls)->itemText (arg1));
 }
 
@@ -332,7 +332,7 @@ static void _call_f_itemToolTip_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QToolBox *)cls)->itemToolTip (arg1));
 }
 
@@ -351,7 +351,7 @@ static void _call_f_removeItem_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox *)cls)->removeItem (arg1);
 }
@@ -371,7 +371,7 @@ static void _call_f_setCurrentIndex_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox *)cls)->setCurrentIndex (arg1);
 }
@@ -391,7 +391,7 @@ static void _call_f_setCurrentWidget_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox *)cls)->setCurrentWidget (arg1);
 }
@@ -413,8 +413,8 @@ static void _call_f_setItemEnabled_1523 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox *)cls)->setItemEnabled (arg1, arg2);
 }
@@ -436,8 +436,8 @@ static void _call_f_setItemIcon_2446 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QIcon &arg2 = args.read<const QIcon & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QIcon &arg2 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox *)cls)->setItemIcon (arg1, arg2);
 }
@@ -459,8 +459,8 @@ static void _call_f_setItemText_2684 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox *)cls)->setItemText (arg1, arg2);
 }
@@ -482,8 +482,8 @@ static void _call_f_setItemToolTip_2684 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox *)cls)->setItemToolTip (arg1, arg2);
 }
@@ -503,7 +503,7 @@ static void _call_f_widget_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QToolBox *)cls)->widget (arg1));
 }
 
@@ -524,8 +524,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QToolBox::tr (arg1, arg2));
 }
 
@@ -548,9 +548,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QToolBox::tr (arg1, arg2, arg3));
 }
 
@@ -571,8 +571,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QToolBox::trUtf8 (arg1, arg2));
 }
 
@@ -595,9 +595,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QToolBox::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1523,8 +1523,8 @@ static void _call_ctor_QToolBox_Adaptor_3702 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QToolBox_Adaptor *> (new QToolBox_Adaptor (arg1, arg2));
 }
 
@@ -1666,9 +1666,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox_Adaptor *)cls)->fp_QToolBox_create_2208 (arg1, arg2, arg3);
 }
@@ -1687,7 +1687,7 @@ static void _call_emitter_currentChanged_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QToolBox_Adaptor *)cls)->emitter_QToolBox_currentChanged_767 (arg1);
 }
 
@@ -1705,7 +1705,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QToolBox_Adaptor *)cls)->emitter_QToolBox_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1749,8 +1749,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox_Adaptor *)cls)->fp_QToolBox_destroy_1620 (arg1, arg2);
 }
@@ -1769,7 +1769,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QToolBox_Adaptor *)cls)->emitter_QToolBox_destroyed_1302 (arg1);
 }
 
@@ -1883,7 +1883,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolBox_Adaptor *)cls)->fp_QToolBox_drawFrame_1426 (arg1);
 }
@@ -2609,7 +2609,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QToolBox_Adaptor *)cls)->fp_QToolBox_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQToolButton.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQToolButton.cc
@@ -204,7 +204,7 @@ static void _call_f_setArrowType_1690 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ArrowType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ArrowType>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ArrowType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ArrowType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolButton *)cls)->setArrowType (qt_gsi::QtToCppAdaptor<Qt::ArrowType>(arg1).cref());
 }
@@ -224,7 +224,7 @@ static void _call_f_setAutoRaise_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolButton *)cls)->setAutoRaise (arg1);
 }
@@ -244,7 +244,7 @@ static void _call_f_setDefaultAction_1309 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolButton *)cls)->setDefaultAction (arg1);
 }
@@ -264,7 +264,7 @@ static void _call_f_setMenu_1108 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QMenu *arg1 = args.read<QMenu * > (heap);
+  QMenu *arg1 = gsi::arg_reader<QMenu * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolButton *)cls)->setMenu (arg1);
 }
@@ -284,7 +284,7 @@ static void _call_f_setPopupMode_3654 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QToolButton::ToolButtonPopupMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QToolButton::ToolButtonPopupMode>::target_type & > (heap);
+  const qt_gsi::Converter<QToolButton::ToolButtonPopupMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QToolButton::ToolButtonPopupMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolButton *)cls)->setPopupMode (qt_gsi::QtToCppAdaptor<QToolButton::ToolButtonPopupMode>(arg1).cref());
 }
@@ -304,7 +304,7 @@ static void _call_f_setToolButtonStyle_2328 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ToolButtonStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolButton *)cls)->setToolButtonStyle (qt_gsi::QtToCppAdaptor<Qt::ToolButtonStyle>(arg1).cref());
 }
@@ -372,8 +372,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QToolButton::tr (arg1, arg2));
 }
 
@@ -396,9 +396,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QToolButton::tr (arg1, arg2, arg3));
 }
 
@@ -419,8 +419,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QToolButton::trUtf8 (arg1, arg2));
 }
 
@@ -443,9 +443,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QToolButton::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1402,7 +1402,7 @@ static void _call_ctor_QToolButton_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QToolButton_Adaptor *> (new QToolButton_Adaptor (arg1));
 }
 
@@ -1512,7 +1512,7 @@ static void _call_emitter_clicked_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ((QToolButton_Adaptor *)cls)->emitter_QToolButton_clicked_864 (arg1);
 }
 
@@ -1582,9 +1582,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolButton_Adaptor *)cls)->fp_QToolButton_create_2208 (arg1, arg2, arg3);
 }
@@ -1603,7 +1603,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QToolButton_Adaptor *)cls)->emitter_QToolButton_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1647,8 +1647,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolButton_Adaptor *)cls)->fp_QToolButton_destroy_1620 (arg1, arg2);
 }
@@ -1667,7 +1667,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QToolButton_Adaptor *)cls)->emitter_QToolButton_destroyed_1302 (arg1);
 }
 
@@ -2095,7 +2095,7 @@ static void _call_fp_initStyleOption_c2915 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyleOptionToolButton *arg1 = args.read<QStyleOptionToolButton * > (heap);
+  QStyleOptionToolButton *arg1 = gsi::arg_reader<QStyleOptionToolButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QToolButton_Adaptor *)cls)->fp_QToolButton_initStyleOption_c2915 (arg1);
 }
@@ -2516,7 +2516,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QToolButton_Adaptor *)cls)->fp_QToolButton_receivers_c1731 (arg1));
 }
 
@@ -2740,7 +2740,7 @@ static void _call_emitter_toggled_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QToolButton_Adaptor *)cls)->emitter_QToolButton_toggled_864 (arg1);
 }
 
@@ -2758,7 +2758,7 @@ static void _call_emitter_triggered_1309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   ((QToolButton_Adaptor *)cls)->emitter_QToolButton_triggered_1309 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQToolTip.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQToolTip.cc
@@ -116,7 +116,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericStaticMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QToolTip::setFont (arg1);
 }
@@ -136,7 +136,7 @@ static void _call_f_setPalette_2113 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QToolTip::setPalette (arg1);
 }
@@ -160,9 +160,9 @@ static void _call_f_showText_5040 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QToolTip::showText (arg1, arg2, arg3);
 }
@@ -188,10 +188,10 @@ static void _call_f_showText_6724 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
-  const QRect &arg4 = args.read<const QRect & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QRect &arg4 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QToolTip::showText (arg1, arg2, arg3, arg4);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTouchEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTouchEvent.cc
@@ -66,7 +66,7 @@ static void _call_f_setDeviceType_2672 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type & arg1 = args.read<const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type & > (heap);
+  const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent *)cls)->setDeviceType (qt_gsi::QtToCppAdaptor<QTouchEvent::DeviceType>(arg1).cref());
 }
@@ -86,7 +86,7 @@ static void _call_f_setTouchPointStates_2995 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::TouchPointState> arg1 = args.read<QFlags<Qt::TouchPointState> > (heap);
+  QFlags<Qt::TouchPointState> arg1 = gsi::arg_reader<QFlags<Qt::TouchPointState> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent *)cls)->setTouchPointStates (arg1);
 }
@@ -106,7 +106,7 @@ static void _call_f_setTouchPoints_4191 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QTouchEvent::TouchPoint> &arg1 = args.read<const QList<QTouchEvent::TouchPoint> & > (heap);
+  const QList<QTouchEvent::TouchPoint> &arg1 = gsi::arg_reader<const QList<QTouchEvent::TouchPoint> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent *)cls)->setTouchPoints (arg1);
 }
@@ -126,7 +126,7 @@ static void _call_f_setWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent *)cls)->setWidget (arg1);
 }
@@ -266,11 +266,11 @@ static void _call_ctor_QTouchEvent_Adaptor_14068 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QEvent::Type>::target_type & > (heap);
-  const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type & > (heap) : (const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QTouchEvent::DeviceType>(heap, QTouchEvent::TouchScreen));
-  QFlags<Qt::KeyboardModifier> arg3 = args ? args.read<QFlags<Qt::KeyboardModifier> > (heap) : (QFlags<Qt::KeyboardModifier>)(Qt::NoModifier);
-  QFlags<Qt::TouchPointState> arg4 = args ? args.read<QFlags<Qt::TouchPointState> > (heap) : (QFlags<Qt::TouchPointState>)(0);
-  const QList<QTouchEvent::TouchPoint> &arg5 = args ? args.read<const QList<QTouchEvent::TouchPoint> & > (heap) : (const QList<QTouchEvent::TouchPoint> &)(QList<QTouchEvent::TouchPoint>());
+  const qt_gsi::Converter<QEvent::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QEvent::Type>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QTouchEvent::DeviceType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QTouchEvent::DeviceType>(heap, QTouchEvent::TouchScreen), heap);
+  QFlags<Qt::KeyboardModifier> arg3 = args ? gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap) : gsi::arg_maker<QFlags<Qt::KeyboardModifier> >() (Qt::NoModifier, heap);
+  QFlags<Qt::TouchPointState> arg4 = args ? gsi::arg_reader<QFlags<Qt::TouchPointState> >() (args, heap) : gsi::arg_maker<QFlags<Qt::TouchPointState> >() (0, heap);
+  const QList<QTouchEvent::TouchPoint> &arg5 = args ? gsi::arg_reader<const QList<QTouchEvent::TouchPoint> & >() (args, heap) : gsi::arg_maker<const QList<QTouchEvent::TouchPoint> & >() (QList<QTouchEvent::TouchPoint>(), heap);
   ret.write<QTouchEvent_Adaptor *> (new QTouchEvent_Adaptor (qt_gsi::QtToCppAdaptor<QEvent::Type>(arg1).cref(), qt_gsi::QtToCppAdaptor<QTouchEvent::DeviceType>(arg2).cref(), arg3, arg4, arg5));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTouchEvent_TouchPoint.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTouchEvent_TouchPoint.cc
@@ -52,7 +52,7 @@ static void _call_ctor_QTouchEvent_TouchPoint_767 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(-1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QTouchEvent::TouchPoint *> (new QTouchEvent::TouchPoint (arg1));
 }
 
@@ -71,7 +71,7 @@ static void _call_ctor_QTouchEvent_TouchPoint_3576 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTouchEvent::TouchPoint &arg1 = args.read<const QTouchEvent::TouchPoint & > (heap);
+  const QTouchEvent::TouchPoint &arg1 = gsi::arg_reader<const QTouchEvent::TouchPoint & >() (args, heap);
   ret.write<QTouchEvent::TouchPoint *> (new QTouchEvent::TouchPoint (arg1));
 }
 
@@ -195,7 +195,7 @@ static void _call_f_operator_eq__3576 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTouchEvent::TouchPoint &arg1 = args.read<const QTouchEvent::TouchPoint & > (heap);
+  const QTouchEvent::TouchPoint &arg1 = gsi::arg_reader<const QTouchEvent::TouchPoint & >() (args, heap);
   ret.write<QTouchEvent::TouchPoint & > ((QTouchEvent::TouchPoint &)((QTouchEvent::TouchPoint *)cls)->operator= (arg1));
 }
 
@@ -319,7 +319,7 @@ static void _call_f_setId_767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setId (arg1);
 }
@@ -339,7 +339,7 @@ static void _call_f_setLastNormalizedPos_1986 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setLastNormalizedPos (arg1);
 }
@@ -359,7 +359,7 @@ static void _call_f_setLastPos_1986 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setLastPos (arg1);
 }
@@ -379,7 +379,7 @@ static void _call_f_setLastScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setLastScenePos (arg1);
 }
@@ -399,7 +399,7 @@ static void _call_f_setLastScreenPos_1986 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setLastScreenPos (arg1);
 }
@@ -419,7 +419,7 @@ static void _call_f_setNormalizedPos_1986 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setNormalizedPos (arg1);
 }
@@ -439,7 +439,7 @@ static void _call_f_setPos_1986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setPos (arg1);
 }
@@ -459,7 +459,7 @@ static void _call_f_setPressure_1071 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setPressure (arg1);
 }
@@ -479,7 +479,7 @@ static void _call_f_setRect_1862 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setRect (arg1);
 }
@@ -499,7 +499,7 @@ static void _call_f_setScenePos_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setScenePos (arg1);
 }
@@ -519,7 +519,7 @@ static void _call_f_setSceneRect_1862 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setSceneRect (arg1);
 }
@@ -539,7 +539,7 @@ static void _call_f_setScreenPos_1986 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setScreenPos (arg1);
 }
@@ -559,7 +559,7 @@ static void _call_f_setScreenRect_1862 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setScreenRect (arg1);
 }
@@ -579,7 +579,7 @@ static void _call_f_setStartNormalizedPos_1986 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setStartNormalizedPos (arg1);
 }
@@ -599,7 +599,7 @@ static void _call_f_setStartPos_1986 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setStartPos (arg1);
 }
@@ -619,7 +619,7 @@ static void _call_f_setStartScenePos_1986 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setStartScenePos (arg1);
 }
@@ -639,7 +639,7 @@ static void _call_f_setStartScreenPos_1986 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setStartScreenPos (arg1);
 }
@@ -659,7 +659,7 @@ static void _call_f_setState_2995 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::TouchPointState> arg1 = args.read<QFlags<Qt::TouchPointState> > (heap);
+  QFlags<Qt::TouchPointState> arg1 = gsi::arg_reader<QFlags<Qt::TouchPointState> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTouchEvent::TouchPoint *)cls)->setState (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTransform.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTransform.cc
@@ -61,7 +61,7 @@ static void _call_ctor_QTransform_2229 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Initialization>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Initialization>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::Initialization>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Initialization>::target_type & >() (args, heap);
   ret.write<QTransform *> (new QTransform (qt_gsi::QtToCppAdaptor<Qt::Initialization>(arg1).cref()));
 }
 
@@ -111,15 +111,15 @@ static void _call_ctor_QTransform_8775 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
-  double arg7 = args.read<double > (heap);
-  double arg8 = args.read<double > (heap);
-  double arg9 = args ? args.read<double > (heap) : (double)(1.0);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
+  double arg7 = gsi::arg_reader<double >() (args, heap);
+  double arg8 = gsi::arg_reader<double >() (args, heap);
+  double arg9 = args ? gsi::arg_reader<double >() (args, heap) : gsi::arg_maker<double >() (1.0, heap);
   ret.write<QTransform *> (new QTransform (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
 }
 
@@ -148,12 +148,12 @@ static void _call_ctor_QTransform_5886 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform *> (new QTransform (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -172,7 +172,7 @@ static void _call_ctor_QTransform_2023 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMatrix &arg1 = args.read<const QMatrix & > (heap);
+  const QMatrix &arg1 = gsi::arg_reader<const QMatrix & >() (args, heap);
   ret.write<QTransform *> (new QTransform (arg1));
 }
 
@@ -266,7 +266,7 @@ static void _call_f_inverted_c1050 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool *arg1 = args ? args.read<bool * > (heap) : (bool *)(0);
+  bool *arg1 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<QTransform > ((QTransform)((QTransform *)cls)->inverted (arg1));
 }
 
@@ -510,7 +510,7 @@ static void _call_f_map_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QTransform *)cls)->map (arg1));
 }
 
@@ -529,7 +529,7 @@ static void _call_f_map_c1986 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QPointF > ((QPointF)((QTransform *)cls)->map (arg1));
 }
 
@@ -548,7 +548,7 @@ static void _call_f_map_c1786 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLine &arg1 = args.read<const QLine & > (heap);
+  const QLine &arg1 = gsi::arg_reader<const QLine & >() (args, heap);
   ret.write<QLine > ((QLine)((QTransform *)cls)->map (arg1));
 }
 
@@ -567,7 +567,7 @@ static void _call_f_map_c1856 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLineF &arg1 = args.read<const QLineF & > (heap);
+  const QLineF &arg1 = gsi::arg_reader<const QLineF & >() (args, heap);
   ret.write<QLineF > ((QLineF)((QTransform *)cls)->map (arg1));
 }
 
@@ -586,7 +586,7 @@ static void _call_f_map_c2208 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
   ret.write<QPolygonF > ((QPolygonF)((QTransform *)cls)->map (arg1));
 }
 
@@ -605,7 +605,7 @@ static void _call_f_map_c2138 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygon &arg1 = args.read<const QPolygon & > (heap);
+  const QPolygon &arg1 = gsi::arg_reader<const QPolygon & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QTransform *)cls)->map (arg1));
 }
 
@@ -624,7 +624,7 @@ static void _call_f_map_c2006 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   ret.write<QRegion > ((QRegion)((QTransform *)cls)->map (arg1));
 }
 
@@ -643,7 +643,7 @@ static void _call_f_map_c2514 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPainterPath &arg1 = args.read<const QPainterPath & > (heap);
+  const QPainterPath &arg1 = gsi::arg_reader<const QPainterPath & >() (args, heap);
   ret.write<QPainterPath > ((QPainterPath)((QTransform *)cls)->map (arg1));
 }
 
@@ -668,10 +668,10 @@ static void _call_f_map_c3116 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTransform *)cls)->map (arg1, arg2, arg3, arg4);
 }
@@ -697,10 +697,10 @@ static void _call_f_map_c4332 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double *arg3 = args.read<double * > (heap);
-  double *arg4 = args.read<double * > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double *arg3 = gsi::arg_reader<double * >() (args, heap);
+  double *arg4 = gsi::arg_reader<double * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTransform *)cls)->map (arg1, arg2, arg3, arg4);
 }
@@ -720,7 +720,7 @@ static void _call_f_mapRect_c1792 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QTransform *)cls)->mapRect (arg1));
 }
 
@@ -739,7 +739,7 @@ static void _call_f_mapRect_c1862 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRectF &arg1 = args.read<const QRectF & > (heap);
+  const QRectF &arg1 = gsi::arg_reader<const QRectF & >() (args, heap);
   ret.write<QRectF > ((QRectF)((QTransform *)cls)->mapRect (arg1));
 }
 
@@ -758,7 +758,7 @@ static void _call_f_mapToPolygon_c1792 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QPolygon > ((QPolygon)((QTransform *)cls)->mapToPolygon (arg1));
 }
 
@@ -777,7 +777,7 @@ static void _call_f_operator_excl__eq__c2350 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<bool > ((bool)((QTransform *)cls)->operator!= (arg1));
 }
 
@@ -796,7 +796,7 @@ static void _call_f_operator_star__c2350 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QTransform > ((QTransform)((QTransform *)cls)->operator* (arg1));
 }
 
@@ -815,7 +815,7 @@ static void _call_f_operator_star__eq__2350 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->operator*= (arg1));
 }
 
@@ -834,7 +834,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->operator*= (arg1));
 }
 
@@ -853,7 +853,7 @@ static void _call_f_operator_plus__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->operator+= (arg1));
 }
 
@@ -872,7 +872,7 @@ static void _call_f_operator_minus__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->operator-= (arg1));
 }
 
@@ -891,7 +891,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->operator/= (arg1));
 }
 
@@ -910,7 +910,7 @@ static void _call_f_operator_eq__2350 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->operator= (arg1));
 }
 
@@ -929,7 +929,7 @@ static void _call_f_operator_eq__eq__c2350 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTransform &arg1 = args.read<const QTransform & > (heap);
+  const QTransform &arg1 = gsi::arg_reader<const QTransform & >() (args, heap);
   ret.write<bool > ((bool)((QTransform *)cls)->operator== (arg1));
 }
 
@@ -966,8 +966,8 @@ static void _call_f_rotate_2117 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::Axis>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::Axis>::target_type & > (heap) : (const qt_gsi::Converter<Qt::Axis>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::Axis>(heap, Qt::ZAxis));
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::Axis>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::Axis>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::Axis>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::Axis>(heap, Qt::ZAxis), heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->rotate (arg1, qt_gsi::QtToCppAdaptor<Qt::Axis>(arg2).cref()));
 }
 
@@ -988,8 +988,8 @@ static void _call_f_rotateRadians_2117 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  const qt_gsi::Converter<Qt::Axis>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::Axis>::target_type & > (heap) : (const qt_gsi::Converter<Qt::Axis>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::Axis>(heap, Qt::ZAxis));
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  const qt_gsi::Converter<Qt::Axis>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::Axis>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::Axis>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::Axis>(heap, Qt::ZAxis), heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->rotateRadians (arg1, qt_gsi::QtToCppAdaptor<Qt::Axis>(arg2).cref()));
 }
 
@@ -1010,8 +1010,8 @@ static void _call_f_scale_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->scale (arg1, arg2));
 }
 
@@ -1046,15 +1046,15 @@ static void _call_f_setMatrix_8775 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
-  double arg5 = args.read<double > (heap);
-  double arg6 = args.read<double > (heap);
-  double arg7 = args.read<double > (heap);
-  double arg8 = args.read<double > (heap);
-  double arg9 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
+  double arg5 = gsi::arg_reader<double >() (args, heap);
+  double arg6 = gsi::arg_reader<double >() (args, heap);
+  double arg7 = gsi::arg_reader<double >() (args, heap);
+  double arg8 = gsi::arg_reader<double >() (args, heap);
+  double arg9 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTransform *)cls)->setMatrix (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
 }
@@ -1076,8 +1076,8 @@ static void _call_f_shear_2034 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->shear (arg1, arg2));
 }
 
@@ -1113,8 +1113,8 @@ static void _call_f_translate_2034 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform & > ((QTransform &)((QTransform *)cls)->translate (arg1, arg2));
 }
 
@@ -1165,8 +1165,8 @@ static void _call_f_fromScale_2034 (const qt_gsi::GenericStaticMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform > ((QTransform)QTransform::fromScale (arg1, arg2));
 }
 
@@ -1187,8 +1187,8 @@ static void _call_f_fromTranslate_2034 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QTransform > ((QTransform)QTransform::fromTranslate (arg1, arg2));
 }
 
@@ -1211,9 +1211,9 @@ static void _call_f_quadToQuad_5855 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
-  const QPolygonF &arg2 = args.read<const QPolygonF & > (heap);
-  QTransform &arg3 = args.read<QTransform & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
+  const QPolygonF &arg2 = gsi::arg_reader<const QPolygonF & >() (args, heap);
+  QTransform &arg3 = gsi::arg_reader<QTransform & >() (args, heap);
   ret.write<bool > ((bool)QTransform::quadToQuad (arg1, arg2, arg3));
 }
 
@@ -1234,8 +1234,8 @@ static void _call_f_quadToSquare_3755 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
-  QTransform &arg2 = args.read<QTransform & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
+  QTransform &arg2 = gsi::arg_reader<QTransform & >() (args, heap);
   ret.write<bool > ((bool)QTransform::quadToSquare (arg1, arg2));
 }
 
@@ -1256,8 +1256,8 @@ static void _call_f_squareToQuad_3755 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPolygonF &arg1 = args.read<const QPolygonF & > (heap);
-  QTransform &arg2 = args.read<QTransform & > (heap);
+  const QPolygonF &arg1 = gsi::arg_reader<const QPolygonF & >() (args, heap);
+  QTransform &arg2 = gsi::arg_reader<QTransform & >() (args, heap);
   ret.write<bool > ((bool)QTransform::squareToQuad (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTreeView.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTreeView.cc
@@ -149,7 +149,7 @@ static void _call_f_collapse_2395 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->collapse (arg1);
 }
@@ -185,7 +185,7 @@ static void _call_f_columnAt_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTreeView *)cls)->columnAt (arg1));
 }
 
@@ -204,7 +204,7 @@ static void _call_f_columnViewportPosition_c767 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTreeView *)cls)->columnViewportPosition (arg1));
 }
 
@@ -223,7 +223,7 @@ static void _call_f_columnWidth_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTreeView *)cls)->columnWidth (arg1));
 }
 
@@ -244,8 +244,8 @@ static void _call_f_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->dataChanged (arg1, arg2);
 }
@@ -281,7 +281,7 @@ static void _call_f_expand_2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->expand (arg1);
 }
@@ -317,7 +317,7 @@ static void _call_f_expandToDepth_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->expandToDepth (arg1);
 }
@@ -367,7 +367,7 @@ static void _call_f_hideColumn_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->hideColumn (arg1);
 }
@@ -402,7 +402,7 @@ static void _call_f_indexAbove_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QTreeView *)cls)->indexAbove (arg1));
 }
 
@@ -421,7 +421,7 @@ static void _call_f_indexAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QTreeView *)cls)->indexAt (arg1));
 }
 
@@ -440,7 +440,7 @@ static void _call_f_indexBelow_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QTreeView *)cls)->indexBelow (arg1));
 }
 
@@ -474,7 +474,7 @@ static void _call_f_isColumnHidden_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTreeView *)cls)->isColumnHidden (arg1));
 }
 
@@ -493,7 +493,7 @@ static void _call_f_isExpanded_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QTreeView *)cls)->isExpanded (arg1));
 }
 
@@ -514,8 +514,8 @@ static void _call_f_isFirstColumnSpanned_c3054 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QTreeView *)cls)->isFirstColumnSpanned (arg1, arg2));
 }
 
@@ -551,8 +551,8 @@ static void _call_f_isRowHidden_c3054 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QTreeView *)cls)->isRowHidden (arg1, arg2));
 }
 
@@ -601,7 +601,7 @@ static void _call_f_keyboardSearch_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->keyboardSearch (arg1);
 }
@@ -637,7 +637,7 @@ static void _call_f_resizeColumnToContents_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->resizeColumnToContents (arg1);
 }
@@ -674,8 +674,8 @@ static void _call_f_scrollTo_5576 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible));
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->scrollTo (arg1, qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollHint>(arg2).cref());
 }
@@ -711,7 +711,7 @@ static void _call_f_setAllColumnsShowFocus_864 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setAllColumnsShowFocus (arg1);
 }
@@ -731,7 +731,7 @@ static void _call_f_setAnimated_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setAnimated (arg1);
 }
@@ -751,7 +751,7 @@ static void _call_f_setAutoExpandDelay_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setAutoExpandDelay (arg1);
 }
@@ -773,8 +773,8 @@ static void _call_f_setColumnHidden_1523 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setColumnHidden (arg1, arg2);
 }
@@ -796,8 +796,8 @@ static void _call_f_setColumnWidth_1426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setColumnWidth (arg1, arg2);
 }
@@ -819,8 +819,8 @@ static void _call_f_setExpanded_3151 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setExpanded (arg1, arg2);
 }
@@ -840,7 +840,7 @@ static void _call_f_setExpandsOnDoubleClick_864 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setExpandsOnDoubleClick (arg1);
 }
@@ -864,9 +864,9 @@ static void _call_f_setFirstColumnSpanned_3810 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
-  bool arg3 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  bool arg3 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setFirstColumnSpanned (arg1, arg2, arg3);
 }
@@ -886,7 +886,7 @@ static void _call_f_setHeader_1699 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QHeaderView *arg1 = args.read<QHeaderView * > (heap);
+  QHeaderView *arg1 = gsi::arg_reader<QHeaderView * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setHeader (arg1);
 }
@@ -906,7 +906,7 @@ static void _call_f_setHeaderHidden_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setHeaderHidden (arg1);
 }
@@ -926,7 +926,7 @@ static void _call_f_setIndentation_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setIndentation (arg1);
 }
@@ -946,7 +946,7 @@ static void _call_f_setItemsExpandable_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setItemsExpandable (arg1);
 }
@@ -966,7 +966,7 @@ static void _call_f_setModel_2419 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractItemModel *arg1 = args.read<QAbstractItemModel * > (heap);
+  QAbstractItemModel *arg1 = gsi::arg_reader<QAbstractItemModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setModel (arg1);
 }
@@ -986,7 +986,7 @@ static void _call_f_setRootIndex_2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setRootIndex (arg1);
 }
@@ -1006,7 +1006,7 @@ static void _call_f_setRootIsDecorated_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setRootIsDecorated (arg1);
 }
@@ -1030,9 +1030,9 @@ static void _call_f_setRowHidden_3810 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
-  bool arg3 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  bool arg3 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setRowHidden (arg1, arg2, arg3);
 }
@@ -1052,7 +1052,7 @@ static void _call_f_setSelectionModel_2533 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QItemSelectionModel *arg1 = args.read<QItemSelectionModel * > (heap);
+  QItemSelectionModel *arg1 = gsi::arg_reader<QItemSelectionModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setSelectionModel (arg1);
 }
@@ -1072,7 +1072,7 @@ static void _call_f_setSortingEnabled_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setSortingEnabled (arg1);
 }
@@ -1092,7 +1092,7 @@ static void _call_f_setUniformRowHeights_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setUniformRowHeights (arg1);
 }
@@ -1112,7 +1112,7 @@ static void _call_f_setWordWrap_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->setWordWrap (arg1);
 }
@@ -1132,7 +1132,7 @@ static void _call_f_showColumn_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->showColumn (arg1);
 }
@@ -1154,8 +1154,8 @@ static void _call_f_sortByColumn_2340 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->sortByColumn (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -1175,7 +1175,7 @@ static void _call_f_sortByColumn_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView *)cls)->sortByColumn (arg1);
 }
@@ -1210,7 +1210,7 @@ static void _call_f_visualRect_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QRect > ((QRect)((QTreeView *)cls)->visualRect (arg1));
 }
 
@@ -1246,8 +1246,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTreeView::tr (arg1, arg2));
 }
 
@@ -1270,9 +1270,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTreeView::tr (arg1, arg2, arg3));
 }
 
@@ -1293,8 +1293,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTreeView::trUtf8 (arg1, arg2));
 }
 
@@ -1317,9 +1317,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTreeView::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -3095,7 +3095,7 @@ static void _call_ctor_QTreeView_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTreeView_Adaptor *> (new QTreeView_Adaptor (arg1));
 }
 
@@ -3137,7 +3137,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeView_Adaptor *)cls)->emitter_QTreeView_activated_2395 (arg1);
 }
 
@@ -3203,7 +3203,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeView_Adaptor *)cls)->emitter_QTreeView_clicked_2395 (arg1);
 }
 
@@ -3272,7 +3272,7 @@ static void _call_emitter_collapsed_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeView_Adaptor *)cls)->emitter_QTreeView_collapsed_2395 (arg1);
 }
 
@@ -3292,8 +3292,8 @@ static void _call_fp_columnCountChanged_1426 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_columnCountChanged_1426 (arg1, arg2);
 }
@@ -3331,9 +3331,9 @@ static void _call_fp_columnResized_2085 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_columnResized_2085 (arg1, arg2, arg3);
 }
@@ -3404,9 +3404,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_create_2208 (arg1, arg2, arg3);
 }
@@ -3452,7 +3452,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QTreeView_Adaptor *)cls)->emitter_QTreeView_customContextMenuRequested_1916 (arg1);
 }
 
@@ -3523,8 +3523,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_destroy_1620 (arg1, arg2);
 }
@@ -3543,7 +3543,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTreeView_Adaptor *)cls)->emitter_QTreeView_destroyed_1302 (arg1);
 }
 
@@ -3634,7 +3634,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeView_Adaptor *)cls)->emitter_QTreeView_doubleClicked_2395 (arg1);
 }
 
@@ -3754,7 +3754,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_drawFrame_1426 (arg1);
 }
@@ -3805,8 +3805,8 @@ static void _call_fp_drawTree_c3324 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRegion &arg2 = args.read<const QRegion & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRegion &arg2 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_drawTree_c3324 (arg1, arg2);
 }
@@ -3964,7 +3964,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeView_Adaptor *)cls)->emitter_QTreeView_entered_2395 (arg1);
 }
 
@@ -4046,7 +4046,7 @@ static void _call_emitter_expanded_2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeView_Adaptor *)cls)->emitter_QTreeView_expanded_2395 (arg1);
 }
 
@@ -4338,7 +4338,7 @@ static void _call_fp_indexRowSizeHint_c2395 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<int > ((int)((QTreeView_Adaptor *)cls)->fp_QTreeView_indexRowSizeHint_c2395 (arg1));
 }
 
@@ -4797,7 +4797,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeView_Adaptor *)cls)->emitter_QTreeView_pressed_2395 (arg1);
 }
 
@@ -4815,7 +4815,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTreeView_Adaptor *)cls)->fp_QTreeView_receivers_c1731 (arg1));
 }
 
@@ -4907,7 +4907,7 @@ static void _call_fp_rowHeight_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<int > ((int)((QTreeView_Adaptor *)cls)->fp_QTreeView_rowHeight_c2395 (arg1));
 }
 
@@ -4989,9 +4989,9 @@ static void _call_fp_rowsRemoved_3713 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_rowsRemoved_3713 (arg1, arg2, arg3);
 }
@@ -5054,8 +5054,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -5207,7 +5207,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_setDirtyRegion_2006 (arg1);
 }
@@ -5226,7 +5226,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -5344,7 +5344,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_setState_2776 (arg1);
 }
@@ -5363,7 +5363,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_setVerticalStepsPerItem_767 (arg1);
 }
@@ -5388,10 +5388,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -5410,7 +5410,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_setViewportMargins_2115 (arg1);
 }
@@ -5453,7 +5453,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeView_Adaptor *)cls)->fp_QTreeView_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTreeWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTreeWidget.cc
@@ -121,7 +121,7 @@ static void _call_f_addTopLevelItem_2114 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->addTopLevelItem (arg1);
@@ -142,7 +142,7 @@ static void _call_f_addTopLevelItems_3462 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QTreeWidgetItem*> &arg1 = args.read<const QList<QTreeWidgetItem*> & > (heap);
+  const QList<QTreeWidgetItem*> &arg1 = gsi::arg_reader<const QList<QTreeWidgetItem*> & >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->addTopLevelItems (arg1);
@@ -181,8 +181,8 @@ static void _call_f_closePersistentEditor_2773 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->closePersistentEditor (arg1, arg2);
 }
@@ -202,7 +202,7 @@ static void _call_f_collapseItem_2809 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->collapseItem (arg1);
 }
@@ -269,8 +269,8 @@ static void _call_f_editItem_2773 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->editItem (arg1, arg2);
 }
@@ -290,7 +290,7 @@ static void _call_f_expandItem_2809 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->expandItem (arg1);
 }
@@ -314,9 +314,9 @@ static void _call_f_findItems_c4892 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<Qt::MatchFlag> arg2 = args.read<QFlags<Qt::MatchFlag> > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<Qt::MatchFlag> arg2 = gsi::arg_reader<QFlags<Qt::MatchFlag> >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QList<QTreeWidgetItem*> > ((QList<QTreeWidgetItem*>)((QTreeWidget *)cls)->findItems (arg1, arg2, arg3));
 }
 
@@ -350,7 +350,7 @@ static void _call_f_indexOfTopLevelItem_2114 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   ret.write<int > ((int)((QTreeWidget *)cls)->indexOfTopLevelItem (arg1));
 }
 
@@ -369,7 +369,7 @@ static void _call_f_indexOfTopLevelItem_c2114 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   ret.write<int > ((int)((QTreeWidget *)cls)->indexOfTopLevelItem (arg1));
 }
 
@@ -390,8 +390,8 @@ static void _call_f_insertTopLevelItem_2773 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QTreeWidgetItem *arg2 = args.read<QTreeWidgetItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QTreeWidgetItem *arg2 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   qt_gsi::qt_keep (arg2);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->insertTopLevelItem (arg1, arg2);
@@ -414,8 +414,8 @@ static void _call_f_insertTopLevelItems_4121 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QList<QTreeWidgetItem*> &arg2 = args.read<const QList<QTreeWidgetItem*> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QList<QTreeWidgetItem*> &arg2 = gsi::arg_reader<const QList<QTreeWidgetItem*> & >() (args, heap);
   qt_gsi::qt_keep (arg2);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->insertTopLevelItems (arg1, arg2);
@@ -451,7 +451,7 @@ static void _call_f_isFirstItemColumnSpanned_c2809 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
   ret.write<bool > ((bool)((QTreeWidget *)cls)->isFirstItemColumnSpanned (arg1));
 }
 
@@ -470,7 +470,7 @@ static void _call_f_isItemExpanded_c2809 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
   ret.write<bool > ((bool)((QTreeWidget *)cls)->isItemExpanded (arg1));
 }
 
@@ -489,7 +489,7 @@ static void _call_f_isItemHidden_c2809 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
   ret.write<bool > ((bool)((QTreeWidget *)cls)->isItemHidden (arg1));
 }
 
@@ -508,7 +508,7 @@ static void _call_f_isItemSelected_c2809 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
   ret.write<bool > ((bool)((QTreeWidget *)cls)->isItemSelected (arg1));
 }
 
@@ -542,7 +542,7 @@ static void _call_f_itemAbove_c2809 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
   ret.write<QTreeWidgetItem * > ((QTreeWidgetItem *)((QTreeWidget *)cls)->itemAbove (arg1));
 }
 
@@ -561,7 +561,7 @@ static void _call_f_itemAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QTreeWidgetItem * > ((QTreeWidgetItem *)((QTreeWidget *)cls)->itemAt (arg1));
 }
 
@@ -582,8 +582,8 @@ static void _call_f_itemAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTreeWidgetItem * > ((QTreeWidgetItem *)((QTreeWidget *)cls)->itemAt (arg1, arg2));
 }
 
@@ -602,7 +602,7 @@ static void _call_f_itemBelow_c2809 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
   ret.write<QTreeWidgetItem * > ((QTreeWidgetItem *)((QTreeWidget *)cls)->itemBelow (arg1));
 }
 
@@ -623,8 +623,8 @@ static void _call_f_itemWidget_c2773 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QTreeWidget *)cls)->itemWidget (arg1, arg2));
 }
 
@@ -645,8 +645,8 @@ static void _call_f_openPersistentEditor_2773 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->openPersistentEditor (arg1, arg2);
 }
@@ -668,8 +668,8 @@ static void _call_f_removeItemWidget_2773 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->removeItemWidget (arg1, arg2);
 }
@@ -691,8 +691,8 @@ static void _call_f_scrollToItem_5990 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
-  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible));
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
+  const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractItemView::ScrollHint>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractItemView::ScrollHint>(heap, QAbstractItemView::EnsureVisible), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->scrollToItem (arg1, qt_gsi::QtToCppAdaptor<QAbstractItemView::ScrollHint>(arg2).cref());
 }
@@ -727,7 +727,7 @@ static void _call_f_setColumnCount_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setColumnCount (arg1);
 }
@@ -747,7 +747,7 @@ static void _call_f_setCurrentItem_2114 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setCurrentItem (arg1);
 }
@@ -769,8 +769,8 @@ static void _call_f_setCurrentItem_2773 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setCurrentItem (arg1, arg2);
 }
@@ -794,9 +794,9 @@ static void _call_f_setCurrentItem_7136 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
-  QFlags<QItemSelectionModel::SelectionFlag> arg3 = args.read<QFlags<QItemSelectionModel::SelectionFlag> > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QFlags<QItemSelectionModel::SelectionFlag> arg3 = gsi::arg_reader<QFlags<QItemSelectionModel::SelectionFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setCurrentItem (arg1, arg2, arg3);
 }
@@ -818,8 +818,8 @@ static void _call_f_setFirstItemColumnSpanned_3565 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setFirstItemColumnSpanned (arg1, arg2);
 }
@@ -839,7 +839,7 @@ static void _call_f_setHeaderItem_2114 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setHeaderItem (arg1);
 }
@@ -859,7 +859,7 @@ static void _call_f_setHeaderLabel_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setHeaderLabel (arg1);
 }
@@ -879,7 +879,7 @@ static void _call_f_setHeaderLabels_2437 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setHeaderLabels (arg1);
 }
@@ -901,8 +901,8 @@ static void _call_f_setItemExpanded_3565 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setItemExpanded (arg1, arg2);
 }
@@ -924,8 +924,8 @@ static void _call_f_setItemHidden_3565 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setItemHidden (arg1, arg2);
 }
@@ -947,8 +947,8 @@ static void _call_f_setItemSelected_3565 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setItemSelected (arg1, arg2);
 }
@@ -972,9 +972,9 @@ static void _call_f_setItemWidget_3980 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
-  QWidget *arg3 = args.read<QWidget * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QWidget *arg3 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setItemWidget (arg1, arg2, arg3);
 }
@@ -994,7 +994,7 @@ static void _call_f_setSelectionModel_2533 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QItemSelectionModel *arg1 = args.read<QItemSelectionModel * > (heap);
+  QItemSelectionModel *arg1 = gsi::arg_reader<QItemSelectionModel * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setSelectionModel (arg1);
 }
@@ -1014,7 +1014,7 @@ static void _call_f_setSortingEnabled_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->setSortingEnabled (arg1);
 }
@@ -1051,8 +1051,8 @@ static void _call_f_sortItems_2340 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget *)cls)->sortItems (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -1072,7 +1072,7 @@ static void _call_f_takeTopLevelItem_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTreeWidgetItem * > ((QTreeWidgetItem *)((QTreeWidget *)cls)->takeTopLevelItem (arg1));
 }
 
@@ -1091,7 +1091,7 @@ static void _call_f_topLevelItem_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTreeWidgetItem * > ((QTreeWidgetItem *)((QTreeWidget *)cls)->topLevelItem (arg1));
 }
 
@@ -1125,7 +1125,7 @@ static void _call_f_visualItemRect_c2809 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem *arg1 = args.read<const QTreeWidgetItem * > (heap);
+  const QTreeWidgetItem *arg1 = gsi::arg_reader<const QTreeWidgetItem * >() (args, heap);
   ret.write<QRect > ((QRect)((QTreeWidget *)cls)->visualItemRect (arg1));
 }
 
@@ -1146,8 +1146,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTreeWidget::tr (arg1, arg2));
 }
 
@@ -1170,9 +1170,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTreeWidget::tr (arg1, arg2, arg3));
 }
 
@@ -1193,8 +1193,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTreeWidget::trUtf8 (arg1, arg2));
 }
 
@@ -1217,9 +1217,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTreeWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -3120,7 +3120,7 @@ static void _call_ctor_QTreeWidget_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QTreeWidget_Adaptor *> (new QTreeWidget_Adaptor (arg1));
 }
 
@@ -3162,7 +3162,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_activated_2395 (arg1);
 }
 
@@ -3228,7 +3228,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_clicked_2395 (arg1);
 }
 
@@ -3297,7 +3297,7 @@ static void _call_emitter_collapsed_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_collapsed_2395 (arg1);
 }
 
@@ -3317,8 +3317,8 @@ static void _call_fp_columnCountChanged_1426 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_columnCountChanged_1426 (arg1, arg2);
 }
@@ -3356,9 +3356,9 @@ static void _call_fp_columnResized_2085 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_columnResized_2085 (arg1, arg2, arg3);
 }
@@ -3429,9 +3429,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -3479,8 +3479,8 @@ static void _call_emitter_currentItemChanged_4120 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  QTreeWidgetItem *arg2 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  QTreeWidgetItem *arg2 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_currentItemChanged_4120 (arg1, arg2);
 }
 
@@ -3498,7 +3498,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -3569,8 +3569,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_destroy_1620 (arg1, arg2);
 }
@@ -3589,7 +3589,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_destroyed_1302 (arg1);
 }
 
@@ -3680,7 +3680,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_doubleClicked_2395 (arg1);
 }
 
@@ -3800,7 +3800,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_drawFrame_1426 (arg1);
 }
@@ -3851,8 +3851,8 @@ static void _call_fp_drawTree_c3324 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QRegion &arg2 = args.read<const QRegion & > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QRegion &arg2 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_drawTree_c3324 (arg1, arg2);
 }
@@ -4042,7 +4042,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_entered_2395 (arg1);
 }
 
@@ -4124,7 +4124,7 @@ static void _call_emitter_expanded_2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_expanded_2395 (arg1);
 }
 
@@ -4418,8 +4418,8 @@ static void _call_fp_indexFromItem_c2773 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(0);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_indexFromItem_c2773 (arg1, arg2));
 }
 
@@ -4437,7 +4437,7 @@ static void _call_fp_indexRowSizeHint_c2395 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<int > ((int)((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_indexRowSizeHint_c2395 (arg1));
 }
 
@@ -4527,8 +4527,8 @@ static void _call_emitter_itemActivated_2773 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_itemActivated_2773 (arg1, arg2);
 }
 
@@ -4548,8 +4548,8 @@ static void _call_emitter_itemChanged_2773 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_itemChanged_2773 (arg1, arg2);
 }
 
@@ -4569,8 +4569,8 @@ static void _call_emitter_itemClicked_2773 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_itemClicked_2773 (arg1, arg2);
 }
 
@@ -4588,7 +4588,7 @@ static void _call_emitter_itemCollapsed_2114 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_itemCollapsed_2114 (arg1);
 }
 
@@ -4608,8 +4608,8 @@ static void _call_emitter_itemDoubleClicked_2773 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_itemDoubleClicked_2773 (arg1, arg2);
 }
 
@@ -4629,8 +4629,8 @@ static void _call_emitter_itemEntered_2773 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_itemEntered_2773 (arg1, arg2);
 }
 
@@ -4648,7 +4648,7 @@ static void _call_emitter_itemExpanded_2114 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_itemExpanded_2114 (arg1);
 }
 
@@ -4666,7 +4666,7 @@ static void _call_fp_itemFromIndex_c2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QTreeWidgetItem * > ((QTreeWidgetItem *)((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_itemFromIndex_c2395 (arg1));
 }
 
@@ -4686,8 +4686,8 @@ static void _call_emitter_itemPressed_2773 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args.read<int > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_itemPressed_2773 (arg1, arg2);
 }
 
@@ -4719,7 +4719,7 @@ static void _call_fp_items_c2168 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMimeData *arg1 = args.read<const QMimeData * > (heap);
+  const QMimeData *arg1 = gsi::arg_reader<const QMimeData * >() (args, heap);
   ret.write<QList<QTreeWidgetItem*> > ((QList<QTreeWidgetItem*>)((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_items_c2168 (arg1));
 }
 
@@ -5150,7 +5150,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QTreeWidget_Adaptor *)cls)->emitter_QTreeWidget_pressed_2395 (arg1);
 }
 
@@ -5168,7 +5168,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_receivers_c1731 (arg1));
 }
 
@@ -5260,7 +5260,7 @@ static void _call_fp_rowHeight_c2395 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<int > ((int)((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_rowHeight_c2395 (arg1));
 }
 
@@ -5342,9 +5342,9 @@ static void _call_fp_rowsRemoved_3713 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_rowsRemoved_3713 (arg1, arg2, arg3);
 }
@@ -5407,8 +5407,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -5560,7 +5560,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_setDirtyRegion_2006 (arg1);
 }
@@ -5579,7 +5579,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -5673,7 +5673,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_setState_2776 (arg1);
 }
@@ -5692,7 +5692,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_setVerticalStepsPerItem_767 (arg1);
 }
@@ -5717,10 +5717,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -5739,7 +5739,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_setViewportMargins_2115 (arg1);
 }
@@ -5782,7 +5782,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidget_Adaptor *)cls)->fp_QTreeWidget_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTreeWidgetItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTreeWidgetItem.cc
@@ -57,7 +57,7 @@ static void _call_f_addChild_2114 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->addChild (arg1);
@@ -78,7 +78,7 @@ static void _call_f_addChildren_3462 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QTreeWidgetItem*> &arg1 = args.read<const QList<QTreeWidgetItem*> & > (heap);
+  const QList<QTreeWidgetItem*> &arg1 = gsi::arg_reader<const QList<QTreeWidgetItem*> & >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->addChildren (arg1);
@@ -99,7 +99,7 @@ static void _call_f_background_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QBrush > ((QBrush)((QTreeWidgetItem *)cls)->background (arg1));
 }
 
@@ -118,7 +118,7 @@ static void _call_f_backgroundColor_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QColor > ((QColor)((QTreeWidgetItem *)cls)->backgroundColor (arg1));
 }
 
@@ -137,7 +137,7 @@ static void _call_f_checkState_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<qt_gsi::Converter<Qt::CheckState>::target_type > ((qt_gsi::Converter<Qt::CheckState>::target_type)qt_gsi::CppToQtAdaptor<Qt::CheckState>(((QTreeWidgetItem *)cls)->checkState (arg1)));
 }
 
@@ -156,7 +156,7 @@ static void _call_f_child_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTreeWidgetItem * > ((QTreeWidgetItem *)((QTreeWidgetItem *)cls)->child (arg1));
 }
 
@@ -237,8 +237,8 @@ static void _call_f_data_c1426 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QTreeWidgetItem *)cls)->data (arg1, arg2));
 }
 
@@ -272,7 +272,7 @@ static void _call_f_font_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFont > ((QFont)((QTreeWidgetItem *)cls)->font (arg1));
 }
 
@@ -291,7 +291,7 @@ static void _call_f_foreground_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QBrush > ((QBrush)((QTreeWidgetItem *)cls)->foreground (arg1));
 }
 
@@ -310,7 +310,7 @@ static void _call_f_icon_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QIcon > ((QIcon)((QTreeWidgetItem *)cls)->icon (arg1));
 }
 
@@ -329,7 +329,7 @@ static void _call_f_indexOfChild_c2114 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   ret.write<int > ((int)((QTreeWidgetItem *)cls)->indexOfChild (arg1));
 }
 
@@ -350,8 +350,8 @@ static void _call_f_insertChild_2773 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QTreeWidgetItem *arg2 = args.read<QTreeWidgetItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QTreeWidgetItem *arg2 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   qt_gsi::qt_keep (arg2);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->insertChild (arg1, arg2);
@@ -374,8 +374,8 @@ static void _call_f_insertChildren_4121 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QList<QTreeWidgetItem*> &arg2 = args.read<const QList<QTreeWidgetItem*> & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QList<QTreeWidgetItem*> &arg2 = gsi::arg_reader<const QList<QTreeWidgetItem*> & >() (args, heap);
   qt_gsi::qt_keep (arg2);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->insertChildren (arg1, arg2);
@@ -471,7 +471,7 @@ static void _call_f_operator_lt__c2805 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem &arg1 = args.read<const QTreeWidgetItem & > (heap);
+  const QTreeWidgetItem &arg1 = gsi::arg_reader<const QTreeWidgetItem & >() (args, heap);
   ret.write<bool > ((bool)((QTreeWidgetItem *)cls)->operator< (arg1));
 }
 
@@ -490,7 +490,7 @@ static void _call_f_operator_eq__2805 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItem &arg1 = args.read<const QTreeWidgetItem & > (heap);
+  const QTreeWidgetItem &arg1 = gsi::arg_reader<const QTreeWidgetItem & >() (args, heap);
   ret.write<QTreeWidgetItem & > ((QTreeWidgetItem &)((QTreeWidgetItem *)cls)->operator= (arg1));
 }
 
@@ -524,7 +524,7 @@ static void _call_f_read_1697 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->read (arg1);
 }
@@ -544,7 +544,7 @@ static void _call_f_removeChild_2114 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->removeChild (arg1);
 }
@@ -566,8 +566,8 @@ static void _call_f_setBackground_2569 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QBrush &arg2 = args.read<const QBrush & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QBrush &arg2 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setBackground (arg1, arg2);
 }
@@ -589,8 +589,8 @@ static void _call_f_setBackgroundColor_2564 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QColor &arg2 = args.read<const QColor & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QColor &arg2 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setBackgroundColor (arg1, arg2);
 }
@@ -612,8 +612,8 @@ static void _call_f_setCheckState_2399 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::CheckState>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::CheckState>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::CheckState>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::CheckState>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setCheckState (arg1, qt_gsi::QtToCppAdaptor<Qt::CheckState>(arg2).cref());
 }
@@ -633,7 +633,7 @@ static void _call_f_setChildIndicatorPolicy_4077 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QTreeWidgetItem::ChildIndicatorPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QTreeWidgetItem::ChildIndicatorPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QTreeWidgetItem::ChildIndicatorPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QTreeWidgetItem::ChildIndicatorPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setChildIndicatorPolicy (qt_gsi::QtToCppAdaptor<QTreeWidgetItem::ChildIndicatorPolicy>(arg1).cref());
 }
@@ -657,9 +657,9 @@ static void _call_f_setData_3437 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setData (arg1, arg2, arg3);
 }
@@ -679,7 +679,7 @@ static void _call_f_setDisabled_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setDisabled (arg1);
 }
@@ -699,7 +699,7 @@ static void _call_f_setExpanded_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setExpanded (arg1);
 }
@@ -719,7 +719,7 @@ static void _call_f_setFirstColumnSpanned_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setFirstColumnSpanned (arg1);
 }
@@ -739,7 +739,7 @@ static void _call_f_setFlags_2222 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::ItemFlag> arg1 = args.read<QFlags<Qt::ItemFlag> > (heap);
+  QFlags<Qt::ItemFlag> arg1 = gsi::arg_reader<QFlags<Qt::ItemFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setFlags (arg1);
 }
@@ -761,8 +761,8 @@ static void _call_f_setFont_2460 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QFont &arg2 = args.read<const QFont & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QFont &arg2 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setFont (arg1, arg2);
 }
@@ -784,8 +784,8 @@ static void _call_f_setForeground_2569 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QBrush &arg2 = args.read<const QBrush & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QBrush &arg2 = gsi::arg_reader<const QBrush & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setForeground (arg1, arg2);
 }
@@ -805,7 +805,7 @@ static void _call_f_setHidden_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setHidden (arg1);
 }
@@ -827,8 +827,8 @@ static void _call_f_setIcon_2446 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QIcon &arg2 = args.read<const QIcon & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QIcon &arg2 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setIcon (arg1, arg2);
 }
@@ -848,7 +848,7 @@ static void _call_f_setSelected_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setSelected (arg1);
 }
@@ -870,8 +870,8 @@ static void _call_f_setSizeHint_2464 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QSize &arg2 = args.read<const QSize & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QSize &arg2 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setSizeHint (arg1, arg2);
 }
@@ -893,8 +893,8 @@ static void _call_f_setStatusTip_2684 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setStatusTip (arg1, arg2);
 }
@@ -916,8 +916,8 @@ static void _call_f_setText_2684 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setText (arg1, arg2);
 }
@@ -939,8 +939,8 @@ static void _call_f_setTextAlignment_1426 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setTextAlignment (arg1, arg2);
 }
@@ -962,8 +962,8 @@ static void _call_f_setTextColor_2564 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QColor &arg2 = args.read<const QColor & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QColor &arg2 = gsi::arg_reader<const QColor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setTextColor (arg1, arg2);
 }
@@ -985,8 +985,8 @@ static void _call_f_setToolTip_2684 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setToolTip (arg1, arg2);
 }
@@ -1008,8 +1008,8 @@ static void _call_f_setWhatsThis_2684 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->setWhatsThis (arg1, arg2);
 }
@@ -1029,7 +1029,7 @@ static void _call_f_sizeHint_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QSize > ((QSize)((QTreeWidgetItem *)cls)->sizeHint (arg1));
 }
 
@@ -1050,8 +1050,8 @@ static void _call_f_sortChildren_2340 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->sortChildren (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -1071,7 +1071,7 @@ static void _call_f_statusTip_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTreeWidgetItem *)cls)->statusTip (arg1));
 }
 
@@ -1090,7 +1090,7 @@ static void _call_f_takeChild_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTreeWidgetItem * > ((QTreeWidgetItem *)((QTreeWidgetItem *)cls)->takeChild (arg1));
 }
 
@@ -1124,7 +1124,7 @@ static void _call_f_text_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTreeWidgetItem *)cls)->text (arg1));
 }
 
@@ -1143,7 +1143,7 @@ static void _call_f_textAlignment_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QTreeWidgetItem *)cls)->textAlignment (arg1));
 }
 
@@ -1162,7 +1162,7 @@ static void _call_f_textColor_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QColor > ((QColor)((QTreeWidgetItem *)cls)->textColor (arg1));
 }
 
@@ -1181,7 +1181,7 @@ static void _call_f_toolTip_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTreeWidgetItem *)cls)->toolTip (arg1));
 }
 
@@ -1230,7 +1230,7 @@ static void _call_f_whatsThis_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QTreeWidgetItem *)cls)->whatsThis (arg1));
 }
 
@@ -1249,7 +1249,7 @@ static void _call_f_write_c1697 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDataStream &arg1 = args.read<QDataStream & > (heap);
+  QDataStream &arg1 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTreeWidgetItem *)cls)->write (arg1);
 }
@@ -1554,7 +1554,7 @@ static void _call_ctor_QTreeWidgetItem_Adaptor_767 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(QTreeWidgetItem::Type);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTreeWidgetItem::Type, heap);
   ret.write<QTreeWidgetItem_Adaptor *> (new QTreeWidgetItem_Adaptor (arg1));
 }
 
@@ -1574,8 +1574,8 @@ static void _call_ctor_QTreeWidgetItem_Adaptor_3096 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QStringList &arg1 = args.read<const QStringList & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(QTreeWidgetItem::Type);
+  const QStringList &arg1 = gsi::arg_reader<const QStringList & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTreeWidgetItem::Type, heap);
   ret.write<QTreeWidgetItem_Adaptor *> (new QTreeWidgetItem_Adaptor (arg1, arg2));
 }
 
@@ -1595,8 +1595,8 @@ static void _call_ctor_QTreeWidgetItem_Adaptor_2374 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidget *arg1 = args.read<QTreeWidget * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(QTreeWidgetItem::Type);
+  QTreeWidget *arg1 = gsi::arg_reader<QTreeWidget * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTreeWidgetItem::Type, heap);
   QTreeWidgetItem_Adaptor *obj = new QTreeWidgetItem_Adaptor (arg1, arg2);
   if (arg1) {
     qt_gsi::qt_keep (obj);
@@ -1622,9 +1622,9 @@ static void _call_ctor_QTreeWidgetItem_Adaptor_4703 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidget *arg1 = args.read<QTreeWidget * > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(QTreeWidgetItem::Type);
+  QTreeWidget *arg1 = gsi::arg_reader<QTreeWidget * >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTreeWidgetItem::Type, heap);
   QTreeWidgetItem_Adaptor *obj = new QTreeWidgetItem_Adaptor (arg1, arg2, arg3);
   if (arg1) {
     qt_gsi::qt_keep (obj);
@@ -1650,9 +1650,9 @@ static void _call_ctor_QTreeWidgetItem_Adaptor_4380 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidget *arg1 = args.read<QTreeWidget * > (heap);
-  QTreeWidgetItem *arg2 = args.read<QTreeWidgetItem * > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(QTreeWidgetItem::Type);
+  QTreeWidget *arg1 = gsi::arg_reader<QTreeWidget * >() (args, heap);
+  QTreeWidgetItem *arg2 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTreeWidgetItem::Type, heap);
   QTreeWidgetItem_Adaptor *obj = new QTreeWidgetItem_Adaptor (arg1, arg2, arg3);
   if (arg1) {
     qt_gsi::qt_keep (obj);
@@ -1676,8 +1676,8 @@ static void _call_ctor_QTreeWidgetItem_Adaptor_2773 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(QTreeWidgetItem::Type);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTreeWidgetItem::Type, heap);
   QTreeWidgetItem_Adaptor *obj = new QTreeWidgetItem_Adaptor (arg1, arg2);
   if (arg1) {
     qt_gsi::qt_keep (obj);
@@ -1703,9 +1703,9 @@ static void _call_ctor_QTreeWidgetItem_Adaptor_5102 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  const QStringList &arg2 = args.read<const QStringList & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(QTreeWidgetItem::Type);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  const QStringList &arg2 = gsi::arg_reader<const QStringList & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTreeWidgetItem::Type, heap);
   QTreeWidgetItem_Adaptor *obj = new QTreeWidgetItem_Adaptor (arg1, arg2, arg3);
   if (arg1) {
     qt_gsi::qt_keep (obj);
@@ -1731,9 +1731,9 @@ static void _call_ctor_QTreeWidgetItem_Adaptor_4779 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  QTreeWidgetItem *arg2 = args.read<QTreeWidgetItem * > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(QTreeWidgetItem::Type);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  QTreeWidgetItem *arg2 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (QTreeWidgetItem::Type, heap);
   QTreeWidgetItem_Adaptor *obj = new QTreeWidgetItem_Adaptor (arg1, arg2, arg3);
   if (arg1) {
     qt_gsi::qt_keep (obj);

--- a/src/gsiqt/qt4/QtGui/gsiDeclQTreeWidgetItemIterator.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQTreeWidgetItemIterator.cc
@@ -52,7 +52,7 @@ static void _call_ctor_QTreeWidgetItemIterator_3647 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItemIterator &arg1 = args.read<const QTreeWidgetItemIterator & > (heap);
+  const QTreeWidgetItemIterator &arg1 = gsi::arg_reader<const QTreeWidgetItemIterator & >() (args, heap);
   ret.write<QTreeWidgetItemIterator *> (new QTreeWidgetItemIterator (arg1));
 }
 
@@ -73,8 +73,8 @@ static void _call_ctor_QTreeWidgetItemIterator_6409 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidget *arg1 = args.read<QTreeWidget * > (heap);
-  QFlags<QTreeWidgetItemIterator::IteratorFlag> arg2 = args ? args.read<QFlags<QTreeWidgetItemIterator::IteratorFlag> > (heap) : (QFlags<QTreeWidgetItemIterator::IteratorFlag>)(QTreeWidgetItemIterator::All);
+  QTreeWidget *arg1 = gsi::arg_reader<QTreeWidget * >() (args, heap);
+  QFlags<QTreeWidgetItemIterator::IteratorFlag> arg2 = args ? gsi::arg_reader<QFlags<QTreeWidgetItemIterator::IteratorFlag> >() (args, heap) : gsi::arg_maker<QFlags<QTreeWidgetItemIterator::IteratorFlag> >() (QTreeWidgetItemIterator::All, heap);
   ret.write<QTreeWidgetItemIterator *> (new QTreeWidgetItemIterator (arg1, arg2));
 }
 
@@ -95,8 +95,8 @@ static void _call_ctor_QTreeWidgetItemIterator_6808 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTreeWidgetItem *arg1 = args.read<QTreeWidgetItem * > (heap);
-  QFlags<QTreeWidgetItemIterator::IteratorFlag> arg2 = args ? args.read<QFlags<QTreeWidgetItemIterator::IteratorFlag> > (heap) : (QFlags<QTreeWidgetItemIterator::IteratorFlag>)(QTreeWidgetItemIterator::All);
+  QTreeWidgetItem *arg1 = gsi::arg_reader<QTreeWidgetItem * >() (args, heap);
+  QFlags<QTreeWidgetItemIterator::IteratorFlag> arg2 = args ? gsi::arg_reader<QFlags<QTreeWidgetItemIterator::IteratorFlag> >() (args, heap) : gsi::arg_maker<QFlags<QTreeWidgetItemIterator::IteratorFlag> >() (QTreeWidgetItemIterator::All, heap);
   ret.write<QTreeWidgetItemIterator *> (new QTreeWidgetItemIterator (arg1, arg2));
 }
 
@@ -145,7 +145,7 @@ static void _call_f_operator_plus__plus__767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<const QTreeWidgetItemIterator > ((const QTreeWidgetItemIterator)((QTreeWidgetItemIterator *)cls)->operator++ (arg1));
 }
 
@@ -164,7 +164,7 @@ static void _call_f_operator_plus__eq__767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTreeWidgetItemIterator & > ((QTreeWidgetItemIterator &)((QTreeWidgetItemIterator *)cls)->operator+= (arg1));
 }
 
@@ -198,7 +198,7 @@ static void _call_f_operator_minus__minus__767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<const QTreeWidgetItemIterator > ((const QTreeWidgetItemIterator)((QTreeWidgetItemIterator *)cls)->operator-- (arg1));
 }
 
@@ -217,7 +217,7 @@ static void _call_f_operator_minus__eq__767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QTreeWidgetItemIterator & > ((QTreeWidgetItemIterator &)((QTreeWidgetItemIterator *)cls)->operator-= (arg1));
 }
 
@@ -236,7 +236,7 @@ static void _call_f_operator_eq__3647 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QTreeWidgetItemIterator &arg1 = args.read<const QTreeWidgetItemIterator & > (heap);
+  const QTreeWidgetItemIterator &arg1 = gsi::arg_reader<const QTreeWidgetItemIterator & >() (args, heap);
   ret.write<QTreeWidgetItemIterator & > ((QTreeWidgetItemIterator &)((QTreeWidgetItemIterator *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQUndoCommand.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQUndoCommand.cc
@@ -50,7 +50,7 @@ static void _call_f_child_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<const QUndoCommand * > ((const QUndoCommand *)((QUndoCommand *)cls)->child (arg1));
 }
 
@@ -99,7 +99,7 @@ static void _call_f_mergeWith_2507 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUndoCommand *arg1 = args.read<const QUndoCommand * > (heap);
+  const QUndoCommand *arg1 = gsi::arg_reader<const QUndoCommand * >() (args, heap);
   ret.write<bool > ((bool)((QUndoCommand *)cls)->mergeWith (arg1));
 }
 
@@ -134,7 +134,7 @@ static void _call_f_setText_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoCommand *)cls)->setText (arg1);
 }
@@ -307,7 +307,7 @@ static void _call_ctor_QUndoCommand_Adaptor_1812 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoCommand *arg1 = args ? args.read<QUndoCommand * > (heap) : (QUndoCommand *)(0);
+  QUndoCommand *arg1 = args ? gsi::arg_reader<QUndoCommand * >() (args, heap) : gsi::arg_maker<QUndoCommand * >() (0, heap);
   ret.write<QUndoCommand_Adaptor *> (new QUndoCommand_Adaptor (arg1));
 }
 
@@ -327,8 +327,8 @@ static void _call_ctor_QUndoCommand_Adaptor_3729 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QUndoCommand *arg2 = args ? args.read<QUndoCommand * > (heap) : (QUndoCommand *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QUndoCommand *arg2 = args ? gsi::arg_reader<QUndoCommand * >() (args, heap) : gsi::arg_maker<QUndoCommand * >() (0, heap);
   ret.write<QUndoCommand_Adaptor *> (new QUndoCommand_Adaptor (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQUndoGroup.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQUndoGroup.cc
@@ -85,7 +85,7 @@ static void _call_f_addStack_1611 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoStack *arg1 = args.read<QUndoStack * > (heap);
+  QUndoStack *arg1 = gsi::arg_reader<QUndoStack * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoGroup *)cls)->addStack (arg1);
 }
@@ -137,8 +137,8 @@ static void _call_f_createRedoAction_c3219 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QAction * > ((QAction *)((QUndoGroup *)cls)->createRedoAction (arg1, arg2));
 }
 
@@ -159,8 +159,8 @@ static void _call_f_createUndoAction_c3219 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QAction * > ((QAction *)((QUndoGroup *)cls)->createUndoAction (arg1, arg2));
 }
 
@@ -225,7 +225,7 @@ static void _call_f_removeStack_1611 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoStack *arg1 = args.read<QUndoStack * > (heap);
+  QUndoStack *arg1 = gsi::arg_reader<QUndoStack * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoGroup *)cls)->removeStack (arg1);
 }
@@ -245,7 +245,7 @@ static void _call_f_setActiveStack_1611 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoStack *arg1 = args.read<QUndoStack * > (heap);
+  QUndoStack *arg1 = gsi::arg_reader<QUndoStack * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoGroup *)cls)->setActiveStack (arg1);
 }
@@ -313,8 +313,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUndoGroup::tr (arg1, arg2));
 }
 
@@ -337,9 +337,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUndoGroup::tr (arg1, arg2, arg3));
 }
 
@@ -360,8 +360,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUndoGroup::trUtf8 (arg1, arg2));
 }
 
@@ -384,9 +384,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUndoGroup::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -626,7 +626,7 @@ static void _call_ctor_QUndoGroup_Adaptor_1302 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QUndoGroup_Adaptor *> (new QUndoGroup_Adaptor (arg1));
 }
 
@@ -644,7 +644,7 @@ static void _call_emitter_activeStackChanged_1611 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoStack *arg1 = args.read<QUndoStack * > (heap);
+  QUndoStack *arg1 = gsi::arg_reader<QUndoStack * >() (args, heap);
   ((QUndoGroup_Adaptor *)cls)->emitter_QUndoGroup_activeStackChanged_1611 (arg1);
 }
 
@@ -662,7 +662,7 @@ static void _call_emitter_canRedoChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QUndoGroup_Adaptor *)cls)->emitter_QUndoGroup_canRedoChanged_864 (arg1);
 }
 
@@ -680,7 +680,7 @@ static void _call_emitter_canUndoChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QUndoGroup_Adaptor *)cls)->emitter_QUndoGroup_canUndoChanged_864 (arg1);
 }
 
@@ -722,7 +722,7 @@ static void _call_emitter_cleanChanged_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QUndoGroup_Adaptor *)cls)->emitter_QUndoGroup_cleanChanged_864 (arg1);
 }
 
@@ -764,7 +764,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QUndoGroup_Adaptor *)cls)->emitter_QUndoGroup_destroyed_1302 (arg1);
 }
 
@@ -855,7 +855,7 @@ static void _call_emitter_indexChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QUndoGroup_Adaptor *)cls)->emitter_QUndoGroup_indexChanged_767 (arg1);
 }
 
@@ -873,7 +873,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QUndoGroup_Adaptor *)cls)->fp_QUndoGroup_receivers_c1731 (arg1));
 }
 
@@ -891,7 +891,7 @@ static void _call_emitter_redoTextChanged_2025 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QUndoGroup_Adaptor *)cls)->emitter_QUndoGroup_redoTextChanged_2025 (arg1);
 }
 
@@ -947,7 +947,7 @@ static void _call_emitter_undoTextChanged_2025 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QUndoGroup_Adaptor *)cls)->emitter_QUndoGroup_undoTextChanged_2025 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQUndoStack.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQUndoStack.cc
@@ -70,7 +70,7 @@ static void _call_f_beginMacro_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoStack *)cls)->beginMacro (arg1);
 }
@@ -151,7 +151,7 @@ static void _call_f_command_c767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<const QUndoCommand * > ((const QUndoCommand *)((QUndoStack *)cls)->command (arg1));
 }
 
@@ -187,8 +187,8 @@ static void _call_f_createRedoAction_c3219 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QAction * > ((QAction *)((QUndoStack *)cls)->createRedoAction (arg1, arg2));
 }
 
@@ -209,8 +209,8 @@ static void _call_f_createUndoAction_c3219 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QAction * > ((QAction *)((QUndoStack *)cls)->createUndoAction (arg1, arg2));
 }
 
@@ -290,7 +290,7 @@ static void _call_f_push_1812 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoCommand *arg1 = args.read<QUndoCommand * > (heap);
+  QUndoCommand *arg1 = gsi::arg_reader<QUndoCommand * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoStack *)cls)->push (arg1);
 }
@@ -341,7 +341,7 @@ static void _call_f_setActive_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoStack *)cls)->setActive (arg1);
 }
@@ -377,7 +377,7 @@ static void _call_f_setIndex_767 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoStack *)cls)->setIndex (arg1);
 }
@@ -397,7 +397,7 @@ static void _call_f_setUndoLimit_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoStack *)cls)->setUndoLimit (arg1);
 }
@@ -417,7 +417,7 @@ static void _call_f_text_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QUndoStack *)cls)->text (arg1));
 }
 
@@ -484,8 +484,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUndoStack::tr (arg1, arg2));
 }
 
@@ -508,9 +508,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUndoStack::tr (arg1, arg2, arg3));
 }
 
@@ -531,8 +531,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUndoStack::trUtf8 (arg1, arg2));
 }
 
@@ -555,9 +555,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUndoStack::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -800,7 +800,7 @@ static void _call_ctor_QUndoStack_Adaptor_1302 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QUndoStack_Adaptor *> (new QUndoStack_Adaptor (arg1));
 }
 
@@ -818,7 +818,7 @@ static void _call_emitter_canRedoChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QUndoStack_Adaptor *)cls)->emitter_QUndoStack_canRedoChanged_864 (arg1);
 }
 
@@ -836,7 +836,7 @@ static void _call_emitter_canUndoChanged_864 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QUndoStack_Adaptor *)cls)->emitter_QUndoStack_canUndoChanged_864 (arg1);
 }
 
@@ -878,7 +878,7 @@ static void _call_emitter_cleanChanged_864 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QUndoStack_Adaptor *)cls)->emitter_QUndoStack_cleanChanged_864 (arg1);
 }
 
@@ -920,7 +920,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QUndoStack_Adaptor *)cls)->emitter_QUndoStack_destroyed_1302 (arg1);
 }
 
@@ -1011,7 +1011,7 @@ static void _call_emitter_indexChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QUndoStack_Adaptor *)cls)->emitter_QUndoStack_indexChanged_767 (arg1);
 }
 
@@ -1029,7 +1029,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QUndoStack_Adaptor *)cls)->fp_QUndoStack_receivers_c1731 (arg1));
 }
 
@@ -1047,7 +1047,7 @@ static void _call_emitter_redoTextChanged_2025 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QUndoStack_Adaptor *)cls)->emitter_QUndoStack_redoTextChanged_2025 (arg1);
 }
 
@@ -1103,7 +1103,7 @@ static void _call_emitter_undoTextChanged_2025 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QUndoStack_Adaptor *)cls)->emitter_QUndoStack_undoTextChanged_2025 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQUndoView.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQUndoView.cc
@@ -165,7 +165,7 @@ static void _call_f_setCleanIcon_1787 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView *)cls)->setCleanIcon (arg1);
 }
@@ -185,7 +185,7 @@ static void _call_f_setEmptyLabel_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView *)cls)->setEmptyLabel (arg1);
 }
@@ -205,7 +205,7 @@ static void _call_f_setGroup_1634 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoGroup *arg1 = args.read<QUndoGroup * > (heap);
+  QUndoGroup *arg1 = gsi::arg_reader<QUndoGroup * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView *)cls)->setGroup (arg1);
 }
@@ -225,7 +225,7 @@ static void _call_f_setStack_1611 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoStack *arg1 = args.read<QUndoStack * > (heap);
+  QUndoStack *arg1 = gsi::arg_reader<QUndoStack * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView *)cls)->setStack (arg1);
 }
@@ -262,8 +262,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUndoView::tr (arg1, arg2));
 }
 
@@ -286,9 +286,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUndoView::tr (arg1, arg2, arg3));
 }
 
@@ -309,8 +309,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUndoView::trUtf8 (arg1, arg2));
 }
 
@@ -333,9 +333,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUndoView::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -2035,7 +2035,7 @@ static void _call_ctor_QUndoView_Adaptor_1315 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QUndoView_Adaptor *> (new QUndoView_Adaptor (arg1));
 }
 
@@ -2055,8 +2055,8 @@ static void _call_ctor_QUndoView_Adaptor_2818 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoStack *arg1 = args.read<QUndoStack * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QUndoStack *arg1 = gsi::arg_reader<QUndoStack * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QUndoView_Adaptor *> (new QUndoView_Adaptor (arg1, arg2));
 }
 
@@ -2076,8 +2076,8 @@ static void _call_ctor_QUndoView_Adaptor_2841 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QUndoGroup *arg1 = args.read<QUndoGroup * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QUndoGroup *arg1 = gsi::arg_reader<QUndoGroup * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QUndoView_Adaptor *> (new QUndoView_Adaptor (arg1, arg2));
 }
 
@@ -2119,7 +2119,7 @@ static void _call_emitter_activated_2395 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QUndoView_Adaptor *)cls)->emitter_QUndoView_activated_2395 (arg1);
 }
 
@@ -2185,7 +2185,7 @@ static void _call_emitter_clicked_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QUndoView_Adaptor *)cls)->emitter_QUndoView_clicked_2395 (arg1);
 }
 
@@ -2320,9 +2320,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_create_2208 (arg1, arg2, arg3);
 }
@@ -2368,7 +2368,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QUndoView_Adaptor *)cls)->emitter_QUndoView_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2439,8 +2439,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_destroy_1620 (arg1, arg2);
 }
@@ -2459,7 +2459,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QUndoView_Adaptor *)cls)->emitter_QUndoView_destroyed_1302 (arg1);
 }
 
@@ -2550,7 +2550,7 @@ static void _call_emitter_doubleClicked_2395 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QUndoView_Adaptor *)cls)->emitter_QUndoView_doubleClicked_2395 (arg1);
 }
 
@@ -2640,7 +2640,7 @@ static void _call_fp_drawFrame_1426 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_drawFrame_1426 (arg1);
 }
@@ -2798,7 +2798,7 @@ static void _call_emitter_entered_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QUndoView_Adaptor *)cls)->emitter_QUndoView_entered_2395 (arg1);
 }
 
@@ -3154,7 +3154,7 @@ static void _call_emitter_indexesMoved_3010 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   ((QUndoView_Adaptor *)cls)->emitter_QUndoView_indexesMoved_3010 (arg1);
 }
 
@@ -3219,7 +3219,7 @@ static void _call_fp_internalDrag_2456 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::DropAction> arg1 = args.read<QFlags<Qt::DropAction> > (heap);
+  QFlags<Qt::DropAction> arg1 = gsi::arg_reader<QFlags<Qt::DropAction> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_internalDrag_2456 (arg1);
 }
@@ -3238,7 +3238,7 @@ static void _call_fp_internalDrop_1622 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QDropEvent *arg1 = args.read<QDropEvent * > (heap);
+  QDropEvent *arg1 = gsi::arg_reader<QDropEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_internalDrop_1622 (arg1);
 }
@@ -3651,7 +3651,7 @@ static void _call_emitter_pressed_2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QUndoView_Adaptor *)cls)->emitter_QUndoView_pressed_2395 (arg1);
 }
 
@@ -3669,7 +3669,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QUndoView_Adaptor *)cls)->fp_QUndoView_receivers_c1731 (arg1));
 }
 
@@ -3687,7 +3687,7 @@ static void _call_fp_rectForIndex_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QRect > ((QRect)((QUndoView_Adaptor *)cls)->fp_QUndoView_rectForIndex_c2395 (arg1));
 }
 
@@ -3742,8 +3742,8 @@ static void _call_fp_resizeContents_1426 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_resizeContents_1426 (arg1, arg2);
 }
@@ -3890,8 +3890,8 @@ static void _call_fp_scrollDirtyRegion_1426 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_scrollDirtyRegion_1426 (arg1, arg2);
 }
@@ -4043,7 +4043,7 @@ static void _call_fp_setDirtyRegion_2006 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_setDirtyRegion_2006 (arg1);
 }
@@ -4062,7 +4062,7 @@ static void _call_fp_setHorizontalStepsPerItem_767 (const qt_gsi::GenericMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_setHorizontalStepsPerItem_767 (arg1);
 }
@@ -4107,8 +4107,8 @@ static void _call_fp_setPositionForIndex_4203 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_setPositionForIndex_4203 (arg1, arg2);
 }
@@ -4202,7 +4202,7 @@ static void _call_fp_setState_2776 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned int arg1 = args.read<unsigned int > (heap);
+  unsigned int arg1 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_setState_2776 (arg1);
 }
@@ -4221,7 +4221,7 @@ static void _call_fp_setVerticalStepsPerItem_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_setVerticalStepsPerItem_767 (arg1);
 }
@@ -4246,10 +4246,10 @@ static void _call_fp_setViewportMargins_2744 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_setViewportMargins_2744 (arg1, arg2, arg3, arg4);
 }
@@ -4268,7 +4268,7 @@ static void _call_fp_setViewportMargins_2115 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_setViewportMargins_2115 (arg1);
 }
@@ -4311,7 +4311,7 @@ static void _call_fp_setupViewport_1315 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUndoView_Adaptor *)cls)->fp_QUndoView_setupViewport_1315 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQUnixPrintWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQUnixPrintWidget.cc
@@ -130,8 +130,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUnixPrintWidget::tr (arg1, arg2));
 }
 
@@ -154,9 +154,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUnixPrintWidget::tr (arg1, arg2, arg3));
 }
 
@@ -177,8 +177,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUnixPrintWidget::trUtf8 (arg1, arg2));
 }
 
@@ -201,9 +201,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUnixPrintWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1056,8 +1056,8 @@ static void _call_ctor_QUnixPrintWidget_Adaptor_2650 (const qt_gsi::GenericStati
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPrinter *arg1 = args.read<QPrinter * > (heap);
-  QWidget *arg2 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QPrinter *arg1 = gsi::arg_reader<QPrinter * >() (args, heap);
+  QWidget *arg2 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QUnixPrintWidget_Adaptor *> (new QUnixPrintWidget_Adaptor (arg1, arg2));
 }
 
@@ -1199,9 +1199,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUnixPrintWidget_Adaptor *)cls)->fp_QUnixPrintWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -1220,7 +1220,7 @@ static void _call_fp_customContextMenuRequested_1916 (const qt_gsi::GenericMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUnixPrintWidget_Adaptor *)cls)->fp_QUnixPrintWidget_customContextMenuRequested_1916 (arg1);
 }
@@ -1265,8 +1265,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUnixPrintWidget_Adaptor *)cls)->fp_QUnixPrintWidget_destroy_1620 (arg1, arg2);
 }
@@ -1285,7 +1285,7 @@ static void _call_fp_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUnixPrintWidget_Adaptor *)cls)->fp_QUnixPrintWidget_destroyed_1302 (arg1);
 }
@@ -2059,7 +2059,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QUnixPrintWidget_Adaptor *)cls)->fp_QUnixPrintWidget_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQVBoxLayout.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQVBoxLayout.cc
@@ -77,8 +77,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QVBoxLayout::tr (arg1, arg2));
 }
 
@@ -101,9 +101,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QVBoxLayout::tr (arg1, arg2, arg3));
 }
 
@@ -124,8 +124,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QVBoxLayout::trUtf8 (arg1, arg2));
 }
 
@@ -148,9 +148,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QVBoxLayout::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -670,7 +670,7 @@ static void _call_ctor_QVBoxLayout_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QVBoxLayout_Adaptor *> (new QVBoxLayout_Adaptor (arg1));
 }
 
@@ -688,7 +688,7 @@ static void _call_fp_addChildLayout_1341 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   qt_gsi::qt_keep (arg1);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVBoxLayout_Adaptor *)cls)->fp_QVBoxLayout_addChildLayout_1341 (arg1);
@@ -708,7 +708,7 @@ static void _call_fp_addChildWidget_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVBoxLayout_Adaptor *)cls)->fp_QVBoxLayout_addChildWidget_1315 (arg1);
 }
@@ -751,7 +751,7 @@ static void _call_fp_alignmentRect_c1792 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   ret.write<QRect > ((QRect)((QVBoxLayout_Adaptor *)cls)->fp_QVBoxLayout_alignmentRect_c1792 (arg1));
 }
 
@@ -836,7 +836,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QVBoxLayout_Adaptor *)cls)->emitter_QVBoxLayout_destroyed_1302 (arg1);
 }
 
@@ -1032,8 +1032,8 @@ static void _call_fp_insertItem_2399 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QLayoutItem *arg2 = args.read<QLayoutItem * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QLayoutItem *arg2 = gsi::arg_reader<QLayoutItem * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVBoxLayout_Adaptor *)cls)->fp_QVBoxLayout_insertItem_2399 (arg1, arg2);
 }
@@ -1194,7 +1194,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QVBoxLayout_Adaptor *)cls)->fp_QVBoxLayout_receivers_c1731 (arg1));
 }
 
@@ -1354,7 +1354,7 @@ static void _call_fp_widgetEvent_1217 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QEvent *arg1 = args.read<QEvent * > (heap);
+  QEvent *arg1 = gsi::arg_reader<QEvent * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVBoxLayout_Adaptor *)cls)->fp_QVBoxLayout_widgetEvent_1217 (arg1);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQValidator.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQValidator.cc
@@ -69,7 +69,7 @@ static void _call_f_fixup_c1330 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QValidator *)cls)->fixup (arg1);
 }
@@ -104,7 +104,7 @@ static void _call_f_setLocale_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLocale &arg1 = args.read<const QLocale & > (heap);
+  const QLocale &arg1 = gsi::arg_reader<const QLocale & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QValidator *)cls)->setLocale (arg1);
 }
@@ -126,8 +126,8 @@ static void _call_f_validate_c2171 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QString &arg1 = args.read<QString & > (heap);
-  int &arg2 = args.read<int & > (heap);
+  QString &arg1 = gsi::arg_reader<QString & >() (args, heap);
+  int &arg2 = gsi::arg_reader<int & >() (args, heap);
   ret.write<qt_gsi::Converter<QValidator::State>::target_type > ((qt_gsi::Converter<QValidator::State>::target_type)qt_gsi::CppToQtAdaptor<QValidator::State>(((QValidator *)cls)->validate (arg1, arg2)));
 }
 
@@ -148,8 +148,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QValidator::tr (arg1, arg2));
 }
 
@@ -172,9 +172,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QValidator::tr (arg1, arg2, arg3));
 }
 
@@ -195,8 +195,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QValidator::trUtf8 (arg1, arg2));
 }
 
@@ -219,9 +219,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QValidator::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -436,7 +436,7 @@ static void _call_ctor_QValidator_Adaptor_1302 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QValidator_Adaptor *> (new QValidator_Adaptor (arg1));
 }
 
@@ -502,7 +502,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QValidator_Adaptor *)cls)->emitter_QValidator_destroyed_1302 (arg1);
 }
 
@@ -617,7 +617,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QValidator_Adaptor *)cls)->fp_QValidator_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQVector2D.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQVector2D.cc
@@ -71,8 +71,8 @@ static void _call_ctor_QVector2D_2034 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector2D *> (new QVector2D (arg1, arg2));
 }
 
@@ -91,7 +91,7 @@ static void _call_ctor_QVector2D_1916 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QVector2D *> (new QVector2D (arg1));
 }
 
@@ -110,7 +110,7 @@ static void _call_ctor_QVector2D_1986 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QVector2D *> (new QVector2D (arg1));
 }
 
@@ -129,7 +129,7 @@ static void _call_ctor_QVector2D_2140 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector2D *> (new QVector2D (arg1));
 }
 
@@ -148,7 +148,7 @@ static void _call_ctor_QVector2D_2141 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector4D &arg1 = args.read<const QVector4D & > (heap);
+  const QVector4D &arg1 = gsi::arg_reader<const QVector4D & >() (args, heap);
   ret.write<QVector2D *> (new QVector2D (arg1));
 }
 
@@ -243,7 +243,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector2D & > ((QVector2D &)((QVector2D *)cls)->operator*= (arg1));
 }
 
@@ -262,7 +262,7 @@ static void _call_f_operator_star__eq__2139 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector2D &arg1 = args.read<const QVector2D & > (heap);
+  const QVector2D &arg1 = gsi::arg_reader<const QVector2D & >() (args, heap);
   ret.write<QVector2D & > ((QVector2D &)((QVector2D *)cls)->operator*= (arg1));
 }
 
@@ -281,7 +281,7 @@ static void _call_f_operator_plus__eq__2139 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector2D &arg1 = args.read<const QVector2D & > (heap);
+  const QVector2D &arg1 = gsi::arg_reader<const QVector2D & >() (args, heap);
   ret.write<QVector2D & > ((QVector2D &)((QVector2D *)cls)->operator+= (arg1));
 }
 
@@ -300,7 +300,7 @@ static void _call_f_operator_minus__eq__2139 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector2D &arg1 = args.read<const QVector2D & > (heap);
+  const QVector2D &arg1 = gsi::arg_reader<const QVector2D & >() (args, heap);
   ret.write<QVector2D & > ((QVector2D &)((QVector2D *)cls)->operator-= (arg1));
 }
 
@@ -319,7 +319,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector2D & > ((QVector2D &)((QVector2D *)cls)->operator/= (arg1));
 }
 
@@ -338,7 +338,7 @@ static void _call_f_setX_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVector2D *)cls)->setX (arg1);
 }
@@ -358,7 +358,7 @@ static void _call_f_setY_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVector2D *)cls)->setY (arg1);
 }
@@ -470,8 +470,8 @@ static void _call_f_dotProduct_4170 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector2D &arg1 = args.read<const QVector2D & > (heap);
-  const QVector2D &arg2 = args.read<const QVector2D & > (heap);
+  const QVector2D &arg1 = gsi::arg_reader<const QVector2D & >() (args, heap);
+  const QVector2D &arg2 = gsi::arg_reader<const QVector2D & >() (args, heap);
   ret.write<double > ((double)QVector2D::dotProduct (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQVector3D.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQVector3D.cc
@@ -71,9 +71,9 @@ static void _call_ctor_QVector3D_2997 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector3D *> (new QVector3D (arg1, arg2, arg3));
 }
 
@@ -92,7 +92,7 @@ static void _call_ctor_QVector3D_1916 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QVector3D *> (new QVector3D (arg1));
 }
 
@@ -111,7 +111,7 @@ static void _call_ctor_QVector3D_1986 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QVector3D *> (new QVector3D (arg1));
 }
 
@@ -130,7 +130,7 @@ static void _call_ctor_QVector3D_2139 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector2D &arg1 = args.read<const QVector2D & > (heap);
+  const QVector2D &arg1 = gsi::arg_reader<const QVector2D & >() (args, heap);
   ret.write<QVector3D *> (new QVector3D (arg1));
 }
 
@@ -151,8 +151,8 @@ static void _call_ctor_QVector3D_3102 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector2D &arg1 = args.read<const QVector2D & > (heap);
-  double arg2 = args.read<double > (heap);
+  const QVector2D &arg1 = gsi::arg_reader<const QVector2D & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector3D *> (new QVector3D (arg1, arg2));
 }
 
@@ -171,7 +171,7 @@ static void _call_ctor_QVector3D_2141 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector4D &arg1 = args.read<const QVector4D & > (heap);
+  const QVector4D &arg1 = gsi::arg_reader<const QVector4D & >() (args, heap);
   ret.write<QVector3D *> (new QVector3D (arg1));
 }
 
@@ -192,8 +192,8 @@ static void _call_f_distanceToLine_c4172 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<double > ((double)((QVector3D *)cls)->distanceToLine (arg1, arg2));
 }
 
@@ -214,8 +214,8 @@ static void _call_f_distanceToPlane_c4172 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<double > ((double)((QVector3D *)cls)->distanceToPlane (arg1, arg2));
 }
 
@@ -238,9 +238,9 @@ static void _call_f_distanceToPlane_c6204 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg3 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg3 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<double > ((double)((QVector3D *)cls)->distanceToPlane (arg1, arg2, arg3));
 }
 
@@ -335,7 +335,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector3D & > ((QVector3D &)((QVector3D *)cls)->operator*= (arg1));
 }
 
@@ -354,7 +354,7 @@ static void _call_f_operator_star__eq__2140 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector3D & > ((QVector3D &)((QVector3D *)cls)->operator*= (arg1));
 }
 
@@ -373,7 +373,7 @@ static void _call_f_operator_plus__eq__2140 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector3D & > ((QVector3D &)((QVector3D *)cls)->operator+= (arg1));
 }
 
@@ -392,7 +392,7 @@ static void _call_f_operator_minus__eq__2140 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector3D & > ((QVector3D &)((QVector3D *)cls)->operator-= (arg1));
 }
 
@@ -411,7 +411,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector3D & > ((QVector3D &)((QVector3D *)cls)->operator/= (arg1));
 }
 
@@ -430,7 +430,7 @@ static void _call_f_setX_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVector3D *)cls)->setX (arg1);
 }
@@ -450,7 +450,7 @@ static void _call_f_setY_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVector3D *)cls)->setY (arg1);
 }
@@ -470,7 +470,7 @@ static void _call_f_setZ_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVector3D *)cls)->setZ (arg1);
 }
@@ -597,8 +597,8 @@ static void _call_f_crossProduct_4172 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector3D > ((QVector3D)QVector3D::crossProduct (arg1, arg2));
 }
 
@@ -619,8 +619,8 @@ static void _call_f_dotProduct_4172 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<double > ((double)QVector3D::dotProduct (arg1, arg2));
 }
 
@@ -641,8 +641,8 @@ static void _call_f_normal_4172 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector3D > ((QVector3D)QVector3D::normal (arg1, arg2));
 }
 
@@ -665,9 +665,9 @@ static void _call_f_normal_6204 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg2 = args.read<const QVector3D & > (heap);
-  const QVector3D &arg3 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg2 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  const QVector3D &arg3 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector3D > ((QVector3D)QVector3D::normal (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQVector4D.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQVector4D.cc
@@ -73,10 +73,10 @@ static void _call_ctor_QVector4D_3960 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
-  double arg4 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
+  double arg4 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector4D *> (new QVector4D (arg1, arg2, arg3, arg4));
 }
 
@@ -95,7 +95,7 @@ static void _call_ctor_QVector4D_1916 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QVector4D *> (new QVector4D (arg1));
 }
 
@@ -114,7 +114,7 @@ static void _call_ctor_QVector4D_1986 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPointF &arg1 = args.read<const QPointF & > (heap);
+  const QPointF &arg1 = gsi::arg_reader<const QPointF & >() (args, heap);
   ret.write<QVector4D *> (new QVector4D (arg1));
 }
 
@@ -133,7 +133,7 @@ static void _call_ctor_QVector4D_2139 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector2D &arg1 = args.read<const QVector2D & > (heap);
+  const QVector2D &arg1 = gsi::arg_reader<const QVector2D & >() (args, heap);
   ret.write<QVector4D *> (new QVector4D (arg1));
 }
 
@@ -156,9 +156,9 @@ static void _call_ctor_QVector4D_4065 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector2D &arg1 = args.read<const QVector2D & > (heap);
-  double arg2 = args.read<double > (heap);
-  double arg3 = args.read<double > (heap);
+  const QVector2D &arg1 = gsi::arg_reader<const QVector2D & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector4D *> (new QVector4D (arg1, arg2, arg3));
 }
 
@@ -177,7 +177,7 @@ static void _call_ctor_QVector4D_2140 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
   ret.write<QVector4D *> (new QVector4D (arg1));
 }
 
@@ -198,8 +198,8 @@ static void _call_ctor_QVector4D_3103 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector3D &arg1 = args.read<const QVector3D & > (heap);
-  double arg2 = args.read<double > (heap);
+  const QVector3D &arg1 = gsi::arg_reader<const QVector3D & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector4D *> (new QVector4D (arg1, arg2));
 }
 
@@ -294,7 +294,7 @@ static void _call_f_operator_star__eq__1071 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector4D & > ((QVector4D &)((QVector4D *)cls)->operator*= (arg1));
 }
 
@@ -313,7 +313,7 @@ static void _call_f_operator_star__eq__2141 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector4D &arg1 = args.read<const QVector4D & > (heap);
+  const QVector4D &arg1 = gsi::arg_reader<const QVector4D & >() (args, heap);
   ret.write<QVector4D & > ((QVector4D &)((QVector4D *)cls)->operator*= (arg1));
 }
 
@@ -332,7 +332,7 @@ static void _call_f_operator_plus__eq__2141 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector4D &arg1 = args.read<const QVector4D & > (heap);
+  const QVector4D &arg1 = gsi::arg_reader<const QVector4D & >() (args, heap);
   ret.write<QVector4D & > ((QVector4D &)((QVector4D *)cls)->operator+= (arg1));
 }
 
@@ -351,7 +351,7 @@ static void _call_f_operator_minus__eq__2141 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector4D &arg1 = args.read<const QVector4D & > (heap);
+  const QVector4D &arg1 = gsi::arg_reader<const QVector4D & >() (args, heap);
   ret.write<QVector4D & > ((QVector4D &)((QVector4D *)cls)->operator-= (arg1));
 }
 
@@ -370,7 +370,7 @@ static void _call_f_operator_slash__eq__1071 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   ret.write<QVector4D & > ((QVector4D &)((QVector4D *)cls)->operator/= (arg1));
 }
 
@@ -389,7 +389,7 @@ static void _call_f_setW_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVector4D *)cls)->setW (arg1);
 }
@@ -409,7 +409,7 @@ static void _call_f_setX_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVector4D *)cls)->setX (arg1);
 }
@@ -429,7 +429,7 @@ static void _call_f_setY_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVector4D *)cls)->setY (arg1);
 }
@@ -449,7 +449,7 @@ static void _call_f_setZ_1071 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QVector4D *)cls)->setZ (arg1);
 }
@@ -621,8 +621,8 @@ static void _call_f_dotProduct_4174 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVector4D &arg1 = args.read<const QVector4D & > (heap);
-  const QVector4D &arg2 = args.read<const QVector4D & > (heap);
+  const QVector4D &arg1 = gsi::arg_reader<const QVector4D & >() (args, heap);
+  const QVector4D &arg2 = gsi::arg_reader<const QVector4D & >() (args, heap);
   ret.write<double > ((double)QVector4D::dotProduct (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWhatsThis.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWhatsThis.cc
@@ -54,7 +54,7 @@ static void _call_f_createAction_1302 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QAction * > ((QAction *)QWhatsThis::createAction (arg1));
 }
 
@@ -140,9 +140,9 @@ static void _call_f_showText_5040 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  QWidget *arg3 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg3 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QWhatsThis::showText (arg1, arg2, arg3);
 }

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWhatsThisClickedEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWhatsThisClickedEvent.cc
@@ -101,7 +101,7 @@ static void _call_ctor_QWhatsThisClickedEvent_Adaptor_2025 (const qt_gsi::Generi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QWhatsThisClickedEvent_Adaptor *> (new QWhatsThisClickedEvent_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWheelEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWheelEvent.cc
@@ -256,11 +256,11 @@ static void _call_ctor_QWheelEvent_Adaptor_9843 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  int arg2 = args.read<int > (heap);
-  QFlags<Qt::MouseButton> arg3 = args.read<QFlags<Qt::MouseButton> > (heap);
-  QFlags<Qt::KeyboardModifier> arg4 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg5 = args ? args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap) : (const qt_gsi::Converter<Qt::Orientation>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::Orientation>(heap, Qt::Vertical));
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::MouseButton> arg3 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg4 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg5 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::Orientation>(heap, Qt::Vertical), heap);
   ret.write<QWheelEvent_Adaptor *> (new QWheelEvent_Adaptor (arg1, arg2, arg3, arg4, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg5).cref()));
 }
 
@@ -288,12 +288,12 @@ static void _call_ctor_QWheelEvent_Adaptor_11651 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
-  int arg3 = args.read<int > (heap);
-  QFlags<Qt::MouseButton> arg4 = args.read<QFlags<Qt::MouseButton> > (heap);
-  QFlags<Qt::KeyboardModifier> arg5 = args.read<QFlags<Qt::KeyboardModifier> > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg6 = args ? args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap) : (const qt_gsi::Converter<Qt::Orientation>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::Orientation>(heap, Qt::Vertical));
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  QFlags<Qt::MouseButton> arg4 = gsi::arg_reader<QFlags<Qt::MouseButton> >() (args, heap);
+  QFlags<Qt::KeyboardModifier> arg5 = gsi::arg_reader<QFlags<Qt::KeyboardModifier> >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg6 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::Orientation>(heap, Qt::Vertical), heap);
   ret.write<QWheelEvent_Adaptor *> (new QWheelEvent_Adaptor (arg1, arg2, arg3, arg4, arg5, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg6).cref()));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWidget.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWidget.cc
@@ -186,7 +186,7 @@ static void _call_f_addAction_1309 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->addAction (arg1);
 }
@@ -206,7 +206,7 @@ static void _call_f_addActions_1780 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QList<QAction*> arg1 = args.read<QList<QAction*> > (heap);
+  QList<QAction*> arg1 = gsi::arg_reader<QList<QAction*> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->addActions (arg1);
 }
@@ -289,8 +289,8 @@ static void _call_f_childAt_c1426 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QWidget *)cls)->childAt (arg1, arg2));
 }
 
@@ -309,7 +309,7 @@ static void _call_f_childAt_c1916 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QWidget *)cls)->childAt (arg1));
 }
 
@@ -668,10 +668,10 @@ static void _call_f_getContentsMargins_c3488 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int *arg1 = args.read<int * > (heap);
-  int *arg2 = args.read<int * > (heap);
-  int *arg3 = args.read<int * > (heap);
-  int *arg4 = args.read<int * > (heap);
+  int *arg1 = gsi::arg_reader<int * >() (args, heap);
+  int *arg2 = gsi::arg_reader<int * >() (args, heap);
+  int *arg3 = gsi::arg_reader<int * >() (args, heap);
+  int *arg4 = gsi::arg_reader<int * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->getContentsMargins (arg1, arg2, arg3, arg4);
 }
@@ -693,8 +693,8 @@ static void _call_f_grabGesture_4352 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
-  QFlags<Qt::GestureFlag> arg2 = args ? args.read<QFlags<Qt::GestureFlag> > (heap) : (QFlags<Qt::GestureFlag>)(Qt::GestureFlags());
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
+  QFlags<Qt::GestureFlag> arg2 = args ? gsi::arg_reader<QFlags<Qt::GestureFlag> >() (args, heap) : gsi::arg_maker<QFlags<Qt::GestureFlag> >() (Qt::GestureFlags(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->grabGesture (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref(), arg2);
 }
@@ -746,7 +746,7 @@ static void _call_f_grabMouse_2032 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QCursor &arg1 = args.read<const QCursor & > (heap);
+  const QCursor &arg1 = gsi::arg_reader<const QCursor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->grabMouse (arg1);
 }
@@ -768,8 +768,8 @@ static void _call_f_grabShortcut_4758 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QKeySequence &arg1 = args.read<const QKeySequence & > (heap);
-  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & > (heap) : (const qt_gsi::Converter<Qt::ShortcutContext>::target_type &)(qt_gsi::CppToQtReadAdaptor<Qt::ShortcutContext>(heap, Qt::WindowShortcut));
+  const QKeySequence &arg1 = gsi::arg_reader<const QKeySequence & >() (args, heap);
+  const qt_gsi::Converter<Qt::ShortcutContext>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<Qt::ShortcutContext>::target_type & >() (qt_gsi::CppToQtReadAdaptor<Qt::ShortcutContext>(heap, Qt::WindowShortcut), heap);
   ret.write<int > ((int)((QWidget *)cls)->grabShortcut (arg1, qt_gsi::QtToCppAdaptor<Qt::ShortcutContext>(arg2).cref()));
 }
 
@@ -863,7 +863,7 @@ static void _call_f_heightForWidth_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QWidget *)cls)->heightForWidth (arg1));
 }
 
@@ -928,7 +928,7 @@ static void _call_f_inputMethodQuery_c2420 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::InputMethodQuery>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QWidget *)cls)->inputMethodQuery (qt_gsi::QtToCppAdaptor<Qt::InputMethodQuery>(arg1).cref()));
 }
 
@@ -949,8 +949,8 @@ static void _call_f_insertAction_2510 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
-  QAction *arg2 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
+  QAction *arg2 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->insertAction (arg1, arg2);
 }
@@ -972,8 +972,8 @@ static void _call_f_insertActions_2981 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
-  QList<QAction*> arg2 = args.read<QList<QAction*> > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
+  QList<QAction*> arg2 = gsi::arg_reader<QList<QAction*> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->insertActions (arg1, arg2);
 }
@@ -1023,7 +1023,7 @@ static void _call_f_isAncestorOf_c2010 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QWidget *arg1 = args.read<const QWidget * > (heap);
+  const QWidget *arg1 = gsi::arg_reader<const QWidget * >() (args, heap);
   ret.write<bool > ((bool)((QWidget *)cls)->isAncestorOf (arg1));
 }
 
@@ -1057,7 +1057,7 @@ static void _call_f_isEnabledTo_c1315 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<bool > ((bool)((QWidget *)cls)->isEnabledTo (arg1));
 }
 
@@ -1226,7 +1226,7 @@ static void _call_f_isVisibleTo_c1315 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<bool > ((bool)((QWidget *)cls)->isVisibleTo (arg1));
 }
 
@@ -1338,8 +1338,8 @@ static void _call_f_mapFrom_c3123 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QWidget *)cls)->mapFrom (arg1, arg2));
 }
 
@@ -1358,7 +1358,7 @@ static void _call_f_mapFromGlobal_c1916 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QWidget *)cls)->mapFromGlobal (arg1));
 }
 
@@ -1377,7 +1377,7 @@ static void _call_f_mapFromParent_c1916 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QWidget *)cls)->mapFromParent (arg1));
 }
 
@@ -1398,8 +1398,8 @@ static void _call_f_mapTo_c3123 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  const QPoint &arg2 = args.read<const QPoint & > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  const QPoint &arg2 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QWidget *)cls)->mapTo (arg1, arg2));
 }
 
@@ -1418,7 +1418,7 @@ static void _call_f_mapToGlobal_c1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QWidget *)cls)->mapToGlobal (arg1));
 }
 
@@ -1437,7 +1437,7 @@ static void _call_f_mapToParent_c1916 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ret.write<QPoint > ((QPoint)((QWidget *)cls)->mapToParent (arg1));
 }
 
@@ -1578,8 +1578,8 @@ static void _call_f_move_1426 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->move (arg1, arg2);
 }
@@ -1599,7 +1599,7 @@ static void _call_f_move_1916 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->move (arg1);
 }
@@ -1664,7 +1664,7 @@ static void _call_f_overrideWindowFlags_2495 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::WindowType> arg1 = args.read<QFlags<Qt::WindowType> > (heap);
+  QFlags<Qt::WindowType> arg1 = gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->overrideWindowFlags (arg1);
 }
@@ -1684,7 +1684,7 @@ static void _call_f_overrideWindowState_2590 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::WindowState> arg1 = args.read<QFlags<Qt::WindowState> > (heap);
+  QFlags<Qt::WindowState> arg1 = gsi::arg_reader<QFlags<Qt::WindowState> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->overrideWindowState (arg1);
 }
@@ -1842,7 +1842,7 @@ static void _call_f_releaseShortcut_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->releaseShortcut (arg1);
 }
@@ -1862,7 +1862,7 @@ static void _call_f_removeAction_1309 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAction *arg1 = args.read<QAction * > (heap);
+  QAction *arg1 = gsi::arg_reader<QAction * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->removeAction (arg1);
 }
@@ -1888,10 +1888,10 @@ static void _call_f_render_8328 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPaintDevice *arg1 = args.read<QPaintDevice * > (heap);
-  const QPoint &arg2 = args ? args.read<const QPoint & > (heap) : (const QPoint &)(QPoint());
-  const QRegion &arg3 = args ? args.read<const QRegion & > (heap) : (const QRegion &)(QRegion());
-  QFlags<QWidget::RenderFlag> arg4 = args ? args.read<QFlags<QWidget::RenderFlag> > (heap) : (QFlags<QWidget::RenderFlag>)(QWidget::RenderFlags(QWidget::DrawWindowBackground | QWidget::DrawChildren));
+  QPaintDevice *arg1 = gsi::arg_reader<QPaintDevice * >() (args, heap);
+  const QPoint &arg2 = args ? gsi::arg_reader<const QPoint & >() (args, heap) : gsi::arg_maker<const QPoint & >() (QPoint(), heap);
+  const QRegion &arg3 = args ? gsi::arg_reader<const QRegion & >() (args, heap) : gsi::arg_maker<const QRegion & >() (QRegion(), heap);
+  QFlags<QWidget::RenderFlag> arg4 = args ? gsi::arg_reader<QFlags<QWidget::RenderFlag> >() (args, heap) : gsi::arg_maker<QFlags<QWidget::RenderFlag> >() (QWidget::RenderFlags(QWidget::DrawWindowBackground | QWidget::DrawChildren), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->render (arg1, arg2, arg3, arg4);
 }
@@ -1917,10 +1917,10 @@ static void _call_f_render_7951 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPainter *arg1 = args.read<QPainter * > (heap);
-  const QPoint &arg2 = args ? args.read<const QPoint & > (heap) : (const QPoint &)(QPoint());
-  const QRegion &arg3 = args ? args.read<const QRegion & > (heap) : (const QRegion &)(QRegion());
-  QFlags<QWidget::RenderFlag> arg4 = args ? args.read<QFlags<QWidget::RenderFlag> > (heap) : (QFlags<QWidget::RenderFlag>)(QWidget::RenderFlags(QWidget::DrawWindowBackground | QWidget::DrawChildren));
+  QPainter *arg1 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QPoint &arg2 = args ? gsi::arg_reader<const QPoint & >() (args, heap) : gsi::arg_maker<const QPoint & >() (QPoint(), heap);
+  const QRegion &arg3 = args ? gsi::arg_reader<const QRegion & >() (args, heap) : gsi::arg_maker<const QRegion & >() (QRegion(), heap);
+  QFlags<QWidget::RenderFlag> arg4 = args ? gsi::arg_reader<QFlags<QWidget::RenderFlag> >() (args, heap) : gsi::arg_maker<QFlags<QWidget::RenderFlag> >() (QWidget::RenderFlags(QWidget::DrawWindowBackground | QWidget::DrawChildren), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->render (arg1, arg2, arg3, arg4);
 }
@@ -1962,10 +1962,10 @@ static void _call_f_repaint_2744 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->repaint (arg1, arg2, arg3, arg4);
 }
@@ -1985,7 +1985,7 @@ static void _call_f_repaint_1792 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->repaint (arg1);
 }
@@ -2005,7 +2005,7 @@ static void _call_f_repaint_2006 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->repaint (arg1);
 }
@@ -2027,8 +2027,8 @@ static void _call_f_resize_1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->resize (arg1, arg2);
 }
@@ -2048,7 +2048,7 @@ static void _call_f_resize_1805 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->resize (arg1);
 }
@@ -2068,7 +2068,7 @@ static void _call_f_restoreGeometry_2309 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<bool > ((bool)((QWidget *)cls)->restoreGeometry (arg1));
 }
 
@@ -2104,8 +2104,8 @@ static void _call_f_scroll_1426 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->scroll (arg1, arg2);
 }
@@ -2129,9 +2129,9 @@ static void _call_f_scroll_3110 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QRect &arg3 = args.read<const QRect & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QRect &arg3 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->scroll (arg1, arg2, arg3);
 }
@@ -2151,7 +2151,7 @@ static void _call_f_setAcceptDrops_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setAcceptDrops (arg1);
 }
@@ -2171,7 +2171,7 @@ static void _call_f_setAccessibleDescription_2025 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setAccessibleDescription (arg1);
 }
@@ -2191,7 +2191,7 @@ static void _call_f_setAccessibleName_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setAccessibleName (arg1);
 }
@@ -2213,8 +2213,8 @@ static void _call_f_setAttribute_3065 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setAttribute (qt_gsi::QtToCppAdaptor<Qt::WidgetAttribute>(arg1).cref(), arg2);
 }
@@ -2234,7 +2234,7 @@ static void _call_f_setAutoFillBackground_864 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setAutoFillBackground (arg1);
 }
@@ -2254,7 +2254,7 @@ static void _call_f_setBackgroundRole_2265 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setBackgroundRole (qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg1).cref());
 }
@@ -2274,7 +2274,7 @@ static void _call_f_setBaseSize_1805 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setBaseSize (arg1);
 }
@@ -2296,8 +2296,8 @@ static void _call_f_setBaseSize_1426 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setBaseSize (arg1, arg2);
 }
@@ -2323,10 +2323,10 @@ static void _call_f_setContentsMargins_2744 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setContentsMargins (arg1, arg2, arg3, arg4);
 }
@@ -2346,7 +2346,7 @@ static void _call_f_setContentsMargins_2115 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QMargins &arg1 = args.read<const QMargins & > (heap);
+  const QMargins &arg1 = gsi::arg_reader<const QMargins & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setContentsMargins (arg1);
 }
@@ -2366,7 +2366,7 @@ static void _call_f_setContextMenuPolicy_2519 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::ContextMenuPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::ContextMenuPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::ContextMenuPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::ContextMenuPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setContextMenuPolicy (qt_gsi::QtToCppAdaptor<Qt::ContextMenuPolicy>(arg1).cref());
 }
@@ -2386,7 +2386,7 @@ static void _call_f_setCursor_2032 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QCursor &arg1 = args.read<const QCursor & > (heap);
+  const QCursor &arg1 = gsi::arg_reader<const QCursor & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setCursor (arg1);
 }
@@ -2406,7 +2406,7 @@ static void _call_f_setDisabled_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setDisabled (arg1);
 }
@@ -2426,7 +2426,7 @@ static void _call_f_setEnabled_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setEnabled (arg1);
 }
@@ -2446,7 +2446,7 @@ static void _call_f_setFixedHeight_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setFixedHeight (arg1);
 }
@@ -2466,7 +2466,7 @@ static void _call_f_setFixedSize_1805 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setFixedSize (arg1);
 }
@@ -2488,8 +2488,8 @@ static void _call_f_setFixedSize_1426 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setFixedSize (arg1, arg2);
 }
@@ -2509,7 +2509,7 @@ static void _call_f_setFixedWidth_767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setFixedWidth (arg1);
 }
@@ -2545,7 +2545,7 @@ static void _call_f_setFocus_1877 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::FocusReason>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::FocusReason>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::FocusReason>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setFocus (qt_gsi::QtToCppAdaptor<Qt::FocusReason>(arg1).cref());
 }
@@ -2565,7 +2565,7 @@ static void _call_f_setFocusPolicy_1885 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::FocusPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::FocusPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::FocusPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::FocusPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setFocusPolicy (qt_gsi::QtToCppAdaptor<Qt::FocusPolicy>(arg1).cref());
 }
@@ -2585,7 +2585,7 @@ static void _call_f_setFocusProxy_1315 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setFocusProxy (arg1);
 }
@@ -2605,7 +2605,7 @@ static void _call_f_setFont_1801 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QFont &arg1 = args.read<const QFont & > (heap);
+  const QFont &arg1 = gsi::arg_reader<const QFont & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setFont (arg1);
 }
@@ -2625,7 +2625,7 @@ static void _call_f_setForegroundRole_2265 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = args.read<const qt_gsi::Converter<QPalette::ColorRole>::target_type & > (heap);
+  const qt_gsi::Converter<QPalette::ColorRole>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QPalette::ColorRole>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setForegroundRole (qt_gsi::QtToCppAdaptor<QPalette::ColorRole>(arg1).cref());
 }
@@ -2651,10 +2651,10 @@ static void _call_f_setGeometry_2744 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setGeometry (arg1, arg2, arg3, arg4);
 }
@@ -2674,7 +2674,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setGeometry (arg1);
 }
@@ -2694,7 +2694,7 @@ static void _call_f_setGraphicsEffect_2109 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QGraphicsEffect *arg1 = args.read<QGraphicsEffect * > (heap);
+  QGraphicsEffect *arg1 = gsi::arg_reader<QGraphicsEffect * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setGraphicsEffect (arg1);
 }
@@ -2714,7 +2714,7 @@ static void _call_f_setHidden_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setHidden (arg1);
 }
@@ -2734,7 +2734,7 @@ static void _call_f_setInputContext_1972 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QInputContext *arg1 = args.read<QInputContext * > (heap);
+  QInputContext *arg1 = gsi::arg_reader<QInputContext * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setInputContext (arg1);
 }
@@ -2754,7 +2754,7 @@ static void _call_f_setInputMethodHints_2985 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::InputMethodHint> arg1 = args.read<QFlags<Qt::InputMethodHint> > (heap);
+  QFlags<Qt::InputMethodHint> arg1 = gsi::arg_reader<QFlags<Qt::InputMethodHint> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setInputMethodHints (arg1);
 }
@@ -2774,7 +2774,7 @@ static void _call_f_setLayout_1341 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QLayout *arg1 = args.read<QLayout * > (heap);
+  QLayout *arg1 = gsi::arg_reader<QLayout * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setLayout (arg1);
 }
@@ -2794,7 +2794,7 @@ static void _call_f_setLayoutDirection_2316 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::LayoutDirection>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::LayoutDirection>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setLayoutDirection (qt_gsi::QtToCppAdaptor<Qt::LayoutDirection>(arg1).cref());
 }
@@ -2814,7 +2814,7 @@ static void _call_f_setLocale_1986 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QLocale &arg1 = args.read<const QLocale & > (heap);
+  const QLocale &arg1 = gsi::arg_reader<const QLocale & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setLocale (arg1);
 }
@@ -2834,7 +2834,7 @@ static void _call_f_setMask_1999 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QBitmap &arg1 = args.read<const QBitmap & > (heap);
+  const QBitmap &arg1 = gsi::arg_reader<const QBitmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMask (arg1);
 }
@@ -2854,7 +2854,7 @@ static void _call_f_setMask_2006 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMask (arg1);
 }
@@ -2874,7 +2874,7 @@ static void _call_f_setMaximumHeight_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMaximumHeight (arg1);
 }
@@ -2894,7 +2894,7 @@ static void _call_f_setMaximumSize_1805 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMaximumSize (arg1);
 }
@@ -2916,8 +2916,8 @@ static void _call_f_setMaximumSize_1426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMaximumSize (arg1, arg2);
 }
@@ -2937,7 +2937,7 @@ static void _call_f_setMaximumWidth_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMaximumWidth (arg1);
 }
@@ -2957,7 +2957,7 @@ static void _call_f_setMinimumHeight_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMinimumHeight (arg1);
 }
@@ -2977,7 +2977,7 @@ static void _call_f_setMinimumSize_1805 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMinimumSize (arg1);
 }
@@ -2999,8 +2999,8 @@ static void _call_f_setMinimumSize_1426 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMinimumSize (arg1, arg2);
 }
@@ -3020,7 +3020,7 @@ static void _call_f_setMinimumWidth_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMinimumWidth (arg1);
 }
@@ -3040,7 +3040,7 @@ static void _call_f_setMouseTracking_864 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setMouseTracking (arg1);
 }
@@ -3060,7 +3060,7 @@ static void _call_f_setPalette_2113 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPalette &arg1 = args.read<const QPalette & > (heap);
+  const QPalette &arg1 = gsi::arg_reader<const QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setPalette (arg1);
 }
@@ -3080,7 +3080,7 @@ static void _call_f_setParent_1315 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setParent (arg1);
 }
@@ -3102,8 +3102,8 @@ static void _call_f_setParent_3702 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QFlags<Qt::WindowType> arg2 = args.read<QFlags<Qt::WindowType> > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QFlags<Qt::WindowType> arg2 = gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setParent (arg1, arg2);
 }
@@ -3125,8 +3125,8 @@ static void _call_f_setShortcutAutoRepeat_1523 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setShortcutAutoRepeat (arg1, arg2);
 }
@@ -3148,8 +3148,8 @@ static void _call_f_setShortcutEnabled_1523 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setShortcutEnabled (arg1, arg2);
 }
@@ -3169,7 +3169,7 @@ static void _call_f_setShown_864 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setShown (arg1);
 }
@@ -3189,7 +3189,7 @@ static void _call_f_setSizeIncrement_1805 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSize &arg1 = args.read<const QSize & > (heap);
+  const QSize &arg1 = gsi::arg_reader<const QSize & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setSizeIncrement (arg1);
 }
@@ -3211,8 +3211,8 @@ static void _call_f_setSizeIncrement_1426 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setSizeIncrement (arg1, arg2);
 }
@@ -3232,7 +3232,7 @@ static void _call_f_setSizePolicy_1552 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QSizePolicy arg1 = args.read<QSizePolicy > (heap);
+  QSizePolicy arg1 = gsi::arg_reader<QSizePolicy >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setSizePolicy (arg1);
 }
@@ -3254,8 +3254,8 @@ static void _call_f_setSizePolicy_4476 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & > (heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::Policy>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::Policy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setSizePolicy (qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg1).cref(), qt_gsi::QtToCppAdaptor<QSizePolicy::Policy>(arg2).cref());
 }
@@ -3275,7 +3275,7 @@ static void _call_f_setStatusTip_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setStatusTip (arg1);
 }
@@ -3295,7 +3295,7 @@ static void _call_f_setStyle_1232 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QStyle *arg1 = args.read<QStyle * > (heap);
+  QStyle *arg1 = gsi::arg_reader<QStyle * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setStyle (arg1);
 }
@@ -3315,7 +3315,7 @@ static void _call_f_setStyleSheet_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setStyleSheet (arg1);
 }
@@ -3335,7 +3335,7 @@ static void _call_f_setToolTip_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setToolTip (arg1);
 }
@@ -3355,7 +3355,7 @@ static void _call_f_setUpdatesEnabled_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setUpdatesEnabled (arg1);
 }
@@ -3375,7 +3375,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setVisible (arg1);
 }
@@ -3395,7 +3395,7 @@ static void _call_f_setWhatsThis_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWhatsThis (arg1);
 }
@@ -3415,7 +3415,7 @@ static void _call_f_setWindowFilePath_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowFilePath (arg1);
 }
@@ -3435,7 +3435,7 @@ static void _call_f_setWindowFlags_2495 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::WindowType> arg1 = args.read<QFlags<Qt::WindowType> > (heap);
+  QFlags<Qt::WindowType> arg1 = gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowFlags (arg1);
 }
@@ -3455,7 +3455,7 @@ static void _call_f_setWindowIcon_1787 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QIcon &arg1 = args.read<const QIcon & > (heap);
+  const QIcon &arg1 = gsi::arg_reader<const QIcon & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowIcon (arg1);
 }
@@ -3475,7 +3475,7 @@ static void _call_f_setWindowIconText_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowIconText (arg1);
 }
@@ -3495,7 +3495,7 @@ static void _call_f_setWindowModality_2216 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::WindowModality>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::WindowModality>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::WindowModality>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::WindowModality>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowModality (qt_gsi::QtToCppAdaptor<Qt::WindowModality>(arg1).cref());
 }
@@ -3515,7 +3515,7 @@ static void _call_f_setWindowModified_864 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowModified (arg1);
 }
@@ -3535,7 +3535,7 @@ static void _call_f_setWindowOpacity_1071 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  double arg1 = args.read<double > (heap);
+  double arg1 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowOpacity (arg1);
 }
@@ -3555,7 +3555,7 @@ static void _call_f_setWindowRole_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowRole (arg1);
 }
@@ -3575,7 +3575,7 @@ static void _call_f_setWindowState_2590 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::WindowState> arg1 = args.read<QFlags<Qt::WindowState> > (heap);
+  QFlags<Qt::WindowState> arg1 = gsi::arg_reader<QFlags<Qt::WindowState> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowState (arg1);
 }
@@ -3595,7 +3595,7 @@ static void _call_f_setWindowTitle_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->setWindowTitle (arg1);
 }
@@ -3755,7 +3755,7 @@ static void _call_f_stackUnder_1315 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->stackUnder (arg1);
 }
@@ -3820,7 +3820,7 @@ static void _call_f_testAttribute_c2309 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::WidgetAttribute>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QWidget *)cls)->testAttribute (qt_gsi::QtToCppAdaptor<Qt::WidgetAttribute>(arg1).cref()));
 }
 
@@ -3884,7 +3884,7 @@ static void _call_f_ungrabGesture_1902 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::GestureType>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::GestureType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::GestureType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->ungrabGesture (qt_gsi::QtToCppAdaptor<Qt::GestureType>(arg1).cref());
 }
@@ -3974,10 +3974,10 @@ static void _call_f_update_2744 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  int arg4 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  int arg4 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->update (arg1, arg2, arg3, arg4);
 }
@@ -3997,7 +3997,7 @@ static void _call_f_update_1792 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->update (arg1);
 }
@@ -4017,7 +4017,7 @@ static void _call_f_update_2006 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRegion &arg1 = args.read<const QRegion & > (heap);
+  const QRegion &arg1 = gsi::arg_reader<const QRegion & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget *)cls)->update (arg1);
 }
@@ -4323,7 +4323,7 @@ static void _call_f_find_696 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi:
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args.read<const qt_gsi::Converter<WId>::target_type & > (heap);
+  const qt_gsi::Converter<WId>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap);
   ret.write<QWidget * > ((QWidget *)QWidget::find (qt_gsi::QtToCppAdaptor<WId>(arg1).cref()));
 }
 
@@ -4374,8 +4374,8 @@ static void _call_f_setTabOrder_2522 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QWidget::setTabOrder (arg1, arg2);
 }
@@ -4397,8 +4397,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWidget::tr (arg1, arg2));
 }
 
@@ -4421,9 +4421,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWidget::tr (arg1, arg2, arg3));
 }
 
@@ -4444,8 +4444,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWidget::trUtf8 (arg1, arg2));
 }
 
@@ -4468,9 +4468,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWidget::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -5619,8 +5619,8 @@ static void _call_ctor_QWidget_Adaptor_3702 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QWidget_Adaptor *> (new QWidget_Adaptor (arg1, arg2));
 }
 
@@ -5762,9 +5762,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget_Adaptor *)cls)->fp_QWidget_create_2208 (arg1, arg2, arg3);
 }
@@ -5783,7 +5783,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QWidget_Adaptor *)cls)->emitter_QWidget_customContextMenuRequested_1916 (arg1);
 }
 
@@ -5827,8 +5827,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidget_Adaptor *)cls)->fp_QWidget_destroy_1620 (arg1, arg2);
 }
@@ -5847,7 +5847,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QWidget_Adaptor *)cls)->emitter_QWidget_destroyed_1302 (arg1);
 }
 
@@ -6620,7 +6620,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QWidget_Adaptor *)cls)->fp_QWidget_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWidgetAction.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWidgetAction.cc
@@ -89,7 +89,7 @@ static void _call_f_releaseWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidgetAction *)cls)->releaseWidget (arg1);
 }
@@ -109,7 +109,7 @@ static void _call_f_requestWidget_1315 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QWidget * > ((QWidget *)((QWidgetAction *)cls)->requestWidget (arg1));
 }
 
@@ -128,7 +128,7 @@ static void _call_f_setDefaultWidget_1315 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidgetAction *)cls)->setDefaultWidget (arg1);
 }
@@ -150,8 +150,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWidgetAction::tr (arg1, arg2));
 }
 
@@ -174,9 +174,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWidgetAction::tr (arg1, arg2, arg3));
 }
 
@@ -197,8 +197,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWidgetAction::trUtf8 (arg1, arg2));
 }
 
@@ -221,9 +221,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWidgetAction::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -463,7 +463,7 @@ static void _call_ctor_QWidgetAction_Adaptor_1302 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QWidgetAction_Adaptor *> (new QWidgetAction_Adaptor (arg1));
 }
 
@@ -604,7 +604,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QWidgetAction_Adaptor *)cls)->emitter_QWidgetAction_destroyed_1302 (arg1);
 }
 
@@ -709,7 +709,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QWidgetAction_Adaptor *)cls)->fp_QWidgetAction_receivers_c1731 (arg1));
 }
 
@@ -765,7 +765,7 @@ static void _call_emitter_toggled_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QWidgetAction_Adaptor *)cls)->emitter_QWidgetAction_toggled_864 (arg1);
 }
 
@@ -783,7 +783,7 @@ static void _call_emitter_triggered_864 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ((QWidgetAction_Adaptor *)cls)->emitter_QWidgetAction_triggered_864 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWidgetItem.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWidgetItem.cc
@@ -100,7 +100,7 @@ static void _call_f_heightForWidth_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<int > ((int)((QWidgetItem *)cls)->heightForWidth (arg1));
 }
 
@@ -164,7 +164,7 @@ static void _call_f_setGeometry_1792 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QRect &arg1 = args.read<const QRect & > (heap);
+  const QRect &arg1 = gsi::arg_reader<const QRect & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWidgetItem *)cls)->setGeometry (arg1);
 }
@@ -482,7 +482,7 @@ static void _call_ctor_QWidgetItem_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   ret.write<QWidgetItem_Adaptor *> (new QWidgetItem_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWindowStateChangeEvent.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWindowStateChangeEvent.cc
@@ -123,7 +123,7 @@ static void _call_ctor_QWindowStateChangeEvent_Adaptor_2590 (const qt_gsi::Gener
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::WindowState> arg1 = args.read<QFlags<Qt::WindowState> > (heap);
+  QFlags<Qt::WindowState> arg1 = gsi::arg_reader<QFlags<Qt::WindowState> >() (args, heap);
   ret.write<QWindowStateChangeEvent_Adaptor *> (new QWindowStateChangeEvent_Adaptor (arg1));
 }
 
@@ -143,8 +143,8 @@ static void _call_ctor_QWindowStateChangeEvent_Adaptor_3346 (const qt_gsi::Gener
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<Qt::WindowState> arg1 = args.read<QFlags<Qt::WindowState> > (heap);
-  bool arg2 = args.read<bool > (heap);
+  QFlags<Qt::WindowState> arg1 = gsi::arg_reader<QFlags<Qt::WindowState> >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   ret.write<QWindowStateChangeEvent_Adaptor *> (new QWindowStateChangeEvent_Adaptor (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWindowsStyle.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWindowsStyle.cc
@@ -88,10 +88,10 @@ static void _call_f_drawComplexControl_c9027 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & > (heap);
-  const QStyleOptionComplex *arg2 = args.read<const QStyleOptionComplex * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ComplexControl>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ComplexControl>::target_type & >() (args, heap);
+  const QStyleOptionComplex *arg2 = gsi::arg_reader<const QStyleOptionComplex * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWindowsStyle *)cls)->drawComplexControl (qt_gsi::QtToCppAdaptor<QStyle::ComplexControl>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -117,10 +117,10 @@ static void _call_f_drawControl_c8285 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ControlElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ControlElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ControlElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWindowsStyle *)cls)->drawControl (qt_gsi::QtToCppAdaptor<QStyle::ControlElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -146,10 +146,10 @@ static void _call_f_drawPrimitive_c8501 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  QPainter *arg3 = args.read<QPainter * > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PrimitiveElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  QPainter *arg3 = gsi::arg_reader<QPainter * >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWindowsStyle *)cls)->drawPrimitive (qt_gsi::QtToCppAdaptor<QStyle::PrimitiveElement>(arg1).cref(), arg2, arg3, arg4);
 }
@@ -173,9 +173,9 @@ static void _call_f_pixelMetric_c6642 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::PixelMetric>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::PixelMetric>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QWindowsStyle *)cls)->pixelMetric (qt_gsi::QtToCppAdaptor<QStyle::PixelMetric>(arg1).cref(), arg2, arg3));
 }
 
@@ -194,7 +194,7 @@ static void _call_f_polish_1843 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWindowsStyle *)cls)->polish (arg1);
 }
@@ -214,7 +214,7 @@ static void _call_f_polish_1315 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWindowsStyle *)cls)->polish (arg1);
 }
@@ -234,7 +234,7 @@ static void _call_f_polish_1418 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QPalette &arg1 = args.read<QPalette & > (heap);
+  QPalette &arg1 = gsi::arg_reader<QPalette & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWindowsStyle *)cls)->polish (arg1);
 }
@@ -260,10 +260,10 @@ static void _call_f_sizeFromContents_c8477 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::ContentsType>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QSize &arg3 = args.read<const QSize & > (heap);
-  const QWidget *arg4 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::ContentsType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::ContentsType>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QSize &arg3 = gsi::arg_reader<const QSize & >() (args, heap);
+  const QWidget *arg4 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QSize > ((QSize)((QWindowsStyle *)cls)->sizeFromContents (qt_gsi::QtToCppAdaptor<QStyle::ContentsType>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -286,9 +286,9 @@ static void _call_f_standardPixmap_c6956 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QPixmap > ((QPixmap)((QWindowsStyle *)cls)->standardPixmap (qt_gsi::QtToCppAdaptor<QStyle::StandardPixmap>(arg1).cref(), arg2, arg3));
 }
 
@@ -313,10 +313,10 @@ static void _call_f_styleHint_c8615 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StyleHint>::target_type & > (heap);
-  const QStyleOption *arg2 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
-  QStyleHintReturn *arg4 = args ? args.read<QStyleHintReturn * > (heap) : (QStyleHintReturn *)(0);
+  const qt_gsi::Converter<QStyle::StyleHint>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StyleHint>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
+  QStyleHintReturn *arg4 = args ? gsi::arg_reader<QStyleHintReturn * >() (args, heap) : gsi::arg_maker<QStyleHintReturn * >() (0, heap);
   ret.write<int > ((int)((QWindowsStyle *)cls)->styleHint (qt_gsi::QtToCppAdaptor<QStyle::StyleHint>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -339,9 +339,9 @@ static void _call_f_subElementRect_c6528 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::SubElement>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::SubElement>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::SubElement>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QRect > ((QRect)((QWindowsStyle *)cls)->subElementRect (qt_gsi::QtToCppAdaptor<QStyle::SubElement>(arg1).cref(), arg2, arg3));
 }
 
@@ -360,7 +360,7 @@ static void _call_f_unpolish_1843 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QApplication *arg1 = args.read<QApplication * > (heap);
+  QApplication *arg1 = gsi::arg_reader<QApplication * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWindowsStyle *)cls)->unpolish (arg1);
 }
@@ -380,7 +380,7 @@ static void _call_f_unpolish_1315 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWindowsStyle *)cls)->unpolish (arg1);
 }
@@ -402,8 +402,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWindowsStyle::tr (arg1, arg2));
 }
 
@@ -426,9 +426,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWindowsStyle::tr (arg1, arg2, arg3));
 }
 
@@ -449,8 +449,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWindowsStyle::trUtf8 (arg1, arg2));
 }
 
@@ -473,9 +473,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWindowsStyle::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1067,7 +1067,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QWindowsStyle_Adaptor *)cls)->emitter_QWindowsStyle_destroyed_1302 (arg1);
 }
 
@@ -1465,11 +1465,11 @@ static void _call_fp_layoutSpacingImplementation_c11697 (const qt_gsi::GenericMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QStyleOption *arg4 = args ? args.read<const QStyleOption * > (heap) : (const QStyleOption *)(0);
-  const QWidget *arg5 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSizePolicy::ControlType>::target_type & >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QStyleOption *arg4 = args ? gsi::arg_reader<const QStyleOption * >() (args, heap) : gsi::arg_maker<const QStyleOption * >() (0, heap);
+  const QWidget *arg5 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<int > ((int)((QWindowsStyle_Adaptor *)cls)->fp_QWindowsStyle_layoutSpacingImplementation_c11697 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1588,7 +1588,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QWindowsStyle_Adaptor *)cls)->fp_QWindowsStyle_receivers_c1731 (arg1));
 }
 
@@ -1656,9 +1656,9 @@ static void _call_fp_standardIconImplementation_c6956 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & > (heap);
-  const QStyleOption *arg2 = args.read<const QStyleOption * > (heap);
-  const QWidget *arg3 = args ? args.read<const QWidget * > (heap) : (const QWidget *)(0);
+  const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QStyle::StandardPixmap>::target_type & >() (args, heap);
+  const QStyleOption *arg2 = gsi::arg_reader<const QStyleOption * >() (args, heap);
+  const QWidget *arg3 = args ? gsi::arg_reader<const QWidget * >() (args, heap) : gsi::arg_maker<const QWidget * >() (0, heap);
   ret.write<QIcon > ((QIcon)((QWindowsStyle_Adaptor *)cls)->fp_QWindowsStyle_standardIconImplementation_c6956 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWizard.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWizard.cc
@@ -114,7 +114,7 @@ static void _call_f_addPage_1709 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWizardPage *arg1 = args.read<QWizardPage * > (heap);
+  QWizardPage *arg1 = gsi::arg_reader<QWizardPage * >() (args, heap);
   ret.write<int > ((int)((QWizard *)cls)->addPage (arg1));
 }
 
@@ -149,7 +149,7 @@ static void _call_f_button_c2519 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardButton>::target_type & > (heap);
+  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardButton>::target_type & >() (args, heap);
   ret.write<QAbstractButton * > ((QAbstractButton *)((QWizard *)cls)->button (qt_gsi::QtToCppAdaptor<QWizard::WizardButton>(arg1).cref()));
 }
 
@@ -168,7 +168,7 @@ static void _call_f_buttonText_c2519 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardButton>::target_type & > (heap);
+  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardButton>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QWizard *)cls)->buttonText (qt_gsi::QtToCppAdaptor<QWizard::WizardButton>(arg1).cref()));
 }
 
@@ -217,7 +217,7 @@ static void _call_f_field_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QWizard *)cls)->field (arg1));
 }
 
@@ -236,7 +236,7 @@ static void _call_f_hasVisitedPage_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QWizard *)cls)->hasVisitedPage (arg1));
 }
 
@@ -301,7 +301,7 @@ static void _call_f_page_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QWizardPage * > ((QWizardPage *)((QWizard *)cls)->page (arg1));
 }
 
@@ -335,7 +335,7 @@ static void _call_f_pixmap_c2506 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & > (heap);
+  const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & >() (args, heap);
   ret.write<QPixmap > ((QPixmap)((QWizard *)cls)->pixmap (qt_gsi::QtToCppAdaptor<QWizard::WizardPixmap>(arg1).cref()));
 }
 
@@ -354,7 +354,7 @@ static void _call_f_removePage_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->removePage (arg1);
 }
@@ -392,8 +392,8 @@ static void _call_f_setButton_4570 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardButton>::target_type & > (heap);
-  QAbstractButton *arg2 = args.read<QAbstractButton * > (heap);
+  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardButton>::target_type & >() (args, heap);
+  QAbstractButton *arg2 = gsi::arg_reader<QAbstractButton * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setButton (qt_gsi::QtToCppAdaptor<QWizard::WizardButton>(arg1).cref(), arg2);
 }
@@ -413,7 +413,7 @@ static void _call_f_setButtonLayout_4011 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QWizard::WizardButton> &arg1 = args.read<const QList<QWizard::WizardButton> & > (heap);
+  const QList<QWizard::WizardButton> &arg1 = gsi::arg_reader<const QList<QWizard::WizardButton> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setButtonLayout (arg1);
 }
@@ -435,8 +435,8 @@ static void _call_f_setButtonText_4436 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardButton>::target_type & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardButton>::target_type & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setButtonText (qt_gsi::QtToCppAdaptor<QWizard::WizardButton>(arg1).cref(), arg2);
 }
@@ -460,9 +460,9 @@ static void _call_f_setDefaultProperty_4977 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  const char *arg3 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setDefaultProperty (arg1, arg2, arg3);
 }
@@ -484,8 +484,8 @@ static void _call_f_setField_4036 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setField (arg1, arg2);
 }
@@ -507,8 +507,8 @@ static void _call_f_setOption_3272 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardOption>::target_type & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<QWizard::WizardOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardOption>::target_type & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setOption (qt_gsi::QtToCppAdaptor<QWizard::WizardOption>(arg1).cref(), arg2);
 }
@@ -528,7 +528,7 @@ static void _call_f_setOptions_3212 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QWizard::WizardOption> arg1 = args.read<QFlags<QWizard::WizardOption> > (heap);
+  QFlags<QWizard::WizardOption> arg1 = gsi::arg_reader<QFlags<QWizard::WizardOption> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setOptions (arg1);
 }
@@ -550,8 +550,8 @@ static void _call_f_setPage_2368 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QWizardPage *arg2 = args.read<QWizardPage * > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QWizardPage *arg2 = gsi::arg_reader<QWizardPage * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setPage (arg1, arg2);
 }
@@ -573,8 +573,8 @@ static void _call_f_setPixmap_4415 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
+  const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setPixmap (qt_gsi::QtToCppAdaptor<QWizard::WizardPixmap>(arg1).cref(), arg2);
 }
@@ -594,7 +594,7 @@ static void _call_f_setStartId_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setStartId (arg1);
 }
@@ -614,7 +614,7 @@ static void _call_f_setSubTitleFormat_1787 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TextFormat>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TextFormat>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TextFormat>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextFormat>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setSubTitleFormat (qt_gsi::QtToCppAdaptor<Qt::TextFormat>(arg1).cref());
 }
@@ -634,7 +634,7 @@ static void _call_f_setTitleFormat_1787 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::TextFormat>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::TextFormat>::target_type & > (heap);
+  const qt_gsi::Converter<Qt::TextFormat>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::TextFormat>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setTitleFormat (qt_gsi::QtToCppAdaptor<Qt::TextFormat>(arg1).cref());
 }
@@ -654,7 +654,7 @@ static void _call_f_setVisible_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setVisible (arg1);
 }
@@ -674,7 +674,7 @@ static void _call_f_setWizardStyle_2412 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardStyle>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardStyle>::target_type & > (heap);
+  const qt_gsi::Converter<QWizard::WizardStyle>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardStyle>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard *)cls)->setWizardStyle (qt_gsi::QtToCppAdaptor<QWizard::WizardStyle>(arg1).cref());
 }
@@ -739,7 +739,7 @@ static void _call_f_testOption_c2516 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardOption>::target_type & > (heap);
+  const qt_gsi::Converter<QWizard::WizardOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardOption>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QWizard *)cls)->testOption (qt_gsi::QtToCppAdaptor<QWizard::WizardOption>(arg1).cref()));
 }
 
@@ -820,8 +820,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWizard::tr (arg1, arg2));
 }
 
@@ -844,9 +844,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWizard::tr (arg1, arg2, arg3));
 }
 
@@ -867,8 +867,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWizard::trUtf8 (arg1, arg2));
 }
 
@@ -891,9 +891,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWizard::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1952,8 +1952,8 @@ static void _call_ctor_QWizard_Adaptor_3702 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
-  QFlags<Qt::WindowType> arg2 = args ? args.read<QFlags<Qt::WindowType> > (heap) : (QFlags<Qt::WindowType>)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
+  QFlags<Qt::WindowType> arg2 = args ? gsi::arg_reader<QFlags<Qt::WindowType> >() (args, heap) : gsi::arg_maker<QFlags<Qt::WindowType> >() (0, heap);
   ret.write<QWizard_Adaptor *> (new QWizard_Adaptor (arg1, arg2));
 }
 
@@ -2029,7 +2029,7 @@ static void _call_fp_adjustPosition_1315 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args.read<QWidget * > (heap);
+  QWidget *arg1 = gsi::arg_reader<QWidget * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard_Adaptor *)cls)->fp_QWizard_adjustPosition_1315 (arg1);
 }
@@ -2172,9 +2172,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard_Adaptor *)cls)->fp_QWizard_create_2208 (arg1, arg2, arg3);
 }
@@ -2193,7 +2193,7 @@ static void _call_emitter_currentIdChanged_767 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QWizard_Adaptor *)cls)->emitter_QWizard_currentIdChanged_767 (arg1);
 }
 
@@ -2211,7 +2211,7 @@ static void _call_emitter_customButtonClicked_767 (const qt_gsi::GenericMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QWizard_Adaptor *)cls)->emitter_QWizard_customButtonClicked_767 (arg1);
 }
 
@@ -2229,7 +2229,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QWizard_Adaptor *)cls)->emitter_QWizard_customContextMenuRequested_1916 (arg1);
 }
 
@@ -2273,8 +2273,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizard_Adaptor *)cls)->fp_QWizard_destroy_1620 (arg1, arg2);
 }
@@ -2293,7 +2293,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QWizard_Adaptor *)cls)->emitter_QWizard_destroyed_1302 (arg1);
 }
 
@@ -2552,7 +2552,7 @@ static void _call_emitter_finished_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QWizard_Adaptor *)cls)->emitter_QWizard_finished_767 (arg1);
 }
 
@@ -3165,7 +3165,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QWizard_Adaptor *)cls)->fp_QWizard_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtGui/gsiDeclQWizardPage.cc
+++ b/src/gsiqt/qt4/QtGui/gsiDeclQWizardPage.cc
@@ -113,7 +113,7 @@ static void _call_f_buttonText_c2519 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardButton>::target_type & > (heap);
+  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardButton>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QWizardPage *)cls)->buttonText (qt_gsi::QtToCppAdaptor<QWizard::WizardButton>(arg1).cref()));
 }
 
@@ -224,7 +224,7 @@ static void _call_f_pixmap_c2506 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & > (heap);
+  const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & >() (args, heap);
   ret.write<QPixmap > ((QPixmap)((QWizardPage *)cls)->pixmap (qt_gsi::QtToCppAdaptor<QWizard::WizardPixmap>(arg1).cref()));
 }
 
@@ -245,8 +245,8 @@ static void _call_f_setButtonText_4436 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardButton>::target_type & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const qt_gsi::Converter<QWizard::WizardButton>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardButton>::target_type & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage *)cls)->setButtonText (qt_gsi::QtToCppAdaptor<QWizard::WizardButton>(arg1).cref(), arg2);
 }
@@ -266,7 +266,7 @@ static void _call_f_setCommitPage_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage *)cls)->setCommitPage (arg1);
 }
@@ -286,7 +286,7 @@ static void _call_f_setFinalPage_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage *)cls)->setFinalPage (arg1);
 }
@@ -308,8 +308,8 @@ static void _call_f_setPixmap_4415 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & arg1 = args.read<const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & > (heap);
-  const QPixmap &arg2 = args.read<const QPixmap & > (heap);
+  const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QWizard::WizardPixmap>::target_type & >() (args, heap);
+  const QPixmap &arg2 = gsi::arg_reader<const QPixmap & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage *)cls)->setPixmap (qt_gsi::QtToCppAdaptor<QWizard::WizardPixmap>(arg1).cref(), arg2);
 }
@@ -329,7 +329,7 @@ static void _call_f_setSubTitle_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage *)cls)->setSubTitle (arg1);
 }
@@ -349,7 +349,7 @@ static void _call_f_setTitle_2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage *)cls)->setTitle (arg1);
 }
@@ -416,8 +416,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWizardPage::tr (arg1, arg2));
 }
 
@@ -440,9 +440,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWizardPage::tr (arg1, arg2, arg3));
 }
 
@@ -463,8 +463,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QWizardPage::trUtf8 (arg1, arg2));
 }
 
@@ -487,9 +487,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QWizardPage::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1467,7 +1467,7 @@ static void _call_ctor_QWizardPage_Adaptor_1315 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QWidget *arg1 = args ? args.read<QWidget * > (heap) : (QWidget *)(0);
+  QWidget *arg1 = args ? gsi::arg_reader<QWidget * >() (args, heap) : gsi::arg_maker<QWidget * >() (0, heap);
   ret.write<QWizardPage_Adaptor *> (new QWizardPage_Adaptor (arg1));
 }
 
@@ -1643,9 +1643,9 @@ static void _call_fp_create_2208 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<WId>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<WId>::target_type & > (heap) : (const qt_gsi::Converter<WId>::target_type &)(qt_gsi::CppToQtReadAdaptor<WId>(heap, 0));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg3 = args ? args.read<bool > (heap) : (bool)(true);
+  const qt_gsi::Converter<WId>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<WId>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<WId>::target_type & >() (qt_gsi::CppToQtReadAdaptor<WId>(heap, 0), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg3 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage_Adaptor *)cls)->fp_QWizardPage_create_2208 (arg1, arg2, arg3);
 }
@@ -1664,7 +1664,7 @@ static void _call_emitter_customContextMenuRequested_1916 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPoint &arg1 = args.read<const QPoint & > (heap);
+  const QPoint &arg1 = gsi::arg_reader<const QPoint & >() (args, heap);
   ((QWizardPage_Adaptor *)cls)->emitter_QWizardPage_customContextMenuRequested_1916 (arg1);
 }
 
@@ -1708,8 +1708,8 @@ static void _call_fp_destroy_1620 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage_Adaptor *)cls)->fp_QWizardPage_destroy_1620 (arg1, arg2);
 }
@@ -1728,7 +1728,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QWizardPage_Adaptor *)cls)->emitter_QWizardPage_destroyed_1302 (arg1);
 }
 
@@ -1963,7 +1963,7 @@ static void _call_fp_field_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QWizardPage_Adaptor *)cls)->fp_QWizardPage_field_c2025 (arg1));
 }
 
@@ -2577,7 +2577,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QWizardPage_Adaptor *)cls)->fp_QWizardPage_receivers_c1731 (arg1));
 }
 
@@ -2601,10 +2601,10 @@ static void _call_fp_registerField_6478 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QWidget *arg2 = args.read<QWidget * > (heap);
-  const char *arg3 = args ? args.read<const char * > (heap) : (const char *)(0);
-  const char *arg4 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QWidget *arg2 = gsi::arg_reader<QWidget * >() (args, heap);
+  const char *arg3 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
+  const char *arg4 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage_Adaptor *)cls)->fp_QWizardPage_registerField_6478 (arg1, arg2, arg3, arg4);
 }
@@ -2678,8 +2678,8 @@ static void _call_fp_setField_4036 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QWizardPage_Adaptor *)cls)->fp_QWizardPage_setField_4036 (arg1, arg2);
 }

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQAbstractNetworkCache.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQAbstractNetworkCache.cc
@@ -102,7 +102,7 @@ static void _call_f_data_1701 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QIODevice * > ((QIODevice *)((QAbstractNetworkCache *)cls)->data (arg1));
 }
 
@@ -121,7 +121,7 @@ static void _call_f_insert_1447 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractNetworkCache *)cls)->insert (arg1);
 }
@@ -141,7 +141,7 @@ static void _call_f_metaData_1701 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QNetworkCacheMetaData > ((QNetworkCacheMetaData)((QAbstractNetworkCache *)cls)->metaData (arg1));
 }
 
@@ -160,7 +160,7 @@ static void _call_f_prepare_3377 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCacheMetaData &arg1 = args.read<const QNetworkCacheMetaData & > (heap);
+  const QNetworkCacheMetaData &arg1 = gsi::arg_reader<const QNetworkCacheMetaData & >() (args, heap);
   ret.write<QIODevice * > ((QIODevice *)((QAbstractNetworkCache *)cls)->prepare (arg1));
 }
 
@@ -179,7 +179,7 @@ static void _call_f_remove_1701 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<bool > ((bool)((QAbstractNetworkCache *)cls)->remove (arg1));
 }
 
@@ -198,7 +198,7 @@ static void _call_f_updateMetaData_3377 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCacheMetaData &arg1 = args.read<const QNetworkCacheMetaData & > (heap);
+  const QNetworkCacheMetaData &arg1 = gsi::arg_reader<const QNetworkCacheMetaData & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractNetworkCache *)cls)->updateMetaData (arg1);
 }
@@ -220,8 +220,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractNetworkCache::tr (arg1, arg2));
 }
 
@@ -244,9 +244,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractNetworkCache::tr (arg1, arg2, arg3));
 }
 
@@ -267,8 +267,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractNetworkCache::trUtf8 (arg1, arg2));
 }
 
@@ -291,9 +291,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractNetworkCache::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -730,7 +730,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QAbstractNetworkCache_Adaptor *)cls)->emitter_QAbstractNetworkCache_destroyed_1302 (arg1);
 }
 
@@ -891,7 +891,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QAbstractNetworkCache_Adaptor *)cls)->fp_QAbstractNetworkCache_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQAbstractSocket.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQAbstractSocket.cc
@@ -71,8 +71,8 @@ static void _call_ctor_QAbstractSocket_4299 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSocket::SocketType>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSocket::SocketType>::target_type & > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
+  const qt_gsi::Converter<QAbstractSocket::SocketType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSocket::SocketType>::target_type & >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
   ret.write<QAbstractSocket *> (new QAbstractSocket (qt_gsi::QtToCppAdaptor<QAbstractSocket::SocketType>(arg1).cref(), arg2));
 }
 
@@ -187,9 +187,9 @@ static void _call_f_connectToHost_6151 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  quint16 arg2 = args.read<quint16 > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg3 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  quint16 arg2 = gsi::arg_reader<quint16 >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg3 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSocket *)cls)->connectToHost (arg1, arg2, arg3);
 }
@@ -213,9 +213,9 @@ static void _call_f_connectToHost_6644 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
-  quint16 arg2 = args.read<quint16 > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg3 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
+  quint16 arg2 = gsi::arg_reader<quint16 >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg3 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSocket *)cls)->connectToHost (arg1, arg2, arg3);
 }
@@ -416,7 +416,7 @@ static void _call_f_setProxy_2686 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxy &arg1 = args.read<const QNetworkProxy & > (heap);
+  const QNetworkProxy &arg1 = gsi::arg_reader<const QNetworkProxy & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSocket *)cls)->setProxy (arg1);
 }
@@ -436,7 +436,7 @@ static void _call_f_setReadBufferSize_986 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSocket *)cls)->setReadBufferSize (arg1);
 }
@@ -460,9 +460,9 @@ static void _call_f_setSocketDescriptor_6993 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractSocket::SocketState>(heap, QAbstractSocket::ConnectedState));
-  QFlags<QIODevice::OpenModeFlag> arg3 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractSocket::SocketState>(heap, QAbstractSocket::ConnectedState), heap);
+  QFlags<QIODevice::OpenModeFlag> arg3 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   ret.write<bool > ((bool)((QAbstractSocket *)cls)->setSocketDescriptor (arg1, qt_gsi::QtToCppAdaptor<QAbstractSocket::SocketState>(arg2).cref(), arg3));
 }
 
@@ -483,8 +483,8 @@ static void _call_f_setSocketOption_5331 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAbstractSocket *)cls)->setSocketOption (qt_gsi::QtToCppAdaptor<QAbstractSocket::SocketOption>(arg1).cref(), arg2);
 }
@@ -519,7 +519,7 @@ static void _call_f_socketOption_3320 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QAbstractSocket *)cls)->socketOption (qt_gsi::QtToCppAdaptor<QAbstractSocket::SocketOption>(arg1).cref()));
 }
 
@@ -568,7 +568,7 @@ static void _call_f_waitForBytesWritten_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QAbstractSocket *)cls)->waitForBytesWritten (arg1));
 }
 
@@ -587,7 +587,7 @@ static void _call_f_waitForConnected_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QAbstractSocket *)cls)->waitForConnected (arg1));
 }
 
@@ -606,7 +606,7 @@ static void _call_f_waitForDisconnected_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QAbstractSocket *)cls)->waitForDisconnected (arg1));
 }
 
@@ -625,7 +625,7 @@ static void _call_f_waitForReadyRead_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QAbstractSocket *)cls)->waitForReadyRead (arg1));
 }
 
@@ -646,8 +646,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractSocket::tr (arg1, arg2));
 }
 
@@ -670,9 +670,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractSocket::tr (arg1, arg2, arg3));
 }
 
@@ -693,8 +693,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QAbstractSocket::trUtf8 (arg1, arg2));
 }
 
@@ -717,9 +717,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QAbstractSocket::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQAuthenticator.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQAuthenticator.cc
@@ -65,7 +65,7 @@ static void _call_ctor_QAuthenticator_2765 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QAuthenticator &arg1 = args.read<const QAuthenticator & > (heap);
+  const QAuthenticator &arg1 = gsi::arg_reader<const QAuthenticator & >() (args, heap);
   ret.write<QAuthenticator *> (new QAuthenticator (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_operator_excl__eq__c2765 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QAuthenticator &arg1 = args.read<const QAuthenticator & > (heap);
+  const QAuthenticator &arg1 = gsi::arg_reader<const QAuthenticator & >() (args, heap);
   ret.write<bool > ((bool)((QAuthenticator *)cls)->operator!= (arg1));
 }
 
@@ -134,7 +134,7 @@ static void _call_f_operator_eq__2765 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QAuthenticator &arg1 = args.read<const QAuthenticator & > (heap);
+  const QAuthenticator &arg1 = gsi::arg_reader<const QAuthenticator & >() (args, heap);
   ret.write<QAuthenticator & > ((QAuthenticator &)((QAuthenticator *)cls)->operator= (arg1));
 }
 
@@ -153,7 +153,7 @@ static void _call_f_operator_eq__eq__c2765 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QAuthenticator &arg1 = args.read<const QAuthenticator & > (heap);
+  const QAuthenticator &arg1 = gsi::arg_reader<const QAuthenticator & >() (args, heap);
   ret.write<bool > ((bool)((QAuthenticator *)cls)->operator== (arg1));
 }
 
@@ -202,7 +202,7 @@ static void _call_f_setPassword_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAuthenticator *)cls)->setPassword (arg1);
 }
@@ -222,7 +222,7 @@ static void _call_f_setUser_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QAuthenticator *)cls)->setUser (arg1);
 }

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQFtp.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQFtp.cc
@@ -101,7 +101,7 @@ static void _call_f_cd_2025 (const qt_gsi::GenericMethod * /*decl*/, void *cls, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QFtp *)cls)->cd (arg1));
 }
 
@@ -153,8 +153,8 @@ static void _call_f_connectToHost_3017 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  quint16 arg2 = args ? args.read<quint16 > (heap) : (quint16)(21);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  quint16 arg2 = args ? gsi::arg_reader<quint16 >() (args, heap) : gsi::arg_maker<quint16 >() (21, heap);
   ret.write<int > ((int)((QFtp *)cls)->connectToHost (arg1, arg2));
 }
 
@@ -252,9 +252,9 @@ static void _call_f_get_5442 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QIODevice *arg2 = args ? args.read<QIODevice * > (heap) : (QIODevice *)(0);
-  const qt_gsi::Converter<QFtp::TransferType>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QFtp::TransferType>::target_type & > (heap) : (const qt_gsi::Converter<QFtp::TransferType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QFtp::TransferType>(heap, QFtp::Binary));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QIODevice *arg2 = args ? gsi::arg_reader<QIODevice * >() (args, heap) : gsi::arg_maker<QIODevice * >() (0, heap);
+  const qt_gsi::Converter<QFtp::TransferType>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QFtp::TransferType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QFtp::TransferType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QFtp::TransferType>(heap, QFtp::Binary), heap);
   ret.write<int > ((int)((QFtp *)cls)->get (arg1, arg2, qt_gsi::QtToCppAdaptor<QFtp::TransferType>(arg3).cref()));
 }
 
@@ -288,7 +288,7 @@ static void _call_f_list_2025 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<int > ((int)((QFtp *)cls)->list (arg1));
 }
 
@@ -309,8 +309,8 @@ static void _call_f_login_3942 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<int > ((int)((QFtp *)cls)->login (arg1, arg2));
 }
 
@@ -329,7 +329,7 @@ static void _call_f_mkdir_2025 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QFtp *)cls)->mkdir (arg1));
 }
 
@@ -352,9 +352,9 @@ static void _call_f_put_6304 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QFtp::TransferType>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QFtp::TransferType>::target_type & > (heap) : (const qt_gsi::Converter<QFtp::TransferType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QFtp::TransferType>(heap, QFtp::Binary));
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QFtp::TransferType>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QFtp::TransferType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QFtp::TransferType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QFtp::TransferType>(heap, QFtp::Binary), heap);
   ret.write<int > ((int)((QFtp *)cls)->put (arg1, arg2, qt_gsi::QtToCppAdaptor<QFtp::TransferType>(arg3).cref()));
 }
 
@@ -377,9 +377,9 @@ static void _call_f_put_5442 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QFtp::TransferType>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QFtp::TransferType>::target_type & > (heap) : (const qt_gsi::Converter<QFtp::TransferType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QFtp::TransferType>(heap, QFtp::Binary));
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QFtp::TransferType>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QFtp::TransferType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QFtp::TransferType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QFtp::TransferType>(heap, QFtp::Binary), heap);
   ret.write<int > ((int)((QFtp *)cls)->put (arg1, arg2, qt_gsi::QtToCppAdaptor<QFtp::TransferType>(arg3).cref()));
 }
 
@@ -398,7 +398,7 @@ static void _call_f_rawCommand_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QFtp *)cls)->rawCommand (arg1));
 }
 
@@ -432,7 +432,7 @@ static void _call_f_remove_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QFtp *)cls)->remove (arg1));
 }
 
@@ -453,8 +453,8 @@ static void _call_f_rename_3942 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QFtp *)cls)->rename (arg1, arg2));
 }
 
@@ -473,7 +473,7 @@ static void _call_f_rmdir_2025 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QFtp *)cls)->rmdir (arg1));
 }
 
@@ -494,8 +494,8 @@ static void _call_f_setProxy_3017 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  quint16 arg2 = args.read<quint16 > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  quint16 arg2 = gsi::arg_reader<quint16 >() (args, heap);
   ret.write<int > ((int)((QFtp *)cls)->setProxy (arg1, arg2));
 }
 
@@ -514,7 +514,7 @@ static void _call_f_setTransferMode_2157 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QFtp::TransferMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QFtp::TransferMode>::target_type & > (heap);
+  const qt_gsi::Converter<QFtp::TransferMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QFtp::TransferMode>::target_type & >() (args, heap);
   ret.write<int > ((int)((QFtp *)cls)->setTransferMode (qt_gsi::QtToCppAdaptor<QFtp::TransferMode>(arg1).cref()));
 }
 
@@ -550,8 +550,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFtp::tr (arg1, arg2));
 }
 
@@ -574,9 +574,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFtp::tr (arg1, arg2, arg3));
 }
 
@@ -597,8 +597,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QFtp::trUtf8 (arg1, arg2));
 }
 
@@ -621,9 +621,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QFtp::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -882,7 +882,7 @@ static void _call_ctor_QFtp_Adaptor_1302 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QFtp_Adaptor *> (new QFtp_Adaptor (arg1));
 }
 
@@ -926,8 +926,8 @@ static void _call_emitter_commandFinished_1523 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   ((QFtp_Adaptor *)cls)->emitter_QFtp_commandFinished_1523 (arg1, arg2);
 }
 
@@ -945,7 +945,7 @@ static void _call_emitter_commandStarted_767 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QFtp_Adaptor *)cls)->emitter_QFtp_commandStarted_767 (arg1);
 }
 
@@ -989,8 +989,8 @@ static void _call_emitter_dataTransferProgress_1864 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
-  qint64 arg2 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
+  qint64 arg2 = gsi::arg_reader<qint64 >() (args, heap);
   ((QFtp_Adaptor *)cls)->emitter_QFtp_dataTransferProgress_1864 (arg1, arg2);
 }
 
@@ -1008,7 +1008,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QFtp_Adaptor *)cls)->emitter_QFtp_destroyed_1302 (arg1);
 }
 
@@ -1050,7 +1050,7 @@ static void _call_emitter_done_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   ((QFtp_Adaptor *)cls)->emitter_QFtp_done_864 (arg1);
 }
 
@@ -1117,7 +1117,7 @@ static void _call_emitter_listInfo_2097 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrlInfo &arg1 = args.read<const QUrlInfo & > (heap);
+  const QUrlInfo &arg1 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
   ((QFtp_Adaptor *)cls)->emitter_QFtp_listInfo_2097 (arg1);
 }
 
@@ -1137,8 +1137,8 @@ static void _call_emitter_rawCommandReply_2684 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ((QFtp_Adaptor *)cls)->emitter_QFtp_rawCommandReply_2684 (arg1, arg2);
 }
 
@@ -1170,7 +1170,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QFtp_Adaptor *)cls)->fp_QFtp_receivers_c1731 (arg1));
 }
 
@@ -1202,7 +1202,7 @@ static void _call_emitter_stateChanged_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QFtp_Adaptor *)cls)->emitter_QFtp_stateChanged_767 (arg1);
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQHostAddress.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQHostAddress.cc
@@ -65,7 +65,7 @@ static void _call_ctor_QHostAddress_1098 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  quint32 arg1 = args.read<quint32 > (heap);
+  quint32 arg1 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QHostAddress *> (new QHostAddress (arg1));
 }
 
@@ -84,7 +84,7 @@ static void _call_ctor_QHostAddress_2025 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QHostAddress *> (new QHostAddress (arg1));
 }
 
@@ -103,7 +103,7 @@ static void _call_ctor_QHostAddress_2518 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
   ret.write<QHostAddress *> (new QHostAddress (arg1));
 }
 
@@ -122,7 +122,7 @@ static void _call_ctor_QHostAddress_3172 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & arg1 = args.read<const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & > (heap);
+  const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & >() (args, heap);
   ret.write<QHostAddress *> (new QHostAddress (qt_gsi::QtToCppAdaptor<QHostAddress::SpecialAddress>(arg1).cref()));
 }
 
@@ -159,8 +159,8 @@ static void _call_f_isInSubnet_c3177 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
-  int arg2 = args.read<int > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QHostAddress *)cls)->isInSubnet (arg1, arg2));
 }
 
@@ -179,7 +179,7 @@ static void _call_f_isInSubnet_c3636 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QPair<QHostAddress, int> &arg1 = args.read<const QPair<QHostAddress, int> & > (heap);
+  const QPair<QHostAddress, int> &arg1 = gsi::arg_reader<const QPair<QHostAddress, int> & >() (args, heap);
   ret.write<bool > ((bool)((QHostAddress *)cls)->isInSubnet (arg1));
 }
 
@@ -213,7 +213,7 @@ static void _call_f_operator_excl__eq__c2518 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
   ret.write<bool > ((bool)((QHostAddress *)cls)->operator != (arg1));
 }
 
@@ -232,7 +232,7 @@ static void _call_f_operator_excl__eq__c3172 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & arg1 = args.read<const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & > (heap);
+  const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QHostAddress *)cls)->operator != (qt_gsi::QtToCppAdaptor<QHostAddress::SpecialAddress>(arg1).cref()));
 }
 
@@ -251,7 +251,7 @@ static void _call_f_operator_eq__eq__c2518 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
   ret.write<bool > ((bool)((QHostAddress *)cls)->operator == (arg1));
 }
 
@@ -270,7 +270,7 @@ static void _call_f_operator_eq__eq__c3172 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & arg1 = args.read<const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & > (heap);
+  const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QHostAddress::SpecialAddress>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QHostAddress *)cls)->operator == (qt_gsi::QtToCppAdaptor<QHostAddress::SpecialAddress>(arg1).cref()));
 }
 
@@ -289,7 +289,7 @@ static void _call_f_operator_eq__2518 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
   ret.write<QHostAddress & > ((QHostAddress &)((QHostAddress *)cls)->operator= (arg1));
 }
 
@@ -308,7 +308,7 @@ static void _call_f_operator_eq__2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QHostAddress & > ((QHostAddress &)((QHostAddress *)cls)->operator= (arg1));
 }
 
@@ -357,7 +357,7 @@ static void _call_f_setAddress_1098 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  quint32 arg1 = args.read<quint32 > (heap);
+  quint32 arg1 = gsi::arg_reader<quint32 >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHostAddress *)cls)->setAddress (arg1);
 }
@@ -377,7 +377,7 @@ static void _call_f_setAddress_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QHostAddress *)cls)->setAddress (arg1));
 }
 
@@ -396,7 +396,7 @@ static void _call_f_setScopeId_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHostAddress *)cls)->setScopeId (arg1);
 }
@@ -446,7 +446,7 @@ static void _call_f_parseSubnet_2025 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QPair<QHostAddress, int> > ((QPair<QHostAddress, int>)QHostAddress::parseSubnet (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQHostInfo.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQHostInfo.cc
@@ -52,7 +52,7 @@ static void _call_ctor_QHostInfo_767 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(-1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QHostInfo *> (new QHostInfo (arg1));
 }
 
@@ -71,7 +71,7 @@ static void _call_ctor_QHostInfo_2204 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostInfo &arg1 = args.read<const QHostInfo & > (heap);
+  const QHostInfo &arg1 = gsi::arg_reader<const QHostInfo & >() (args, heap);
   ret.write<QHostInfo *> (new QHostInfo (arg1));
 }
 
@@ -165,7 +165,7 @@ static void _call_f_operator_eq__2204 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostInfo &arg1 = args.read<const QHostInfo & > (heap);
+  const QHostInfo &arg1 = gsi::arg_reader<const QHostInfo & >() (args, heap);
   ret.write<QHostInfo & > ((QHostInfo &)((QHostInfo *)cls)->operator= (arg1));
 }
 
@@ -184,7 +184,7 @@ static void _call_f_setAddresses_3133 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QHostAddress> &arg1 = args.read<const QList<QHostAddress> & > (heap);
+  const QList<QHostAddress> &arg1 = gsi::arg_reader<const QList<QHostAddress> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHostInfo *)cls)->setAddresses (arg1);
 }
@@ -204,7 +204,7 @@ static void _call_f_setError_2775 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QHostInfo::HostInfoError>::target_type & arg1 = args.read<const qt_gsi::Converter<QHostInfo::HostInfoError>::target_type & > (heap);
+  const qt_gsi::Converter<QHostInfo::HostInfoError>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QHostInfo::HostInfoError>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHostInfo *)cls)->setError (qt_gsi::QtToCppAdaptor<QHostInfo::HostInfoError>(arg1).cref());
 }
@@ -224,7 +224,7 @@ static void _call_f_setErrorString_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHostInfo *)cls)->setErrorString (arg1);
 }
@@ -244,7 +244,7 @@ static void _call_f_setHostName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHostInfo *)cls)->setHostName (arg1);
 }
@@ -264,7 +264,7 @@ static void _call_f_setLookupId_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QHostInfo *)cls)->setLookupId (arg1);
 }
@@ -284,7 +284,7 @@ static void _call_f_abortHostLookup_767 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QHostInfo::abortHostLookup (arg1);
 }
@@ -304,7 +304,7 @@ static void _call_f_fromName_2025 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QHostInfo > ((QHostInfo)QHostInfo::fromName (arg1));
 }
 
@@ -357,9 +357,9 @@ static void _call_f_lookupHost_4842 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QObject *arg2 = args.read<QObject * > (heap);
-  const char *arg3 = args.read<const char * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QObject *arg2 = gsi::arg_reader<QObject * >() (args, heap);
+  const char *arg3 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)QHostInfo::lookupHost (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQIPv6Address.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQIPv6Address.cc
@@ -65,7 +65,7 @@ static void _call_f_operator_index__767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<quint8 & > ((quint8 &)((QIPv6Address *)cls)->operator [] (arg1));
 }
 
@@ -84,7 +84,7 @@ static void _call_f_operator_index__c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<quint8 > ((quint8)((QIPv6Address *)cls)->operator [] (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQLocalServer.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQLocalServer.cc
@@ -145,7 +145,7 @@ static void _call_f_listen_2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QLocalServer *)cls)->listen (arg1));
 }
 
@@ -224,7 +224,7 @@ static void _call_f_setMaxPendingConnections_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLocalServer *)cls)->setMaxPendingConnections (arg1);
 }
@@ -246,8 +246,8 @@ static void _call_f_waitForNewConnection_1709 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<bool > ((bool)((QLocalServer *)cls)->waitForNewConnection (arg1, arg2));
 }
 
@@ -266,7 +266,7 @@ static void _call_f_removeServer_2025 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QLocalServer::removeServer (arg1));
 }
 
@@ -287,8 +287,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLocalServer::tr (arg1, arg2));
 }
 
@@ -311,9 +311,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLocalServer::tr (arg1, arg2, arg3));
 }
 
@@ -334,8 +334,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLocalServer::trUtf8 (arg1, arg2));
 }
 
@@ -358,9 +358,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLocalServer::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -605,7 +605,7 @@ static void _call_ctor_QLocalServer_Adaptor_1302 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QLocalServer_Adaptor *> (new QLocalServer_Adaptor (arg1));
 }
 
@@ -671,7 +671,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QLocalServer_Adaptor *)cls)->emitter_QLocalServer_destroyed_1302 (arg1);
 }
 
@@ -838,7 +838,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QLocalServer_Adaptor *)cls)->fp_QLocalServer_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQLocalSocket.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQLocalSocket.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QLocalSocket_1302 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QLocalSocket *> (new QLocalSocket (arg1));
 }
 
@@ -164,8 +164,8 @@ static void _call_f_connectToServer_5159 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg2 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg2 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLocalSocket *)cls)->connectToServer (arg1, arg2);
 }
@@ -306,7 +306,7 @@ static void _call_f_setReadBufferSize_986 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QLocalSocket *)cls)->setReadBufferSize (arg1);
 }
@@ -330,9 +330,9 @@ static void _call_f_setSocketDescriptor_7727 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  quintptr arg1 = args.read<quintptr > (heap);
-  const qt_gsi::Converter<QLocalSocket::LocalSocketState>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QLocalSocket::LocalSocketState>::target_type & > (heap) : (const qt_gsi::Converter<QLocalSocket::LocalSocketState>::target_type &)(qt_gsi::CppToQtReadAdaptor<QLocalSocket::LocalSocketState>(heap, QLocalSocket::ConnectedState));
-  QFlags<QIODevice::OpenModeFlag> arg3 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  quintptr arg1 = gsi::arg_reader<quintptr >() (args, heap);
+  const qt_gsi::Converter<QLocalSocket::LocalSocketState>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QLocalSocket::LocalSocketState>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QLocalSocket::LocalSocketState>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QLocalSocket::LocalSocketState>(heap, QLocalSocket::ConnectedState), heap);
+  QFlags<QIODevice::OpenModeFlag> arg3 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   ret.write<bool > ((bool)((QLocalSocket *)cls)->setSocketDescriptor (arg1, qt_gsi::QtToCppAdaptor<QLocalSocket::LocalSocketState>(arg2).cref(), arg3));
 }
 
@@ -381,7 +381,7 @@ static void _call_f_waitForBytesWritten_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QLocalSocket *)cls)->waitForBytesWritten (arg1));
 }
 
@@ -400,7 +400,7 @@ static void _call_f_waitForConnected_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QLocalSocket *)cls)->waitForConnected (arg1));
 }
 
@@ -419,7 +419,7 @@ static void _call_f_waitForDisconnected_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QLocalSocket *)cls)->waitForDisconnected (arg1));
 }
 
@@ -438,7 +438,7 @@ static void _call_f_waitForReadyRead_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QLocalSocket *)cls)->waitForReadyRead (arg1));
 }
 
@@ -459,8 +459,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLocalSocket::tr (arg1, arg2));
 }
 
@@ -483,9 +483,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLocalSocket::tr (arg1, arg2, arg3));
 }
 
@@ -506,8 +506,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QLocalSocket::trUtf8 (arg1, arg2));
 }
 
@@ -530,9 +530,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QLocalSocket::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkAccessManager.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkAccessManager.cc
@@ -107,7 +107,7 @@ static void _call_f_deleteResource_2885 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
   ret.write<QNetworkReply * > ((QNetworkReply *)((QNetworkAccessManager *)cls)->deleteResource (arg1));
 }
 
@@ -126,7 +126,7 @@ static void _call_f_get_2885 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
   ret.write<QNetworkReply * > ((QNetworkReply *)((QNetworkAccessManager *)cls)->get (arg1));
 }
 
@@ -145,7 +145,7 @@ static void _call_f_head_2885 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
   ret.write<QNetworkReply * > ((QNetworkReply *)((QNetworkAccessManager *)cls)->head (arg1));
 }
 
@@ -166,8 +166,8 @@ static void _call_f_post_4224 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
-  QIODevice *arg2 = args.read<QIODevice * > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
+  QIODevice *arg2 = gsi::arg_reader<QIODevice * >() (args, heap);
   ret.write<QNetworkReply * > ((QNetworkReply *)((QNetworkAccessManager *)cls)->post (arg1, arg2));
 }
 
@@ -188,8 +188,8 @@ static void _call_f_post_5086 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
-  const QByteArray &arg2 = args.read<const QByteArray & > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
+  const QByteArray &arg2 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QNetworkReply * > ((QNetworkReply *)((QNetworkAccessManager *)cls)->post (arg1, arg2));
 }
 
@@ -240,8 +240,8 @@ static void _call_f_put_4224 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
-  QIODevice *arg2 = args.read<QIODevice * > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
+  QIODevice *arg2 = gsi::arg_reader<QIODevice * >() (args, heap);
   ret.write<QNetworkReply * > ((QNetworkReply *)((QNetworkAccessManager *)cls)->put (arg1, arg2));
 }
 
@@ -262,8 +262,8 @@ static void _call_f_put_5086 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
-  const QByteArray &arg2 = args.read<const QByteArray & > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
+  const QByteArray &arg2 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QNetworkReply * > ((QNetworkReply *)((QNetworkAccessManager *)cls)->put (arg1, arg2));
 }
 
@@ -282,7 +282,7 @@ static void _call_f_setCache_2737 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QAbstractNetworkCache *arg1 = args.read<QAbstractNetworkCache * > (heap);
+  QAbstractNetworkCache *arg1 = gsi::arg_reader<QAbstractNetworkCache * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkAccessManager *)cls)->setCache (arg1);
 }
@@ -302,7 +302,7 @@ static void _call_f_setCookieJar_2336 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QNetworkCookieJar *arg1 = args.read<QNetworkCookieJar * > (heap);
+  QNetworkCookieJar *arg1 = gsi::arg_reader<QNetworkCookieJar * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkAccessManager *)cls)->setCookieJar (arg1);
 }
@@ -322,7 +322,7 @@ static void _call_f_setProxy_2686 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxy &arg1 = args.read<const QNetworkProxy & > (heap);
+  const QNetworkProxy &arg1 = gsi::arg_reader<const QNetworkProxy & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkAccessManager *)cls)->setProxy (arg1);
 }
@@ -342,7 +342,7 @@ static void _call_f_setProxyFactory_2723 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QNetworkProxyFactory *arg1 = args.read<QNetworkProxyFactory * > (heap);
+  QNetworkProxyFactory *arg1 = gsi::arg_reader<QNetworkProxyFactory * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkAccessManager *)cls)->setProxyFactory (arg1);
 }
@@ -364,8 +364,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QNetworkAccessManager::tr (arg1, arg2));
 }
 
@@ -388,9 +388,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QNetworkAccessManager::tr (arg1, arg2, arg3));
 }
 
@@ -411,8 +411,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QNetworkAccessManager::trUtf8 (arg1, arg2));
 }
 
@@ -435,9 +435,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QNetworkAccessManager::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -673,7 +673,7 @@ static void _call_ctor_QNetworkAccessManager_Adaptor_1302 (const qt_gsi::Generic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QNetworkAccessManager_Adaptor *> (new QNetworkAccessManager_Adaptor (arg1));
 }
 
@@ -693,8 +693,8 @@ static void _call_emitter_authenticationRequired_3939 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QNetworkReply *arg1 = args.read<QNetworkReply * > (heap);
-  QAuthenticator *arg2 = args.read<QAuthenticator * > (heap);
+  QNetworkReply *arg1 = gsi::arg_reader<QNetworkReply * >() (args, heap);
+  QAuthenticator *arg2 = gsi::arg_reader<QAuthenticator * >() (args, heap);
   ((QNetworkAccessManager_Adaptor *)cls)->emitter_QNetworkAccessManager_authenticationRequired_3939 (arg1, arg2);
 }
 
@@ -789,7 +789,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QNetworkAccessManager_Adaptor *)cls)->emitter_QNetworkAccessManager_destroyed_1302 (arg1);
 }
 
@@ -880,7 +880,7 @@ static void _call_emitter_finished_1973 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QNetworkReply *arg1 = args.read<QNetworkReply * > (heap);
+  QNetworkReply *arg1 = gsi::arg_reader<QNetworkReply * >() (args, heap);
   ((QNetworkAccessManager_Adaptor *)cls)->emitter_QNetworkAccessManager_finished_1973 (arg1);
 }
 
@@ -900,8 +900,8 @@ static void _call_emitter_proxyAuthenticationRequired_4652 (const qt_gsi::Generi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxy &arg1 = args.read<const QNetworkProxy & > (heap);
-  QAuthenticator *arg2 = args.read<QAuthenticator * > (heap);
+  const QNetworkProxy &arg1 = gsi::arg_reader<const QNetworkProxy & >() (args, heap);
+  QAuthenticator *arg2 = gsi::arg_reader<QAuthenticator * >() (args, heap);
   ((QNetworkAccessManager_Adaptor *)cls)->emitter_QNetworkAccessManager_proxyAuthenticationRequired_4652 (arg1, arg2);
 }
 
@@ -919,7 +919,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QNetworkAccessManager_Adaptor *)cls)->fp_QNetworkAccessManager_receivers_c1731 (arg1));
 }
 
@@ -953,8 +953,8 @@ static void _call_emitter_sslErrors_4702 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QNetworkReply *arg1 = args.read<QNetworkReply * > (heap);
-  const QList<QSslError> &arg2 = args.read<const QList<QSslError> & > (heap);
+  QNetworkReply *arg1 = gsi::arg_reader<QNetworkReply * >() (args, heap);
+  const QList<QSslError> &arg2 = gsi::arg_reader<const QList<QSslError> & >() (args, heap);
   ((QNetworkAccessManager_Adaptor *)cls)->emitter_QNetworkAccessManager_sslErrors_4702 (arg1, arg2);
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkAddressEntry.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkAddressEntry.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QNetworkAddressEntry_3380 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkAddressEntry &arg1 = args.read<const QNetworkAddressEntry & > (heap);
+  const QNetworkAddressEntry &arg1 = gsi::arg_reader<const QNetworkAddressEntry & >() (args, heap);
   ret.write<QNetworkAddressEntry *> (new QNetworkAddressEntry (arg1));
 }
 
@@ -130,7 +130,7 @@ static void _call_f_operator_excl__eq__c3380 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkAddressEntry &arg1 = args.read<const QNetworkAddressEntry & > (heap);
+  const QNetworkAddressEntry &arg1 = gsi::arg_reader<const QNetworkAddressEntry & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkAddressEntry *)cls)->operator!= (arg1));
 }
 
@@ -149,7 +149,7 @@ static void _call_f_operator_eq__3380 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkAddressEntry &arg1 = args.read<const QNetworkAddressEntry & > (heap);
+  const QNetworkAddressEntry &arg1 = gsi::arg_reader<const QNetworkAddressEntry & >() (args, heap);
   ret.write<QNetworkAddressEntry & > ((QNetworkAddressEntry &)((QNetworkAddressEntry *)cls)->operator= (arg1));
 }
 
@@ -168,7 +168,7 @@ static void _call_f_operator_eq__eq__c3380 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkAddressEntry &arg1 = args.read<const QNetworkAddressEntry & > (heap);
+  const QNetworkAddressEntry &arg1 = gsi::arg_reader<const QNetworkAddressEntry & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkAddressEntry *)cls)->operator== (arg1));
 }
 
@@ -202,7 +202,7 @@ static void _call_f_setBroadcast_2518 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkAddressEntry *)cls)->setBroadcast (arg1);
 }
@@ -222,7 +222,7 @@ static void _call_f_setIp_2518 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkAddressEntry *)cls)->setIp (arg1);
 }
@@ -242,7 +242,7 @@ static void _call_f_setNetmask_2518 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkAddressEntry *)cls)->setNetmask (arg1);
 }
@@ -262,7 +262,7 @@ static void _call_f_setPrefixLength_767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkAddressEntry *)cls)->setPrefixLength (arg1);
 }

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkCacheMetaData.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkCacheMetaData.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QNetworkCacheMetaData_3377 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCacheMetaData &arg1 = args.read<const QNetworkCacheMetaData & > (heap);
+  const QNetworkCacheMetaData &arg1 = gsi::arg_reader<const QNetworkCacheMetaData & >() (args, heap);
   ret.write<QNetworkCacheMetaData *> (new QNetworkCacheMetaData (arg1));
 }
 
@@ -131,7 +131,7 @@ static void _call_f_operator_excl__eq__c3377 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCacheMetaData &arg1 = args.read<const QNetworkCacheMetaData & > (heap);
+  const QNetworkCacheMetaData &arg1 = gsi::arg_reader<const QNetworkCacheMetaData & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkCacheMetaData *)cls)->operator!= (arg1));
 }
 
@@ -150,7 +150,7 @@ static void _call_f_operator_eq__3377 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCacheMetaData &arg1 = args.read<const QNetworkCacheMetaData & > (heap);
+  const QNetworkCacheMetaData &arg1 = gsi::arg_reader<const QNetworkCacheMetaData & >() (args, heap);
   ret.write<QNetworkCacheMetaData & > ((QNetworkCacheMetaData &)((QNetworkCacheMetaData *)cls)->operator= (arg1));
 }
 
@@ -169,7 +169,7 @@ static void _call_f_operator_eq__eq__c3377 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCacheMetaData &arg1 = args.read<const QNetworkCacheMetaData & > (heap);
+  const QNetworkCacheMetaData &arg1 = gsi::arg_reader<const QNetworkCacheMetaData & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkCacheMetaData *)cls)->operator== (arg1));
 }
 
@@ -218,7 +218,7 @@ static void _call_f_setExpirationDate_2175 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCacheMetaData *)cls)->setExpirationDate (arg1);
 }
@@ -238,7 +238,7 @@ static void _call_f_setLastModified_2175 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCacheMetaData *)cls)->setLastModified (arg1);
 }
@@ -258,7 +258,7 @@ static void _call_f_setRawHeaders_4991 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QNetworkCacheMetaData::RawHeader> &arg1 = args.read<const QList<QNetworkCacheMetaData::RawHeader> & > (heap);
+  const QList<QNetworkCacheMetaData::RawHeader> &arg1 = gsi::arg_reader<const QList<QNetworkCacheMetaData::RawHeader> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCacheMetaData *)cls)->setRawHeaders (arg1);
 }
@@ -278,7 +278,7 @@ static void _call_f_setSaveToDisk_864 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCacheMetaData *)cls)->setSaveToDisk (arg1);
 }
@@ -298,7 +298,7 @@ static void _call_f_setUrl_1701 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCacheMetaData *)cls)->setUrl (arg1);
 }

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkCookie.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkCookie.cc
@@ -53,8 +53,8 @@ static void _call_ctor_QNetworkCookie_4510 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
-  const QByteArray &arg2 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QByteArray &arg1 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
+  const QByteArray &arg2 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QNetworkCookie *> (new QNetworkCookie (arg1, arg2));
 }
 
@@ -73,7 +73,7 @@ static void _call_ctor_QNetworkCookie_2742 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCookie &arg1 = args.read<const QNetworkCookie & > (heap);
+  const QNetworkCookie &arg1 = gsi::arg_reader<const QNetworkCookie & >() (args, heap);
   ret.write<QNetworkCookie *> (new QNetworkCookie (arg1));
 }
 
@@ -182,7 +182,7 @@ static void _call_f_operator_excl__eq__c2742 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCookie &arg1 = args.read<const QNetworkCookie & > (heap);
+  const QNetworkCookie &arg1 = gsi::arg_reader<const QNetworkCookie & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkCookie *)cls)->operator!= (arg1));
 }
 
@@ -201,7 +201,7 @@ static void _call_f_operator_eq__2742 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCookie &arg1 = args.read<const QNetworkCookie & > (heap);
+  const QNetworkCookie &arg1 = gsi::arg_reader<const QNetworkCookie & >() (args, heap);
   ret.write<QNetworkCookie & > ((QNetworkCookie &)((QNetworkCookie *)cls)->operator= (arg1));
 }
 
@@ -220,7 +220,7 @@ static void _call_f_operator_eq__eq__c2742 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCookie &arg1 = args.read<const QNetworkCookie & > (heap);
+  const QNetworkCookie &arg1 = gsi::arg_reader<const QNetworkCookie & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkCookie *)cls)->operator== (arg1));
 }
 
@@ -254,7 +254,7 @@ static void _call_f_setDomain_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCookie *)cls)->setDomain (arg1);
 }
@@ -274,7 +274,7 @@ static void _call_f_setExpirationDate_2175 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCookie *)cls)->setExpirationDate (arg1);
 }
@@ -294,7 +294,7 @@ static void _call_f_setHttpOnly_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCookie *)cls)->setHttpOnly (arg1);
 }
@@ -314,7 +314,7 @@ static void _call_f_setName_2309 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCookie *)cls)->setName (arg1);
 }
@@ -334,7 +334,7 @@ static void _call_f_setPath_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCookie *)cls)->setPath (arg1);
 }
@@ -354,7 +354,7 @@ static void _call_f_setSecure_864 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCookie *)cls)->setSecure (arg1);
 }
@@ -374,7 +374,7 @@ static void _call_f_setValue_2309 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCookie *)cls)->setValue (arg1);
 }
@@ -394,7 +394,7 @@ static void _call_f_toRawForm_c2683 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkCookie::RawForm>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QNetworkCookie::RawForm>::target_type & > (heap) : (const qt_gsi::Converter<QNetworkCookie::RawForm>::target_type &)(qt_gsi::CppToQtReadAdaptor<QNetworkCookie::RawForm>(heap, QNetworkCookie::Full));
+  const qt_gsi::Converter<QNetworkCookie::RawForm>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QNetworkCookie::RawForm>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QNetworkCookie::RawForm>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QNetworkCookie::RawForm>(heap, QNetworkCookie::Full), heap);
   ret.write<QByteArray > ((QByteArray)((QNetworkCookie *)cls)->toRawForm (qt_gsi::QtToCppAdaptor<QNetworkCookie::RawForm>(arg1).cref()));
 }
 
@@ -428,7 +428,7 @@ static void _call_f_parseCookies_2309 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QList<QNetworkCookie> > ((QList<QNetworkCookie>)QNetworkCookie::parseCookies (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkCookieJar.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkCookieJar.cc
@@ -70,7 +70,7 @@ static void _call_f_cookiesForUrl_c1701 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QList<QNetworkCookie> > ((QList<QNetworkCookie>)((QNetworkCookieJar *)cls)->cookiesForUrl (arg1));
 }
 
@@ -91,8 +91,8 @@ static void _call_f_setCookiesFromUrl_4950 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QNetworkCookie> &arg1 = args.read<const QList<QNetworkCookie> & > (heap);
-  const QUrl &arg2 = args.read<const QUrl & > (heap);
+  const QList<QNetworkCookie> &arg1 = gsi::arg_reader<const QList<QNetworkCookie> & >() (args, heap);
+  const QUrl &arg2 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkCookieJar *)cls)->setCookiesFromUrl (arg1, arg2));
 }
 
@@ -113,8 +113,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QNetworkCookieJar::tr (arg1, arg2));
 }
 
@@ -137,9 +137,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QNetworkCookieJar::tr (arg1, arg2, arg3));
 }
 
@@ -160,8 +160,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QNetworkCookieJar::trUtf8 (arg1, arg2));
 }
 
@@ -184,9 +184,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QNetworkCookieJar::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -407,7 +407,7 @@ static void _call_ctor_QNetworkCookieJar_Adaptor_1302 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QNetworkCookieJar_Adaptor *> (new QNetworkCookieJar_Adaptor (arg1));
 }
 
@@ -510,7 +510,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QNetworkCookieJar_Adaptor *)cls)->emitter_QNetworkCookieJar_destroyed_1302 (arg1);
 }
 
@@ -601,7 +601,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QNetworkCookieJar_Adaptor *)cls)->fp_QNetworkCookieJar_receivers_c1731 (arg1));
 }
 
@@ -633,7 +633,7 @@ static void _call_fp_setAllCookies_3357 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QNetworkCookie> &arg1 = args.read<const QList<QNetworkCookie> & > (heap);
+  const QList<QNetworkCookie> &arg1 = gsi::arg_reader<const QList<QNetworkCookie> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkCookieJar_Adaptor *)cls)->fp_QNetworkCookieJar_setAllCookies_3357 (arg1);
 }

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkDiskCache.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkDiskCache.cc
@@ -117,7 +117,7 @@ static void _call_f_data_1701 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QIODevice * > ((QIODevice *)((QNetworkDiskCache *)cls)->data (arg1));
 }
 
@@ -136,7 +136,7 @@ static void _call_f_fileMetaData_c2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QNetworkCacheMetaData > ((QNetworkCacheMetaData)((QNetworkDiskCache *)cls)->fileMetaData (arg1));
 }
 
@@ -155,7 +155,7 @@ static void _call_f_insert_1447 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkDiskCache *)cls)->insert (arg1);
 }
@@ -190,7 +190,7 @@ static void _call_f_metaData_1701 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<QNetworkCacheMetaData > ((QNetworkCacheMetaData)((QNetworkDiskCache *)cls)->metaData (arg1));
 }
 
@@ -209,7 +209,7 @@ static void _call_f_prepare_3377 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCacheMetaData &arg1 = args.read<const QNetworkCacheMetaData & > (heap);
+  const QNetworkCacheMetaData &arg1 = gsi::arg_reader<const QNetworkCacheMetaData & >() (args, heap);
   ret.write<QIODevice * > ((QIODevice *)((QNetworkDiskCache *)cls)->prepare (arg1));
 }
 
@@ -228,7 +228,7 @@ static void _call_f_remove_1701 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkDiskCache *)cls)->remove (arg1));
 }
 
@@ -247,7 +247,7 @@ static void _call_f_setCacheDirectory_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkDiskCache *)cls)->setCacheDirectory (arg1);
 }
@@ -267,7 +267,7 @@ static void _call_f_setMaximumCacheSize_986 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkDiskCache *)cls)->setMaximumCacheSize (arg1);
 }
@@ -287,7 +287,7 @@ static void _call_f_updateMetaData_3377 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkCacheMetaData &arg1 = args.read<const QNetworkCacheMetaData & > (heap);
+  const QNetworkCacheMetaData &arg1 = gsi::arg_reader<const QNetworkCacheMetaData & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkDiskCache *)cls)->updateMetaData (arg1);
 }
@@ -309,8 +309,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QNetworkDiskCache::tr (arg1, arg2));
 }
 
@@ -333,9 +333,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QNetworkDiskCache::tr (arg1, arg2, arg3));
 }
 
@@ -356,8 +356,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QNetworkDiskCache::trUtf8 (arg1, arg2));
 }
 
@@ -380,9 +380,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QNetworkDiskCache::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -716,7 +716,7 @@ static void _call_ctor_QNetworkDiskCache_Adaptor_1302 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QNetworkDiskCache_Adaptor *> (new QNetworkDiskCache_Adaptor (arg1));
 }
 
@@ -844,7 +844,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QNetworkDiskCache_Adaptor *)cls)->emitter_QNetworkDiskCache_destroyed_1302 (arg1);
 }
 
@@ -1024,7 +1024,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QNetworkDiskCache_Adaptor *)cls)->fp_QNetworkDiskCache_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkInterface.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkInterface.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QNetworkInterface_3053 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkInterface &arg1 = args.read<const QNetworkInterface & > (heap);
+  const QNetworkInterface &arg1 = gsi::arg_reader<const QNetworkInterface & >() (args, heap);
   ret.write<QNetworkInterface *> (new QNetworkInterface (arg1));
 }
 
@@ -191,7 +191,7 @@ static void _call_f_operator_eq__3053 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkInterface &arg1 = args.read<const QNetworkInterface & > (heap);
+  const QNetworkInterface &arg1 = gsi::arg_reader<const QNetworkInterface & >() (args, heap);
   ret.write<QNetworkInterface & > ((QNetworkInterface &)((QNetworkInterface *)cls)->operator= (arg1));
 }
 
@@ -240,7 +240,7 @@ static void _call_f_interfaceFromIndex_767 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QNetworkInterface > ((QNetworkInterface)QNetworkInterface::interfaceFromIndex (arg1));
 }
 
@@ -259,7 +259,7 @@ static void _call_f_interfaceFromName_2025 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QNetworkInterface > ((QNetworkInterface)QNetworkInterface::interfaceFromName (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkProxy.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkProxy.cc
@@ -73,11 +73,11 @@ static void _call_ctor_QNetworkProxy_9632 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkProxy::ProxyType>::target_type & arg1 = args.read<const qt_gsi::Converter<QNetworkProxy::ProxyType>::target_type & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  quint16 arg3 = args ? args.read<quint16 > (heap) : (quint16)(0);
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg5 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const qt_gsi::Converter<QNetworkProxy::ProxyType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QNetworkProxy::ProxyType>::target_type & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  quint16 arg3 = args ? gsi::arg_reader<quint16 >() (args, heap) : gsi::arg_maker<quint16 >() (0, heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg5 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QNetworkProxy *> (new QNetworkProxy (qt_gsi::QtToCppAdaptor<QNetworkProxy::ProxyType>(arg1).cref(), arg2, arg3, arg4, arg5));
 }
 
@@ -96,7 +96,7 @@ static void _call_ctor_QNetworkProxy_2686 (const qt_gsi::GenericStaticMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxy &arg1 = args.read<const QNetworkProxy & > (heap);
+  const QNetworkProxy &arg1 = gsi::arg_reader<const QNetworkProxy & >() (args, heap);
   ret.write<QNetworkProxy *> (new QNetworkProxy (arg1));
 }
 
@@ -175,7 +175,7 @@ static void _call_f_operator_excl__eq__c2686 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxy &arg1 = args.read<const QNetworkProxy & > (heap);
+  const QNetworkProxy &arg1 = gsi::arg_reader<const QNetworkProxy & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkProxy *)cls)->operator!= (arg1));
 }
 
@@ -194,7 +194,7 @@ static void _call_f_operator_eq__2686 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxy &arg1 = args.read<const QNetworkProxy & > (heap);
+  const QNetworkProxy &arg1 = gsi::arg_reader<const QNetworkProxy & >() (args, heap);
   ret.write<QNetworkProxy & > ((QNetworkProxy &)((QNetworkProxy *)cls)->operator= (arg1));
 }
 
@@ -213,7 +213,7 @@ static void _call_f_operator_eq__eq__c2686 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxy &arg1 = args.read<const QNetworkProxy & > (heap);
+  const QNetworkProxy &arg1 = gsi::arg_reader<const QNetworkProxy & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkProxy *)cls)->operator== (arg1));
 }
 
@@ -262,7 +262,7 @@ static void _call_f_setCapabilities_3647 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QFlags<QNetworkProxy::Capability> arg1 = args.read<QFlags<QNetworkProxy::Capability> > (heap);
+  QFlags<QNetworkProxy::Capability> arg1 = gsi::arg_reader<QFlags<QNetworkProxy::Capability> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxy *)cls)->setCapabilities (arg1);
 }
@@ -282,7 +282,7 @@ static void _call_f_setHostName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxy *)cls)->setHostName (arg1);
 }
@@ -302,7 +302,7 @@ static void _call_f_setPassword_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxy *)cls)->setPassword (arg1);
 }
@@ -322,7 +322,7 @@ static void _call_f_setPort_1100 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  quint16 arg1 = args.read<quint16 > (heap);
+  quint16 arg1 = gsi::arg_reader<quint16 >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxy *)cls)->setPort (arg1);
 }
@@ -342,7 +342,7 @@ static void _call_f_setType_2889 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkProxy::ProxyType>::target_type & arg1 = args.read<const qt_gsi::Converter<QNetworkProxy::ProxyType>::target_type & > (heap);
+  const qt_gsi::Converter<QNetworkProxy::ProxyType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QNetworkProxy::ProxyType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxy *)cls)->setType (qt_gsi::QtToCppAdaptor<QNetworkProxy::ProxyType>(arg1).cref());
 }
@@ -362,7 +362,7 @@ static void _call_f_setUser_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxy *)cls)->setUser (arg1);
 }
@@ -427,7 +427,7 @@ static void _call_f_setApplicationProxy_2686 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxy &arg1 = args.read<const QNetworkProxy & > (heap);
+  const QNetworkProxy &arg1 = gsi::arg_reader<const QNetworkProxy & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QNetworkProxy::setApplicationProxy (arg1);
 }

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkProxyFactory.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkProxyFactory.cc
@@ -52,7 +52,7 @@ static void _call_f_queryProxy_3220 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxyQuery &arg1 = args ? args.read<const QNetworkProxyQuery & > (heap) : (const QNetworkProxyQuery &)(QNetworkProxyQuery());
+  const QNetworkProxyQuery &arg1 = args ? gsi::arg_reader<const QNetworkProxyQuery & >() (args, heap) : gsi::arg_maker<const QNetworkProxyQuery & >() (QNetworkProxyQuery(), heap);
   ret.write<QList<QNetworkProxy> > ((QList<QNetworkProxy>)((QNetworkProxyFactory *)cls)->queryProxy (arg1));
 }
 
@@ -71,7 +71,7 @@ static void _call_f_proxyForQuery_3220 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxyQuery &arg1 = args.read<const QNetworkProxyQuery & > (heap);
+  const QNetworkProxyQuery &arg1 = gsi::arg_reader<const QNetworkProxyQuery & >() (args, heap);
   ret.write<QList<QNetworkProxy> > ((QList<QNetworkProxy>)QNetworkProxyFactory::proxyForQuery (arg1));
 }
 
@@ -90,7 +90,7 @@ static void _call_f_setApplicationProxyFactory_2723 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QNetworkProxyFactory *arg1 = args.read<QNetworkProxyFactory * > (heap);
+  QNetworkProxyFactory *arg1 = gsi::arg_reader<QNetworkProxyFactory * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QNetworkProxyFactory::setApplicationProxyFactory (arg1);
 }
@@ -110,7 +110,7 @@ static void _call_f_setUseSystemConfiguration_864 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QNetworkProxyFactory::setUseSystemConfiguration (arg1);
 }
@@ -130,7 +130,7 @@ static void _call_f_systemProxyForQuery_3220 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxyQuery &arg1 = args ? args.read<const QNetworkProxyQuery & > (heap) : (const QNetworkProxyQuery &)(QNetworkProxyQuery());
+  const QNetworkProxyQuery &arg1 = args ? gsi::arg_reader<const QNetworkProxyQuery & >() (args, heap) : gsi::arg_maker<const QNetworkProxyQuery & >() (QNetworkProxyQuery(), heap);
   ret.write<QList<QNetworkProxy> > ((QList<QNetworkProxy>)QNetworkProxyFactory::systemProxyForQuery (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkProxyQuery.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkProxyQuery.cc
@@ -68,8 +68,8 @@ static void _call_ctor_QNetworkProxyQuery_5004 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
-  const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & > (heap) : (const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QNetworkProxyQuery::QueryType>(heap, QNetworkProxyQuery::UrlRequest));
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
+  const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QNetworkProxyQuery::QueryType>(heap, QNetworkProxyQuery::UrlRequest), heap);
   ret.write<QNetworkProxyQuery *> (new QNetworkProxyQuery (arg1, qt_gsi::QtToCppAdaptor<QNetworkProxyQuery::QueryType>(arg2).cref()));
 }
 
@@ -94,10 +94,10 @@ static void _call_ctor_QNetworkProxyQuery_7904 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args.read<int > (heap);
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & > (heap) : (const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QNetworkProxyQuery::QueryType>(heap, QNetworkProxyQuery::TcpSocket));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QNetworkProxyQuery::QueryType>(heap, QNetworkProxyQuery::TcpSocket), heap);
   ret.write<QNetworkProxyQuery *> (new QNetworkProxyQuery (arg1, arg2, arg3, qt_gsi::QtToCppAdaptor<QNetworkProxyQuery::QueryType>(arg4).cref()));
 }
 
@@ -120,9 +120,9 @@ static void _call_ctor_QNetworkProxyQuery_6320 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  quint16 arg1 = args.read<quint16 > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & > (heap) : (const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QNetworkProxyQuery::QueryType>(heap, QNetworkProxyQuery::TcpServer));
+  quint16 arg1 = gsi::arg_reader<quint16 >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QNetworkProxyQuery::QueryType>(heap, QNetworkProxyQuery::TcpServer), heap);
   ret.write<QNetworkProxyQuery *> (new QNetworkProxyQuery (arg1, arg2, qt_gsi::QtToCppAdaptor<QNetworkProxyQuery::QueryType>(arg3).cref()));
 }
 
@@ -141,7 +141,7 @@ static void _call_ctor_QNetworkProxyQuery_3220 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxyQuery &arg1 = args.read<const QNetworkProxyQuery & > (heap);
+  const QNetworkProxyQuery &arg1 = gsi::arg_reader<const QNetworkProxyQuery & >() (args, heap);
   ret.write<QNetworkProxyQuery *> (new QNetworkProxyQuery (arg1));
 }
 
@@ -175,7 +175,7 @@ static void _call_f_operator_excl__eq__c3220 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxyQuery &arg1 = args.read<const QNetworkProxyQuery & > (heap);
+  const QNetworkProxyQuery &arg1 = gsi::arg_reader<const QNetworkProxyQuery & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkProxyQuery *)cls)->operator!= (arg1));
 }
 
@@ -194,7 +194,7 @@ static void _call_f_operator_eq__3220 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxyQuery &arg1 = args.read<const QNetworkProxyQuery & > (heap);
+  const QNetworkProxyQuery &arg1 = gsi::arg_reader<const QNetworkProxyQuery & >() (args, heap);
   ret.write<QNetworkProxyQuery & > ((QNetworkProxyQuery &)((QNetworkProxyQuery *)cls)->operator= (arg1));
 }
 
@@ -213,7 +213,7 @@ static void _call_f_operator_eq__eq__c3220 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxyQuery &arg1 = args.read<const QNetworkProxyQuery & > (heap);
+  const QNetworkProxyQuery &arg1 = gsi::arg_reader<const QNetworkProxyQuery & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkProxyQuery *)cls)->operator== (arg1));
 }
 
@@ -292,7 +292,7 @@ static void _call_f_setLocalPort_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxyQuery *)cls)->setLocalPort (arg1);
 }
@@ -312,7 +312,7 @@ static void _call_f_setPeerHostName_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxyQuery *)cls)->setPeerHostName (arg1);
 }
@@ -332,7 +332,7 @@ static void _call_f_setPeerPort_767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxyQuery *)cls)->setPeerPort (arg1);
 }
@@ -352,7 +352,7 @@ static void _call_f_setProtocolTag_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxyQuery *)cls)->setProtocolTag (arg1);
 }
@@ -372,7 +372,7 @@ static void _call_f_setQueryType_3411 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & arg1 = args.read<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & > (heap);
+  const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QNetworkProxyQuery::QueryType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxyQuery *)cls)->setQueryType (qt_gsi::QtToCppAdaptor<QNetworkProxyQuery::QueryType>(arg1).cref());
 }
@@ -392,7 +392,7 @@ static void _call_f_setUrl_1701 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkProxyQuery *)cls)->setUrl (arg1);
 }

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkReply.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkReply.cc
@@ -87,7 +87,7 @@ static void _call_f_attribute_c3072 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & arg1 = args.read<const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & > (heap);
+  const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QNetworkReply *)cls)->attribute (qt_gsi::QtToCppAdaptor<QNetworkRequest::Attribute>(arg1).cref()));
 }
 
@@ -137,7 +137,7 @@ static void _call_f_hasRawHeader_c2309 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkReply *)cls)->hasRawHeader (arg1));
 }
 
@@ -156,7 +156,7 @@ static void _call_f_header_c3349 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & arg1 = args.read<const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & > (heap);
+  const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QNetworkReply *)cls)->header (qt_gsi::QtToCppAdaptor<QNetworkRequest::KnownHeaders>(arg1).cref()));
 }
 
@@ -175,7 +175,7 @@ static void _call_f_ignoreSslErrors_2837 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslError> &arg1 = args.read<const QList<QSslError> & > (heap);
+  const QList<QSslError> &arg1 = gsi::arg_reader<const QList<QSslError> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkReply *)cls)->ignoreSslErrors (arg1);
 }
@@ -286,7 +286,7 @@ static void _call_f_rawHeader_c2309 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QNetworkReply *)cls)->rawHeader (arg1));
 }
 
@@ -350,7 +350,7 @@ static void _call_f_setReadBufferSize_986 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkReply *)cls)->setReadBufferSize (arg1);
 }
@@ -370,7 +370,7 @@ static void _call_f_setSslConfiguration_3068 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslConfiguration &arg1 = args.read<const QSslConfiguration & > (heap);
+  const QSslConfiguration &arg1 = gsi::arg_reader<const QSslConfiguration & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkReply *)cls)->setSslConfiguration (arg1);
 }
@@ -422,8 +422,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QNetworkReply::tr (arg1, arg2));
 }
 
@@ -446,9 +446,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QNetworkReply::tr (arg1, arg2, arg3));
 }
 
@@ -469,8 +469,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QNetworkReply::trUtf8 (arg1, arg2));
 }
 
@@ -493,9 +493,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QNetworkReply::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkRequest.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQNetworkRequest.cc
@@ -53,7 +53,7 @@ static void _call_ctor_QNetworkRequest_1701 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args ? args.read<const QUrl & > (heap) : (const QUrl &)(QUrl());
+  const QUrl &arg1 = args ? gsi::arg_reader<const QUrl & >() (args, heap) : gsi::arg_maker<const QUrl & >() (QUrl(), heap);
   ret.write<QNetworkRequest *> (new QNetworkRequest (arg1));
 }
 
@@ -72,7 +72,7 @@ static void _call_ctor_QNetworkRequest_2885 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
   ret.write<QNetworkRequest *> (new QNetworkRequest (arg1));
 }
 
@@ -93,8 +93,8 @@ static void _call_f_attribute_c5083 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & arg1 = args.read<const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & > (heap);
-  const QVariant &arg2 = args ? args.read<const QVariant & > (heap) : (const QVariant &)(QVariant());
+  const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & >() (args, heap);
+  const QVariant &arg2 = args ? gsi::arg_reader<const QVariant & >() (args, heap) : gsi::arg_maker<const QVariant & >() (QVariant(), heap);
   ret.write<QVariant > ((QVariant)((QNetworkRequest *)cls)->attribute (qt_gsi::QtToCppAdaptor<QNetworkRequest::Attribute>(arg1).cref(), arg2));
 }
 
@@ -113,7 +113,7 @@ static void _call_f_hasRawHeader_c2309 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkRequest *)cls)->hasRawHeader (arg1));
 }
 
@@ -132,7 +132,7 @@ static void _call_f_header_c3349 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & arg1 = args.read<const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & > (heap);
+  const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QNetworkRequest *)cls)->header (qt_gsi::QtToCppAdaptor<QNetworkRequest::KnownHeaders>(arg1).cref()));
 }
 
@@ -151,7 +151,7 @@ static void _call_f_operator_excl__eq__c2885 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkRequest *)cls)->operator!= (arg1));
 }
 
@@ -170,7 +170,7 @@ static void _call_f_operator_eq__2885 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
   ret.write<QNetworkRequest & > ((QNetworkRequest &)((QNetworkRequest *)cls)->operator= (arg1));
 }
 
@@ -189,7 +189,7 @@ static void _call_f_operator_eq__eq__c2885 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkRequest &arg1 = args.read<const QNetworkRequest & > (heap);
+  const QNetworkRequest &arg1 = gsi::arg_reader<const QNetworkRequest & >() (args, heap);
   ret.write<bool > ((bool)((QNetworkRequest *)cls)->operator== (arg1));
 }
 
@@ -223,7 +223,7 @@ static void _call_f_rawHeader_c2309 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QByteArray > ((QByteArray)((QNetworkRequest *)cls)->rawHeader (arg1));
 }
 
@@ -259,8 +259,8 @@ static void _call_f_setAttribute_5083 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & arg1 = args.read<const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QNetworkRequest::Attribute>::target_type & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkRequest *)cls)->setAttribute (qt_gsi::QtToCppAdaptor<QNetworkRequest::Attribute>(arg1).cref(), arg2);
 }
@@ -282,8 +282,8 @@ static void _call_f_setHeader_5360 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & arg1 = args.read<const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QNetworkRequest::KnownHeaders>::target_type & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkRequest *)cls)->setHeader (qt_gsi::QtToCppAdaptor<QNetworkRequest::KnownHeaders>(arg1).cref(), arg2);
 }
@@ -303,7 +303,7 @@ static void _call_f_setOriginatingObject_1302 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args.read<QObject * > (heap);
+  QObject *arg1 = gsi::arg_reader<QObject * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkRequest *)cls)->setOriginatingObject (arg1);
 }
@@ -325,8 +325,8 @@ static void _call_f_setRawHeader_4510 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const QByteArray &arg2 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const QByteArray &arg2 = gsi::arg_reader<const QByteArray & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkRequest *)cls)->setRawHeader (arg1, arg2);
 }
@@ -346,7 +346,7 @@ static void _call_f_setSslConfiguration_3068 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslConfiguration &arg1 = args.read<const QSslConfiguration & > (heap);
+  const QSslConfiguration &arg1 = gsi::arg_reader<const QSslConfiguration & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkRequest *)cls)->setSslConfiguration (arg1);
 }
@@ -366,7 +366,7 @@ static void _call_f_setUrl_1701 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrl &arg1 = args.read<const QUrl & > (heap);
+  const QUrl &arg1 = gsi::arg_reader<const QUrl & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QNetworkRequest *)cls)->setUrl (arg1);
 }

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQSslCertificate.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQSslCertificate.cc
@@ -55,8 +55,8 @@ static void _call_ctor_QSslCertificate_3702 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
   ret.write<QSslCertificate *> (new QSslCertificate (arg1, qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg2).cref()));
 }
 
@@ -77,8 +77,8 @@ static void _call_ctor_QSslCertificate_4564 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
+  const QByteArray &arg1 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
   ret.write<QSslCertificate *> (new QSslCertificate (arg1, qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg2).cref()));
 }
 
@@ -97,7 +97,7 @@ static void _call_ctor_QSslCertificate_2823 (const qt_gsi::GenericStaticMethod *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCertificate &arg1 = args.read<const QSslCertificate & > (heap);
+  const QSslCertificate &arg1 = gsi::arg_reader<const QSslCertificate & >() (args, heap);
   ret.write<QSslCertificate *> (new QSslCertificate (arg1));
 }
 
@@ -132,7 +132,7 @@ static void _call_f_digest_c3331 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & > (heap) : (const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type &)(qt_gsi::CppToQtReadAdaptor<QCryptographicHash::Algorithm>(heap, QCryptographicHash::Md5));
+  const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QCryptographicHash::Algorithm>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QCryptographicHash::Algorithm>(heap, QCryptographicHash::Md5), heap);
   ret.write<QByteArray > ((QByteArray)((QSslCertificate *)cls)->digest (qt_gsi::QtToCppAdaptor<QCryptographicHash::Algorithm>(arg1).cref()));
 }
 
@@ -226,7 +226,7 @@ static void _call_f_issuerInfo_c3178 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSslCertificate::SubjectInfo>::target_type & arg1 = args.read<const qt_gsi::Converter<QSslCertificate::SubjectInfo>::target_type & > (heap);
+  const qt_gsi::Converter<QSslCertificate::SubjectInfo>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSslCertificate::SubjectInfo>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QSslCertificate *)cls)->issuerInfo (qt_gsi::QtToCppAdaptor<QSslCertificate::SubjectInfo>(arg1).cref()));
 }
 
@@ -245,7 +245,7 @@ static void _call_f_issuerInfo_c2309 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QString > ((QString)((QSslCertificate *)cls)->issuerInfo (arg1));
 }
 
@@ -264,7 +264,7 @@ static void _call_f_operator_excl__eq__c2823 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCertificate &arg1 = args.read<const QSslCertificate & > (heap);
+  const QSslCertificate &arg1 = gsi::arg_reader<const QSslCertificate & >() (args, heap);
   ret.write<bool > ((bool)((QSslCertificate *)cls)->operator!= (arg1));
 }
 
@@ -283,7 +283,7 @@ static void _call_f_operator_eq__2823 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCertificate &arg1 = args.read<const QSslCertificate & > (heap);
+  const QSslCertificate &arg1 = gsi::arg_reader<const QSslCertificate & >() (args, heap);
   ret.write<QSslCertificate & > ((QSslCertificate &)((QSslCertificate *)cls)->operator= (arg1));
 }
 
@@ -302,7 +302,7 @@ static void _call_f_operator_eq__eq__c2823 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCertificate &arg1 = args.read<const QSslCertificate & > (heap);
+  const QSslCertificate &arg1 = gsi::arg_reader<const QSslCertificate & >() (args, heap);
   ret.write<bool > ((bool)((QSslCertificate *)cls)->operator== (arg1));
 }
 
@@ -351,7 +351,7 @@ static void _call_f_subjectInfo_c3178 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSslCertificate::SubjectInfo>::target_type & arg1 = args.read<const qt_gsi::Converter<QSslCertificate::SubjectInfo>::target_type & > (heap);
+  const qt_gsi::Converter<QSslCertificate::SubjectInfo>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSslCertificate::SubjectInfo>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QSslCertificate *)cls)->subjectInfo (qt_gsi::QtToCppAdaptor<QSslCertificate::SubjectInfo>(arg1).cref()));
 }
 
@@ -370,7 +370,7 @@ static void _call_f_subjectInfo_c2309 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
   ret.write<QString > ((QString)((QSslCertificate *)cls)->subjectInfo (arg1));
 }
 
@@ -436,8 +436,8 @@ static void _call_f_fromData_4564 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
   ret.write<QList<QSslCertificate> > ((QList<QSslCertificate>)QSslCertificate::fromData (arg1, qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg2).cref()));
 }
 
@@ -458,8 +458,8 @@ static void _call_f_fromDevice_3702 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
   ret.write<QList<QSslCertificate> > ((QList<QSslCertificate>)QSslCertificate::fromDevice (arg1, qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg2).cref()));
 }
 
@@ -482,9 +482,9 @@ static void _call_f_fromPath_6773 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
-  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & > (heap) : (const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type &)(qt_gsi::CppToQtReadAdaptor<QRegExp::PatternSyntax>(heap, QRegExp::FixedString));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
+  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QRegExp::PatternSyntax>(heap, QRegExp::FixedString), heap);
   ret.write<QList<QSslCertificate> > ((QList<QSslCertificate>)QSslCertificate::fromPath (arg1, qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg2).cref(), qt_gsi::QtToCppAdaptor<QRegExp::PatternSyntax>(arg3).cref()));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQSslCipher.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQSslCipher.cc
@@ -67,8 +67,8 @@ static void _call_ctor_QSslCipher_4012 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSsl::SslProtocol>::target_type & arg2 = args.read<const qt_gsi::Converter<QSsl::SslProtocol>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSsl::SslProtocol>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSsl::SslProtocol>::target_type & >() (args, heap);
   ret.write<QSslCipher *> (new QSslCipher (arg1, qt_gsi::QtToCppAdaptor<QSsl::SslProtocol>(arg2).cref()));
 }
 
@@ -87,7 +87,7 @@ static void _call_ctor_QSslCipher_2303 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCipher &arg1 = args.read<const QSslCipher & > (heap);
+  const QSslCipher &arg1 = gsi::arg_reader<const QSslCipher & >() (args, heap);
   ret.write<QSslCipher *> (new QSslCipher (arg1));
 }
 
@@ -181,7 +181,7 @@ static void _call_f_operator_excl__eq__c2303 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCipher &arg1 = args.read<const QSslCipher & > (heap);
+  const QSslCipher &arg1 = gsi::arg_reader<const QSslCipher & >() (args, heap);
   ret.write<bool > ((bool)((QSslCipher *)cls)->operator!= (arg1));
 }
 
@@ -200,7 +200,7 @@ static void _call_f_operator_eq__2303 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCipher &arg1 = args.read<const QSslCipher & > (heap);
+  const QSslCipher &arg1 = gsi::arg_reader<const QSslCipher & >() (args, heap);
   ret.write<QSslCipher & > ((QSslCipher &)((QSslCipher *)cls)->operator= (arg1));
 }
 
@@ -219,7 +219,7 @@ static void _call_f_operator_eq__eq__c2303 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCipher &arg1 = args.read<const QSslCipher & > (heap);
+  const QSslCipher &arg1 = gsi::arg_reader<const QSslCipher & >() (args, heap);
   ret.write<bool > ((bool)((QSslCipher *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQSslConfiguration.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQSslConfiguration.cc
@@ -68,7 +68,7 @@ static void _call_ctor_QSslConfiguration_3068 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslConfiguration &arg1 = args.read<const QSslConfiguration & > (heap);
+  const QSslConfiguration &arg1 = gsi::arg_reader<const QSslConfiguration & >() (args, heap);
   ret.write<QSslConfiguration *> (new QSslConfiguration (arg1));
 }
 
@@ -147,7 +147,7 @@ static void _call_f_operator_excl__eq__c3068 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslConfiguration &arg1 = args.read<const QSslConfiguration & > (heap);
+  const QSslConfiguration &arg1 = gsi::arg_reader<const QSslConfiguration & >() (args, heap);
   ret.write<bool > ((bool)((QSslConfiguration *)cls)->operator!= (arg1));
 }
 
@@ -166,7 +166,7 @@ static void _call_f_operator_eq__3068 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslConfiguration &arg1 = args.read<const QSslConfiguration & > (heap);
+  const QSslConfiguration &arg1 = gsi::arg_reader<const QSslConfiguration & >() (args, heap);
   ret.write<QSslConfiguration & > ((QSslConfiguration &)((QSslConfiguration *)cls)->operator= (arg1));
 }
 
@@ -185,7 +185,7 @@ static void _call_f_operator_eq__eq__c3068 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslConfiguration &arg1 = args.read<const QSslConfiguration & > (heap);
+  const QSslConfiguration &arg1 = gsi::arg_reader<const QSslConfiguration & >() (args, heap);
   ret.write<bool > ((bool)((QSslConfiguration *)cls)->operator== (arg1));
 }
 
@@ -309,7 +309,7 @@ static void _call_f_setCaCertificates_3438 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslCertificate> &arg1 = args.read<const QList<QSslCertificate> & > (heap);
+  const QList<QSslCertificate> &arg1 = gsi::arg_reader<const QList<QSslCertificate> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslConfiguration *)cls)->setCaCertificates (arg1);
 }
@@ -329,7 +329,7 @@ static void _call_f_setCiphers_2918 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslCipher> &arg1 = args.read<const QList<QSslCipher> & > (heap);
+  const QList<QSslCipher> &arg1 = gsi::arg_reader<const QList<QSslCipher> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslConfiguration *)cls)->setCiphers (arg1);
 }
@@ -349,7 +349,7 @@ static void _call_f_setLocalCertificate_2823 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCertificate &arg1 = args.read<const QSslCertificate & > (heap);
+  const QSslCertificate &arg1 = gsi::arg_reader<const QSslCertificate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslConfiguration *)cls)->setLocalCertificate (arg1);
 }
@@ -369,7 +369,7 @@ static void _call_f_setPeerVerifyDepth_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslConfiguration *)cls)->setPeerVerifyDepth (arg1);
 }
@@ -389,7 +389,7 @@ static void _call_f_setPeerVerifyMode_2970 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSslSocket::PeerVerifyMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QSslSocket::PeerVerifyMode>::target_type & > (heap);
+  const qt_gsi::Converter<QSslSocket::PeerVerifyMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSslSocket::PeerVerifyMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslConfiguration *)cls)->setPeerVerifyMode (qt_gsi::QtToCppAdaptor<QSslSocket::PeerVerifyMode>(arg1).cref());
 }
@@ -409,7 +409,7 @@ static void _call_f_setPrivateKey_1997 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslKey &arg1 = args.read<const QSslKey & > (heap);
+  const QSslKey &arg1 = gsi::arg_reader<const QSslKey & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslConfiguration *)cls)->setPrivateKey (arg1);
 }
@@ -429,7 +429,7 @@ static void _call_f_setProtocol_2095 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSsl::SslProtocol>::target_type & arg1 = args.read<const qt_gsi::Converter<QSsl::SslProtocol>::target_type & > (heap);
+  const qt_gsi::Converter<QSsl::SslProtocol>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSsl::SslProtocol>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslConfiguration *)cls)->setProtocol (qt_gsi::QtToCppAdaptor<QSsl::SslProtocol>(arg1).cref());
 }
@@ -464,7 +464,7 @@ static void _call_f_setDefaultConfiguration_3068 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslConfiguration &arg1 = args.read<const QSslConfiguration & > (heap);
+  const QSslConfiguration &arg1 = gsi::arg_reader<const QSslConfiguration & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSslConfiguration::setDefaultConfiguration (arg1);
 }

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQSslError.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQSslError.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QSslError_2289 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSslError::SslError>::target_type & arg1 = args.read<const qt_gsi::Converter<QSslError::SslError>::target_type & > (heap);
+  const qt_gsi::Converter<QSslError::SslError>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSslError::SslError>::target_type & >() (args, heap);
   ret.write<QSslError *> (new QSslError (qt_gsi::QtToCppAdaptor<QSslError::SslError>(arg1).cref()));
 }
 
@@ -87,8 +87,8 @@ static void _call_ctor_QSslError_5004 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSslError::SslError>::target_type & arg1 = args.read<const qt_gsi::Converter<QSslError::SslError>::target_type & > (heap);
-  const QSslCertificate &arg2 = args.read<const QSslCertificate & > (heap);
+  const qt_gsi::Converter<QSslError::SslError>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSslError::SslError>::target_type & >() (args, heap);
+  const QSslCertificate &arg2 = gsi::arg_reader<const QSslCertificate & >() (args, heap);
   ret.write<QSslError *> (new QSslError (qt_gsi::QtToCppAdaptor<QSslError::SslError>(arg1).cref(), arg2));
 }
 
@@ -107,7 +107,7 @@ static void _call_ctor_QSslError_2222 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslError &arg1 = args.read<const QSslError & > (heap);
+  const QSslError &arg1 = gsi::arg_reader<const QSslError & >() (args, heap);
   ret.write<QSslError *> (new QSslError (arg1));
 }
 
@@ -171,7 +171,7 @@ static void _call_f_operator_excl__eq__c2222 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslError &arg1 = args.read<const QSslError & > (heap);
+  const QSslError &arg1 = gsi::arg_reader<const QSslError & >() (args, heap);
   ret.write<bool > ((bool)((QSslError *)cls)->operator!= (arg1));
 }
 
@@ -190,7 +190,7 @@ static void _call_f_operator_eq__2222 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslError &arg1 = args.read<const QSslError & > (heap);
+  const QSslError &arg1 = gsi::arg_reader<const QSslError & >() (args, heap);
   ret.write<QSslError & > ((QSslError &)((QSslError *)cls)->operator= (arg1));
 }
 
@@ -209,7 +209,7 @@ static void _call_f_operator_eq__eq__c2222 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslError &arg1 = args.read<const QSslError & > (heap);
+  const QSslError &arg1 = gsi::arg_reader<const QSslError & >() (args, heap);
   ret.write<bool > ((bool)((QSslError *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQSslKey.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQSslKey.cc
@@ -74,11 +74,11 @@ static void _call_ctor_QSslKey_10374 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & arg2 = args.read<const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & > (heap);
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
-  const qt_gsi::Converter<QSsl::KeyType>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QSsl::KeyType>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::KeyType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::KeyType>(heap, QSsl::PrivateKey));
-  const QByteArray &arg5 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
+  const qt_gsi::Converter<QSsl::KeyType>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::KeyType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::KeyType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::KeyType>(heap, QSsl::PrivateKey), heap);
+  const QByteArray &arg5 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QSslKey *> (new QSslKey (arg1, qt_gsi::QtToCppAdaptor<QSsl::KeyAlgorithm>(arg2).cref(), qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg3).cref(), qt_gsi::QtToCppAdaptor<QSsl::KeyType>(arg4).cref(), arg5));
 }
 
@@ -105,11 +105,11 @@ static void _call_ctor_QSslKey_9512 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & arg2 = args.read<const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & > (heap);
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
-  const qt_gsi::Converter<QSsl::KeyType>::target_type & arg4 = args ? args.read<const qt_gsi::Converter<QSsl::KeyType>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::KeyType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::KeyType>(heap, QSsl::PrivateKey));
-  const QByteArray &arg5 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & >() (args, heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
+  const qt_gsi::Converter<QSsl::KeyType>::target_type & arg4 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::KeyType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::KeyType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::KeyType>(heap, QSsl::PrivateKey), heap);
+  const QByteArray &arg5 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QSslKey *> (new QSslKey (arg1, qt_gsi::QtToCppAdaptor<QSsl::KeyAlgorithm>(arg2).cref(), qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg3).cref(), qt_gsi::QtToCppAdaptor<QSsl::KeyType>(arg4).cref(), arg5));
 }
 
@@ -128,7 +128,7 @@ static void _call_ctor_QSslKey_1997 (const qt_gsi::GenericStaticMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslKey &arg1 = args.read<const QSslKey & > (heap);
+  const QSslKey &arg1 = gsi::arg_reader<const QSslKey & >() (args, heap);
   ret.write<QSslKey *> (new QSslKey (arg1));
 }
 
@@ -223,7 +223,7 @@ static void _call_f_operator_excl__eq__c1997 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslKey &arg1 = args.read<const QSslKey & > (heap);
+  const QSslKey &arg1 = gsi::arg_reader<const QSslKey & >() (args, heap);
   ret.write<bool > ((bool)((QSslKey *)cls)->operator!= (arg1));
 }
 
@@ -242,7 +242,7 @@ static void _call_f_operator_eq__1997 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslKey &arg1 = args.read<const QSslKey & > (heap);
+  const QSslKey &arg1 = gsi::arg_reader<const QSslKey & >() (args, heap);
   ret.write<QSslKey & > ((QSslKey &)((QSslKey *)cls)->operator= (arg1));
 }
 
@@ -261,7 +261,7 @@ static void _call_f_operator_eq__eq__c1997 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslKey &arg1 = args.read<const QSslKey & > (heap);
+  const QSslKey &arg1 = gsi::arg_reader<const QSslKey & >() (args, heap);
   ret.write<bool > ((bool)((QSslKey *)cls)->operator== (arg1));
 }
 
@@ -280,7 +280,7 @@ static void _call_f_toDer_c2309 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QByteArray &arg1 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QByteArray > ((QByteArray)((QSslKey *)cls)->toDer (arg1));
 }
 
@@ -299,7 +299,7 @@ static void _call_f_toPem_c2309 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QByteArray &arg1 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   ret.write<QByteArray > ((QByteArray)((QSslKey *)cls)->toPem (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQSslSocket.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQSslSocket.cc
@@ -74,7 +74,7 @@ static void _call_ctor_QSslSocket_1302 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSslSocket *> (new QSslSocket (arg1));
 }
 
@@ -109,7 +109,7 @@ static void _call_f_addCaCertificate_2823 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCertificate &arg1 = args.read<const QSslCertificate & > (heap);
+  const QSslCertificate &arg1 = gsi::arg_reader<const QSslCertificate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->addCaCertificate (arg1);
 }
@@ -133,9 +133,9 @@ static void _call_f_addCaCertificates_6773 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
-  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & > (heap) : (const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type &)(qt_gsi::CppToQtReadAdaptor<QRegExp::PatternSyntax>(heap, QRegExp::FixedString));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
+  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QRegExp::PatternSyntax>(heap, QRegExp::FixedString), heap);
   ret.write<bool > ((bool)((QSslSocket *)cls)->addCaCertificates (arg1, qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg2).cref(), qt_gsi::QtToCppAdaptor<QRegExp::PatternSyntax>(arg3).cref()));
 }
 
@@ -154,7 +154,7 @@ static void _call_f_addCaCertificates_3438 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslCertificate> &arg1 = args.read<const QList<QSslCertificate> & > (heap);
+  const QList<QSslCertificate> &arg1 = gsi::arg_reader<const QList<QSslCertificate> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->addCaCertificates (arg1);
 }
@@ -284,9 +284,9 @@ static void _call_f_connectToHostEncrypted_6151 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  quint16 arg2 = args.read<quint16 > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg3 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  quint16 arg2 = gsi::arg_reader<quint16 >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg3 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->connectToHostEncrypted (arg1, arg2, arg3);
 }
@@ -312,10 +312,10 @@ static void _call_f_connectToHostEncrypted_8068 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  quint16 arg2 = args.read<quint16 > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  QFlags<QIODevice::OpenModeFlag> arg4 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  quint16 arg2 = gsi::arg_reader<quint16 >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  QFlags<QIODevice::OpenModeFlag> arg4 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->connectToHostEncrypted (arg1, arg2, arg3, arg4);
 }
@@ -380,7 +380,7 @@ static void _call_f_ignoreSslErrors_2837 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslError> &arg1 = args.read<const QList<QSslError> & > (heap);
+  const QList<QSslError> &arg1 = gsi::arg_reader<const QList<QSslError> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->ignoreSslErrors (arg1);
 }
@@ -566,7 +566,7 @@ static void _call_f_setCaCertificates_3438 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslCertificate> &arg1 = args.read<const QList<QSslCertificate> & > (heap);
+  const QList<QSslCertificate> &arg1 = gsi::arg_reader<const QList<QSslCertificate> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setCaCertificates (arg1);
 }
@@ -586,7 +586,7 @@ static void _call_f_setCiphers_2918 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslCipher> &arg1 = args.read<const QList<QSslCipher> & > (heap);
+  const QList<QSslCipher> &arg1 = gsi::arg_reader<const QList<QSslCipher> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setCiphers (arg1);
 }
@@ -606,7 +606,7 @@ static void _call_f_setCiphers_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setCiphers (arg1);
 }
@@ -626,7 +626,7 @@ static void _call_f_setLocalCertificate_2823 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCertificate &arg1 = args.read<const QSslCertificate & > (heap);
+  const QSslCertificate &arg1 = gsi::arg_reader<const QSslCertificate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setLocalCertificate (arg1);
 }
@@ -648,8 +648,8 @@ static void _call_f_setLocalCertificate_4280 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setLocalCertificate (arg1, qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg2).cref());
 }
@@ -669,7 +669,7 @@ static void _call_f_setPeerVerifyDepth_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setPeerVerifyDepth (arg1);
 }
@@ -689,7 +689,7 @@ static void _call_f_setPeerVerifyMode_2970 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSslSocket::PeerVerifyMode>::target_type & arg1 = args.read<const qt_gsi::Converter<QSslSocket::PeerVerifyMode>::target_type & > (heap);
+  const qt_gsi::Converter<QSslSocket::PeerVerifyMode>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSslSocket::PeerVerifyMode>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setPeerVerifyMode (qt_gsi::QtToCppAdaptor<QSslSocket::PeerVerifyMode>(arg1).cref());
 }
@@ -709,7 +709,7 @@ static void _call_f_setPrivateKey_1997 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslKey &arg1 = args.read<const QSslKey & > (heap);
+  const QSslKey &arg1 = gsi::arg_reader<const QSslKey & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setPrivateKey (arg1);
 }
@@ -735,10 +735,10 @@ static void _call_f_setPrivateKey_8544 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::KeyAlgorithm>(heap, QSsl::Rsa));
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
-  const QByteArray &arg4 = args ? args.read<const QByteArray & > (heap) : (const QByteArray &)(QByteArray());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::KeyAlgorithm>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::KeyAlgorithm>(heap, QSsl::Rsa), heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
+  const QByteArray &arg4 = args ? gsi::arg_reader<const QByteArray & >() (args, heap) : gsi::arg_maker<const QByteArray & >() (QByteArray(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setPrivateKey (arg1, qt_gsi::QtToCppAdaptor<QSsl::KeyAlgorithm>(arg2).cref(), qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg3).cref(), arg4);
 }
@@ -758,7 +758,7 @@ static void _call_f_setProtocol_2095 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSsl::SslProtocol>::target_type & arg1 = args.read<const qt_gsi::Converter<QSsl::SslProtocol>::target_type & > (heap);
+  const qt_gsi::Converter<QSsl::SslProtocol>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSsl::SslProtocol>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setProtocol (qt_gsi::QtToCppAdaptor<QSsl::SslProtocol>(arg1).cref());
 }
@@ -778,7 +778,7 @@ static void _call_f_setReadBufferSize_986 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setReadBufferSize (arg1);
 }
@@ -802,9 +802,9 @@ static void _call_f_setSocketDescriptor_6993 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & > (heap) : (const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type &)(qt_gsi::CppToQtReadAdaptor<QAbstractSocket::SocketState>(heap, QAbstractSocket::ConnectedState));
-  QFlags<QIODevice::OpenModeFlag> arg3 = args ? args.read<QFlags<QIODevice::OpenModeFlag> > (heap) : (QFlags<QIODevice::OpenModeFlag>)(QIODevice::ReadWrite);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QAbstractSocket::SocketState>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QAbstractSocket::SocketState>(heap, QAbstractSocket::ConnectedState), heap);
+  QFlags<QIODevice::OpenModeFlag> arg3 = args ? gsi::arg_reader<QFlags<QIODevice::OpenModeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QIODevice::OpenModeFlag> >() (QIODevice::ReadWrite, heap);
   ret.write<bool > ((bool)((QSslSocket *)cls)->setSocketDescriptor (arg1, qt_gsi::QtToCppAdaptor<QAbstractSocket::SocketState>(arg2).cref(), arg3));
 }
 
@@ -825,8 +825,8 @@ static void _call_f_setSocketOption_5331 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setSocketOption (qt_gsi::QtToCppAdaptor<QAbstractSocket::SocketOption>(arg1).cref(), arg2);
 }
@@ -846,7 +846,7 @@ static void _call_f_setSslConfiguration_3068 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslConfiguration &arg1 = args.read<const QSslConfiguration & > (heap);
+  const QSslConfiguration &arg1 = gsi::arg_reader<const QSslConfiguration & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSslSocket *)cls)->setSslConfiguration (arg1);
 }
@@ -866,7 +866,7 @@ static void _call_f_socketOption_3320 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & arg1 = args.read<const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & > (heap);
+  const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QAbstractSocket::SocketOption>::target_type & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QSslSocket *)cls)->socketOption (qt_gsi::QtToCppAdaptor<QAbstractSocket::SocketOption>(arg1).cref()));
 }
 
@@ -947,7 +947,7 @@ static void _call_f_waitForBytesWritten_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QSslSocket *)cls)->waitForBytesWritten (arg1));
 }
 
@@ -966,7 +966,7 @@ static void _call_f_waitForConnected_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QSslSocket *)cls)->waitForConnected (arg1));
 }
 
@@ -985,7 +985,7 @@ static void _call_f_waitForDisconnected_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QSslSocket *)cls)->waitForDisconnected (arg1));
 }
 
@@ -1004,7 +1004,7 @@ static void _call_f_waitForEncrypted_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QSslSocket *)cls)->waitForEncrypted (arg1));
 }
 
@@ -1023,7 +1023,7 @@ static void _call_f_waitForReadyRead_767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(30000);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (30000, heap);
   ret.write<bool > ((bool)((QSslSocket *)cls)->waitForReadyRead (arg1));
 }
 
@@ -1042,7 +1042,7 @@ static void _call_f_addDefaultCaCertificate_2823 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSslCertificate &arg1 = args.read<const QSslCertificate & > (heap);
+  const QSslCertificate &arg1 = gsi::arg_reader<const QSslCertificate & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSslSocket::addDefaultCaCertificate (arg1);
 }
@@ -1066,9 +1066,9 @@ static void _call_f_addDefaultCaCertificates_6773 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & > (heap) : (const qt_gsi::Converter<QSsl::EncodingFormat>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem));
-  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & > (heap) : (const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type &)(qt_gsi::CppToQtReadAdaptor<QRegExp::PatternSyntax>(heap, QRegExp::FixedString));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSsl::EncodingFormat>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSsl::EncodingFormat>(heap, QSsl::Pem), heap);
+  const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QRegExp::PatternSyntax>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QRegExp::PatternSyntax>(heap, QRegExp::FixedString), heap);
   ret.write<bool > ((bool)QSslSocket::addDefaultCaCertificates (arg1, qt_gsi::QtToCppAdaptor<QSsl::EncodingFormat>(arg2).cref(), qt_gsi::QtToCppAdaptor<QRegExp::PatternSyntax>(arg3).cref()));
 }
 
@@ -1087,7 +1087,7 @@ static void _call_f_addDefaultCaCertificates_3438 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslCertificate> &arg1 = args.read<const QList<QSslCertificate> & > (heap);
+  const QList<QSslCertificate> &arg1 = gsi::arg_reader<const QList<QSslCertificate> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSslSocket::addDefaultCaCertificates (arg1);
 }
@@ -1137,7 +1137,7 @@ static void _call_f_setDefaultCaCertificates_3438 (const qt_gsi::GenericStaticMe
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslCertificate> &arg1 = args.read<const QList<QSslCertificate> & > (heap);
+  const QList<QSslCertificate> &arg1 = gsi::arg_reader<const QList<QSslCertificate> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSslSocket::setDefaultCaCertificates (arg1);
 }
@@ -1157,7 +1157,7 @@ static void _call_f_setDefaultCiphers_2918 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QSslCipher> &arg1 = args.read<const QList<QSslCipher> & > (heap);
+  const QList<QSslCipher> &arg1 = gsi::arg_reader<const QList<QSslCipher> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSslSocket::setDefaultCiphers (arg1);
 }
@@ -1224,8 +1224,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSslSocket::tr (arg1, arg2));
 }
 
@@ -1248,9 +1248,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSslSocket::tr (arg1, arg2, arg3));
 }
 
@@ -1271,8 +1271,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSslSocket::trUtf8 (arg1, arg2));
 }
 
@@ -1295,9 +1295,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSslSocket::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQTcpServer.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQTcpServer.cc
@@ -134,8 +134,8 @@ static void _call_f_listen_3510 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args ? args.read<const QHostAddress & > (heap) : (const QHostAddress &)(QHostAddress::Any);
-  quint16 arg2 = args ? args.read<quint16 > (heap) : (quint16)(0);
+  const QHostAddress &arg1 = args ? gsi::arg_reader<const QHostAddress & >() (args, heap) : gsi::arg_maker<const QHostAddress & >() (QHostAddress::Any, heap);
+  quint16 arg2 = args ? gsi::arg_reader<quint16 >() (args, heap) : gsi::arg_maker<quint16 >() (0, heap);
   ret.write<bool > ((bool)((QTcpServer *)cls)->listen (arg1, arg2));
 }
 
@@ -244,7 +244,7 @@ static void _call_f_setMaxPendingConnections_767 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTcpServer *)cls)->setMaxPendingConnections (arg1);
 }
@@ -264,7 +264,7 @@ static void _call_f_setProxy_2686 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QNetworkProxy &arg1 = args.read<const QNetworkProxy & > (heap);
+  const QNetworkProxy &arg1 = gsi::arg_reader<const QNetworkProxy & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QTcpServer *)cls)->setProxy (arg1);
 }
@@ -284,7 +284,7 @@ static void _call_f_setSocketDescriptor_767 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QTcpServer *)cls)->setSocketDescriptor (arg1));
 }
 
@@ -320,8 +320,8 @@ static void _call_f_waitForNewConnection_1709 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(0);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (0, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<bool > ((bool)((QTcpServer *)cls)->waitForNewConnection (arg1, arg2));
 }
 
@@ -342,8 +342,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTcpServer::tr (arg1, arg2));
 }
 
@@ -366,9 +366,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTcpServer::tr (arg1, arg2, arg3));
 }
 
@@ -389,8 +389,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTcpServer::trUtf8 (arg1, arg2));
 }
 
@@ -413,9 +413,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTcpServer::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -663,7 +663,7 @@ static void _call_ctor_QTcpServer_Adaptor_1302 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTcpServer_Adaptor *> (new QTcpServer_Adaptor (arg1));
 }
 
@@ -729,7 +729,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QTcpServer_Adaptor *)cls)->emitter_QTcpServer_destroyed_1302 (arg1);
 }
 
@@ -896,7 +896,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QTcpServer_Adaptor *)cls)->fp_QTcpServer_receivers_c1731 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQTcpSocket.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQTcpSocket.cc
@@ -69,7 +69,7 @@ static void _call_ctor_QTcpSocket_1302 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QTcpSocket *> (new QTcpSocket (arg1));
 }
 
@@ -90,8 +90,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTcpSocket::tr (arg1, arg2));
 }
 
@@ -114,9 +114,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTcpSocket::tr (arg1, arg2, arg3));
 }
 
@@ -137,8 +137,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QTcpSocket::trUtf8 (arg1, arg2));
 }
 
@@ -161,9 +161,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QTcpSocket::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQUdpSocket.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQUdpSocket.cc
@@ -69,7 +69,7 @@ static void _call_ctor_QUdpSocket_1302 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QUdpSocket *> (new QUdpSocket (arg1));
 }
 
@@ -90,8 +90,8 @@ static void _call_f_bind_3510 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
-  quint16 arg2 = args.read<quint16 > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
+  quint16 arg2 = gsi::arg_reader<quint16 >() (args, heap);
   ret.write<bool > ((bool)((QUdpSocket *)cls)->bind (arg1, arg2));
 }
 
@@ -110,7 +110,7 @@ static void _call_f_bind_1100 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  quint16 arg1 = args ? args.read<quint16 > (heap) : (quint16)(0);
+  quint16 arg1 = args ? gsi::arg_reader<quint16 >() (args, heap) : gsi::arg_maker<quint16 >() (0, heap);
   ret.write<bool > ((bool)((QUdpSocket *)cls)->bind (arg1));
 }
 
@@ -133,9 +133,9 @@ static void _call_f_bind_6404 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHostAddress &arg1 = args.read<const QHostAddress & > (heap);
-  quint16 arg2 = args.read<quint16 > (heap);
-  QFlags<QUdpSocket::BindFlag> arg3 = args.read<QFlags<QUdpSocket::BindFlag> > (heap);
+  const QHostAddress &arg1 = gsi::arg_reader<const QHostAddress & >() (args, heap);
+  quint16 arg2 = gsi::arg_reader<quint16 >() (args, heap);
+  QFlags<QUdpSocket::BindFlag> arg3 = gsi::arg_reader<QFlags<QUdpSocket::BindFlag> >() (args, heap);
   ret.write<bool > ((bool)((QUdpSocket *)cls)->bind (arg1, arg2, arg3));
 }
 
@@ -156,8 +156,8 @@ static void _call_f_bind_3994 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  quint16 arg1 = args.read<quint16 > (heap);
-  QFlags<QUdpSocket::BindFlag> arg2 = args.read<QFlags<QUdpSocket::BindFlag> > (heap);
+  quint16 arg1 = gsi::arg_reader<quint16 >() (args, heap);
+  QFlags<QUdpSocket::BindFlag> arg2 = gsi::arg_reader<QFlags<QUdpSocket::BindFlag> >() (args, heap);
   ret.write<bool > ((bool)((QUdpSocket *)cls)->bind (arg1, arg2));
 }
 
@@ -212,10 +212,10 @@ static void _call_f_writeDatagram_6011 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  qint64 arg2 = args.read<qint64 > (heap);
-  const QHostAddress &arg3 = args.read<const QHostAddress & > (heap);
-  quint16 arg4 = args.read<quint16 > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  qint64 arg2 = gsi::arg_reader<qint64 >() (args, heap);
+  const QHostAddress &arg3 = gsi::arg_reader<const QHostAddress & >() (args, heap);
+  quint16 arg4 = gsi::arg_reader<quint16 >() (args, heap);
   ret.write<qint64 > ((qint64)((QUdpSocket *)cls)->writeDatagram (arg1, arg2, arg3, arg4));
 }
 
@@ -238,9 +238,9 @@ static void _call_f_writeDatagram_5711 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QByteArray &arg1 = args.read<const QByteArray & > (heap);
-  const QHostAddress &arg2 = args.read<const QHostAddress & > (heap);
-  quint16 arg3 = args.read<quint16 > (heap);
+  const QByteArray &arg1 = gsi::arg_reader<const QByteArray & >() (args, heap);
+  const QHostAddress &arg2 = gsi::arg_reader<const QHostAddress & >() (args, heap);
+  quint16 arg3 = gsi::arg_reader<quint16 >() (args, heap);
   ret.write<qint64 > ((qint64)((QUdpSocket *)cls)->writeDatagram (arg1, arg2, arg3));
 }
 
@@ -261,8 +261,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUdpSocket::tr (arg1, arg2));
 }
 
@@ -285,9 +285,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUdpSocket::tr (arg1, arg2, arg3));
 }
 
@@ -308,8 +308,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QUdpSocket::trUtf8 (arg1, arg2));
 }
 
@@ -332,9 +332,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QUdpSocket::trUtf8 (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtNetwork/gsiDeclQUrlInfo.cc
+++ b/src/gsiqt/qt4/QtNetwork/gsiDeclQUrlInfo.cc
@@ -216,7 +216,7 @@ static void _call_f_operator_excl__eq__c2097 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrlInfo &arg1 = args.read<const QUrlInfo & > (heap);
+  const QUrlInfo &arg1 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
   ret.write<bool > ((bool)((QUrlInfo *)cls)->operator!= (arg1));
 }
 
@@ -235,7 +235,7 @@ static void _call_f_operator_eq__2097 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrlInfo &arg1 = args.read<const QUrlInfo & > (heap);
+  const QUrlInfo &arg1 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
   ret.write<QUrlInfo & > ((QUrlInfo &)((QUrlInfo *)cls)->operator= (arg1));
 }
 
@@ -254,7 +254,7 @@ static void _call_f_operator_eq__eq__c2097 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrlInfo &arg1 = args.read<const QUrlInfo & > (heap);
+  const QUrlInfo &arg1 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
   ret.write<bool > ((bool)((QUrlInfo *)cls)->operator== (arg1));
 }
 
@@ -303,7 +303,7 @@ static void _call_f_setDir_864 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setDir (arg1);
 }
@@ -323,7 +323,7 @@ static void _call_f_setFile_864 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setFile (arg1);
 }
@@ -343,7 +343,7 @@ static void _call_f_setGroup_2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setGroup (arg1);
 }
@@ -363,7 +363,7 @@ static void _call_f_setLastModified_2175 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setLastModified (arg1);
 }
@@ -383,7 +383,7 @@ static void _call_f_setLastRead_2175 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDateTime &arg1 = args.read<const QDateTime & > (heap);
+  const QDateTime &arg1 = gsi::arg_reader<const QDateTime & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setLastRead (arg1);
 }
@@ -403,7 +403,7 @@ static void _call_f_setName_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setName (arg1);
 }
@@ -423,7 +423,7 @@ static void _call_f_setOwner_2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setOwner (arg1);
 }
@@ -443,7 +443,7 @@ static void _call_f_setPermissions_767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setPermissions (arg1);
 }
@@ -463,7 +463,7 @@ static void _call_f_setReadable_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setReadable (arg1);
 }
@@ -483,7 +483,7 @@ static void _call_f_setSize_986 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  qint64 arg1 = args.read<qint64 > (heap);
+  qint64 arg1 = gsi::arg_reader<qint64 >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setSize (arg1);
 }
@@ -503,7 +503,7 @@ static void _call_f_setSymLink_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setSymLink (arg1);
 }
@@ -523,7 +523,7 @@ static void _call_f_setWritable_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QUrlInfo *)cls)->setWritable (arg1);
 }
@@ -562,9 +562,9 @@ static void _call_f_equal_4745 (const qt_gsi::GenericStaticMethod * /*decl*/, gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrlInfo &arg1 = args.read<const QUrlInfo & > (heap);
-  const QUrlInfo &arg2 = args.read<const QUrlInfo & > (heap);
-  int arg3 = args.read<int > (heap);
+  const QUrlInfo &arg1 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
+  const QUrlInfo &arg2 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)QUrlInfo::equal (arg1, arg2, arg3));
 }
 
@@ -587,9 +587,9 @@ static void _call_f_greaterThan_4745 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrlInfo &arg1 = args.read<const QUrlInfo & > (heap);
-  const QUrlInfo &arg2 = args.read<const QUrlInfo & > (heap);
-  int arg3 = args.read<int > (heap);
+  const QUrlInfo &arg1 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
+  const QUrlInfo &arg2 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)QUrlInfo::greaterThan (arg1, arg2, arg3));
 }
 
@@ -612,9 +612,9 @@ static void _call_f_lessThan_4745 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrlInfo &arg1 = args.read<const QUrlInfo & > (heap);
-  const QUrlInfo &arg2 = args.read<const QUrlInfo & > (heap);
-  int arg3 = args.read<int > (heap);
+  const QUrlInfo &arg1 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
+  const QUrlInfo &arg2 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)QUrlInfo::lessThan (arg1, arg2, arg3));
 }
 
@@ -893,7 +893,7 @@ static void _call_ctor_QUrlInfo_Adaptor_2097 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QUrlInfo &arg1 = args.read<const QUrlInfo & > (heap);
+  const QUrlInfo &arg1 = gsi::arg_reader<const QUrlInfo & >() (args, heap);
   ret.write<QUrlInfo_Adaptor *> (new QUrlInfo_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlDatabase.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlDatabase.cc
@@ -71,7 +71,7 @@ static void _call_ctor_QSqlDatabase_2487 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlDatabase &arg1 = args.read<const QSqlDatabase & > (heap);
+  const QSqlDatabase &arg1 = gsi::arg_reader<const QSqlDatabase & >() (args, heap);
   ret.write<QSqlDatabase *> (new QSqlDatabase (arg1));
 }
 
@@ -196,7 +196,7 @@ static void _call_f_exec_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QSqlQuery > ((QSqlQuery)((QSqlDatabase *)cls)->exec (arg1));
 }
 
@@ -322,8 +322,8 @@ static void _call_f_open_3942 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlDatabase *)cls)->open (arg1, arg2));
 }
 
@@ -342,7 +342,7 @@ static void _call_f_operator_eq__2487 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlDatabase &arg1 = args.read<const QSqlDatabase & > (heap);
+  const QSqlDatabase &arg1 = gsi::arg_reader<const QSqlDatabase & >() (args, heap);
   ret.write<QSqlDatabase & > ((QSqlDatabase &)((QSqlDatabase *)cls)->operator= (arg1));
 }
 
@@ -391,7 +391,7 @@ static void _call_f_primaryIndex_c2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QSqlIndex > ((QSqlIndex)((QSqlDatabase *)cls)->primaryIndex (arg1));
 }
 
@@ -410,7 +410,7 @@ static void _call_f_record_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QSqlRecord > ((QSqlRecord)((QSqlDatabase *)cls)->record (arg1));
 }
 
@@ -444,7 +444,7 @@ static void _call_f_setConnectOptions_2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlDatabase *)cls)->setConnectOptions (arg1);
 }
@@ -464,7 +464,7 @@ static void _call_f_setDatabaseName_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlDatabase *)cls)->setDatabaseName (arg1);
 }
@@ -484,7 +484,7 @@ static void _call_f_setHostName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlDatabase *)cls)->setHostName (arg1);
 }
@@ -504,7 +504,7 @@ static void _call_f_setNumericalPrecisionPolicy_3429 (const qt_gsi::GenericMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlDatabase *)cls)->setNumericalPrecisionPolicy (qt_gsi::QtToCppAdaptor<QSql::NumericalPrecisionPolicy>(arg1).cref());
 }
@@ -524,7 +524,7 @@ static void _call_f_setPassword_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlDatabase *)cls)->setPassword (arg1);
 }
@@ -544,7 +544,7 @@ static void _call_f_setPort_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlDatabase *)cls)->setPort (arg1);
 }
@@ -564,7 +564,7 @@ static void _call_f_setUserName_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlDatabase *)cls)->setUserName (arg1);
 }
@@ -584,7 +584,7 @@ static void _call_f_tables_c1843 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSql::TableType>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QSql::TableType>::target_type & > (heap) : (const qt_gsi::Converter<QSql::TableType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSql::TableType>(heap, QSql::Tables));
+  const qt_gsi::Converter<QSql::TableType>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QSql::TableType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSql::TableType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSql::TableType>(heap, QSql::Tables), heap);
   ret.write<QStringList > ((QStringList)((QSqlDatabase *)cls)->tables (qt_gsi::QtToCppAdaptor<QSql::TableType>(arg1).cref()));
 }
 
@@ -635,8 +635,8 @@ static void _call_f_addDatabase_3942 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QLatin1String(QSqlDatabase::defaultConnection));
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QLatin1String(QSqlDatabase::defaultConnection), heap);
   ret.write<QSqlDatabase > ((QSqlDatabase)QSqlDatabase::addDatabase (arg1, arg2));
 }
 
@@ -657,8 +657,8 @@ static void _call_f_addDatabase_3544 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QSqlDriver *arg1 = args.read<QSqlDriver * > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QLatin1String(QSqlDatabase::defaultConnection));
+  QSqlDriver *arg1 = gsi::arg_reader<QSqlDriver * >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QLatin1String(QSqlDatabase::defaultConnection), heap);
   ret.write<QSqlDatabase > ((QSqlDatabase)QSqlDatabase::addDatabase (arg1, arg2));
 }
 
@@ -679,8 +679,8 @@ static void _call_f_cloneDatabase_4404 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlDatabase &arg1 = args.read<const QSqlDatabase & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QSqlDatabase &arg1 = gsi::arg_reader<const QSqlDatabase & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QSqlDatabase > ((QSqlDatabase)QSqlDatabase::cloneDatabase (arg1, arg2));
 }
 
@@ -714,7 +714,7 @@ static void _call_f_contains_2025 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QLatin1String(QSqlDatabase::defaultConnection));
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QLatin1String(QSqlDatabase::defaultConnection), heap);
   ret.write<bool > ((bool)QSqlDatabase::contains (arg1));
 }
 
@@ -735,8 +735,8 @@ static void _call_f_database_2781 (const qt_gsi::GenericStaticMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QLatin1String(QSqlDatabase::defaultConnection));
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(true);
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QLatin1String(QSqlDatabase::defaultConnection), heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   ret.write<QSqlDatabase > ((QSqlDatabase)QSqlDatabase::database (arg1, arg2));
 }
 
@@ -770,7 +770,7 @@ static void _call_f_isDriverAvailable_2025 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)QSqlDatabase::isDriverAvailable (arg1));
 }
 
@@ -791,8 +791,8 @@ static void _call_f_registerSqlDriver_4643 (const qt_gsi::GenericStaticMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QSqlDriverCreatorBase *arg2 = args.read<QSqlDriverCreatorBase * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QSqlDriverCreatorBase *arg2 = gsi::arg_reader<QSqlDriverCreatorBase * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSqlDatabase::registerSqlDriver (arg1, arg2);
 }
@@ -812,7 +812,7 @@ static void _call_f_removeDatabase_2025 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QSqlDatabase::removeDatabase (arg1);
 }

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlDriver.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlDriver.cc
@@ -136,8 +136,8 @@ static void _call_f_escapeIdentifier_c4919 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QSqlDriver *)cls)->escapeIdentifier (arg1, qt_gsi::QtToCppAdaptor<QSqlDriver::IdentifierType>(arg2).cref()));
 }
 
@@ -158,8 +158,8 @@ static void _call_f_formatValue_c2938 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlField &arg1 = args.read<const QSqlField & > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  const QSqlField &arg1 = gsi::arg_reader<const QSqlField & >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<QString > ((QString)((QSqlDriver *)cls)->formatValue (arg1, arg2));
 }
 
@@ -193,7 +193,7 @@ static void _call_f_hasFeature_c2893 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSqlDriver::DriverFeature>::target_type & arg1 = args.read<const qt_gsi::Converter<QSqlDriver::DriverFeature>::target_type & > (heap);
+  const qt_gsi::Converter<QSqlDriver::DriverFeature>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSqlDriver::DriverFeature>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QSqlDriver *)cls)->hasFeature (qt_gsi::QtToCppAdaptor<QSqlDriver::DriverFeature>(arg1).cref()));
 }
 
@@ -214,8 +214,8 @@ static void _call_f_isIdentifierEscaped_c4919 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QSqlDriver *)cls)->isIdentifierEscaped (arg1, qt_gsi::QtToCppAdaptor<QSqlDriver::IdentifierType>(arg2).cref()));
 }
 
@@ -304,12 +304,12 @@ static void _call_f_open_10352 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  int arg5 = args ? args.read<int > (heap) : (int)(-1);
-  const QString &arg6 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  int arg5 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  const QString &arg6 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<bool > ((bool)((QSqlDriver *)cls)->open (arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -328,7 +328,7 @@ static void _call_f_primaryIndex_c2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QSqlIndex > ((QSqlIndex)((QSqlDriver *)cls)->primaryIndex (arg1));
 }
 
@@ -347,7 +347,7 @@ static void _call_f_record_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QSqlRecord > ((QSqlRecord)((QSqlDriver *)cls)->record (arg1));
 }
 
@@ -381,7 +381,7 @@ static void _call_f_setNumericalPrecisionPolicy_3429 (const qt_gsi::GenericMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlDriver *)cls)->setNumericalPrecisionPolicy (qt_gsi::QtToCppAdaptor<QSql::NumericalPrecisionPolicy>(arg1).cref());
 }
@@ -407,10 +407,10 @@ static void _call_f_sqlStatement_c7794 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSqlDriver::StatementType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSqlDriver::StatementType>::target_type & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QSqlRecord &arg3 = args.read<const QSqlRecord & > (heap);
-  bool arg4 = args.read<bool > (heap);
+  const qt_gsi::Converter<QSqlDriver::StatementType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSqlDriver::StatementType>::target_type & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QSqlRecord &arg3 = gsi::arg_reader<const QSqlRecord & >() (args, heap);
+  bool arg4 = gsi::arg_reader<bool >() (args, heap);
   ret.write<QString > ((QString)((QSqlDriver *)cls)->sqlStatement (qt_gsi::QtToCppAdaptor<QSqlDriver::StatementType>(arg1).cref(), arg2, arg3, arg4));
 }
 
@@ -431,8 +431,8 @@ static void _call_f_stripDelimiters_c4919 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QSqlDriver *)cls)->stripDelimiters (arg1, qt_gsi::QtToCppAdaptor<QSqlDriver::IdentifierType>(arg2).cref()));
 }
 
@@ -451,7 +451,7 @@ static void _call_f_subscribeToNotification_2025 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlDriver *)cls)->subscribeToNotification (arg1));
 }
 
@@ -485,7 +485,7 @@ static void _call_f_tables_c1843 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSql::TableType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSql::TableType>::target_type & > (heap);
+  const qt_gsi::Converter<QSql::TableType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSql::TableType>::target_type & >() (args, heap);
   ret.write<QStringList > ((QStringList)((QSqlDriver *)cls)->tables (qt_gsi::QtToCppAdaptor<QSql::TableType>(arg1).cref()));
 }
 
@@ -504,7 +504,7 @@ static void _call_f_unsubscribeFromNotification_2025 (const qt_gsi::GenericMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlDriver *)cls)->unsubscribeFromNotification (arg1));
 }
 
@@ -525,8 +525,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSqlDriver::tr (arg1, arg2));
 }
 
@@ -549,9 +549,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSqlDriver::tr (arg1, arg2, arg3));
 }
 
@@ -572,8 +572,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSqlDriver::trUtf8 (arg1, arg2));
 }
 
@@ -596,9 +596,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSqlDriver::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1126,7 +1126,7 @@ static void _call_ctor_QSqlDriver_Adaptor_1302 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSqlDriver_Adaptor *> (new QSqlDriver_Adaptor (arg1));
 }
 
@@ -1269,7 +1269,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSqlDriver_Adaptor *)cls)->emitter_QSqlDriver_destroyed_1302 (arg1);
 }
 
@@ -1456,8 +1456,8 @@ static void _call_fp_isIdentifierEscapedImplementation_c4919 (const qt_gsi::Gene
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & >() (args, heap);
   ret.write<bool > ((bool)((QSqlDriver_Adaptor *)cls)->fp_QSqlDriver_isIdentifierEscapedImplementation_c4919 (arg1, arg2));
 }
 
@@ -1494,7 +1494,7 @@ static void _call_emitter_notification_2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ((QSqlDriver_Adaptor *)cls)->emitter_QSqlDriver_notification_2025 (arg1);
 }
 
@@ -1573,7 +1573,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSqlDriver_Adaptor *)cls)->fp_QSqlDriver_receivers_c1731 (arg1));
 }
 
@@ -1753,8 +1753,8 @@ static void _call_fp_stripDelimitersImplementation_c4919 (const qt_gsi::GenericM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = args.read<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<QSqlDriver::IdentifierType>::target_type & >() (args, heap);
   ret.write<QString > ((QString)((QSqlDriver_Adaptor *)cls)->fp_QSqlDriver_stripDelimitersImplementation_c4919 (arg1, arg2));
 }
 
@@ -1772,7 +1772,7 @@ static void _call_fp_subscribeToNotificationImplementation_2025 (const qt_gsi::G
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlDriver_Adaptor *)cls)->fp_QSqlDriver_subscribeToNotificationImplementation_2025 (arg1));
 }
 
@@ -1851,7 +1851,7 @@ static void _call_fp_unsubscribeFromNotificationImplementation_2025 (const qt_gs
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlDriver_Adaptor *)cls)->fp_QSqlDriver_unsubscribeFromNotificationImplementation_2025 (arg1));
 }
 

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlError.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlError.cc
@@ -56,10 +56,10 @@ static void _call_ctor_QSqlError_6892 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const qt_gsi::Converter<QSqlError::ErrorType>::target_type & arg3 = args ? args.read<const qt_gsi::Converter<QSqlError::ErrorType>::target_type & > (heap) : (const qt_gsi::Converter<QSqlError::ErrorType>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSqlError::ErrorType>(heap, QSqlError::NoError));
-  int arg4 = args ? args.read<int > (heap) : (int)(-1);
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const qt_gsi::Converter<QSqlError::ErrorType>::target_type & arg3 = args ? gsi::arg_reader<const qt_gsi::Converter<QSqlError::ErrorType>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSqlError::ErrorType>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSqlError::ErrorType>(heap, QSqlError::NoError), heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
   ret.write<QSqlError *> (new QSqlError (arg1, arg2, qt_gsi::QtToCppAdaptor<QSqlError::ErrorType>(arg3).cref(), arg4));
 }
 
@@ -78,7 +78,7 @@ static void _call_ctor_QSqlError_2220 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlError &arg1 = args.read<const QSqlError & > (heap);
+  const QSqlError &arg1 = gsi::arg_reader<const QSqlError & >() (args, heap);
   ret.write<QSqlError *> (new QSqlError (arg1));
 }
 
@@ -157,7 +157,7 @@ static void _call_f_operator_eq__2220 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlError &arg1 = args.read<const QSqlError & > (heap);
+  const QSqlError &arg1 = gsi::arg_reader<const QSqlError & >() (args, heap);
   ret.write<QSqlError & > ((QSqlError &)((QSqlError *)cls)->operator= (arg1));
 }
 
@@ -176,7 +176,7 @@ static void _call_f_setDatabaseText_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlError *)cls)->setDatabaseText (arg1);
 }
@@ -196,7 +196,7 @@ static void _call_f_setDriverText_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlError *)cls)->setDriverText (arg1);
 }
@@ -216,7 +216,7 @@ static void _call_f_setNumber_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlError *)cls)->setNumber (arg1);
 }
@@ -236,7 +236,7 @@ static void _call_f_setType_2399 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSqlError::ErrorType>::target_type & arg1 = args.read<const qt_gsi::Converter<QSqlError::ErrorType>::target_type & > (heap);
+  const qt_gsi::Converter<QSqlError::ErrorType>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSqlError::ErrorType>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlError *)cls)->setType (qt_gsi::QtToCppAdaptor<QSqlError::ErrorType>(arg1).cref());
 }

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlField.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlField.cc
@@ -52,8 +52,8 @@ static void _call_ctor_QSqlField_3693 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const qt_gsi::Converter<QVariant::Type>::target_type & arg2 = args ? args.read<const qt_gsi::Converter<QVariant::Type>::target_type & > (heap) : (const qt_gsi::Converter<QVariant::Type>::target_type &)(qt_gsi::CppToQtReadAdaptor<QVariant::Type>(heap, QVariant::Invalid));
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const qt_gsi::Converter<QVariant::Type>::target_type & arg2 = args ? gsi::arg_reader<const qt_gsi::Converter<QVariant::Type>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QVariant::Type>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QVariant::Type>(heap, QVariant::Invalid), heap);
   ret.write<QSqlField *> (new QSqlField (arg1, qt_gsi::QtToCppAdaptor<QVariant::Type>(arg2).cref()));
 }
 
@@ -72,7 +72,7 @@ static void _call_ctor_QSqlField_2182 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlField &arg1 = args.read<const QSqlField & > (heap);
+  const QSqlField &arg1 = gsi::arg_reader<const QSqlField & >() (args, heap);
   ret.write<QSqlField *> (new QSqlField (arg1));
 }
 
@@ -227,7 +227,7 @@ static void _call_f_operator_excl__eq__c2182 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlField &arg1 = args.read<const QSqlField & > (heap);
+  const QSqlField &arg1 = gsi::arg_reader<const QSqlField & >() (args, heap);
   ret.write<bool > ((bool)((QSqlField *)cls)->operator!= (arg1));
 }
 
@@ -246,7 +246,7 @@ static void _call_f_operator_eq__2182 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlField &arg1 = args.read<const QSqlField & > (heap);
+  const QSqlField &arg1 = gsi::arg_reader<const QSqlField & >() (args, heap);
   ret.write<QSqlField & > ((QSqlField &)((QSqlField *)cls)->operator= (arg1));
 }
 
@@ -265,7 +265,7 @@ static void _call_f_operator_eq__eq__c2182 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlField &arg1 = args.read<const QSqlField & > (heap);
+  const QSqlField &arg1 = gsi::arg_reader<const QSqlField & >() (args, heap);
   ret.write<bool > ((bool)((QSqlField *)cls)->operator== (arg1));
 }
 
@@ -314,7 +314,7 @@ static void _call_f_setAutoValue_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setAutoValue (arg1);
 }
@@ -334,7 +334,7 @@ static void _call_f_setDefaultValue_2119 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setDefaultValue (arg1);
 }
@@ -354,7 +354,7 @@ static void _call_f_setGenerated_864 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setGenerated (arg1);
 }
@@ -374,7 +374,7 @@ static void _call_f_setLength_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setLength (arg1);
 }
@@ -394,7 +394,7 @@ static void _call_f_setName_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setName (arg1);
 }
@@ -414,7 +414,7 @@ static void _call_f_setPrecision_767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setPrecision (arg1);
 }
@@ -434,7 +434,7 @@ static void _call_f_setReadOnly_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setReadOnly (arg1);
 }
@@ -454,7 +454,7 @@ static void _call_f_setRequired_864 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setRequired (arg1);
 }
@@ -474,7 +474,7 @@ static void _call_f_setRequiredStatus_2898 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSqlField::RequiredStatus>::target_type & arg1 = args.read<const qt_gsi::Converter<QSqlField::RequiredStatus>::target_type & > (heap);
+  const qt_gsi::Converter<QSqlField::RequiredStatus>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSqlField::RequiredStatus>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setRequiredStatus (qt_gsi::QtToCppAdaptor<QSqlField::RequiredStatus>(arg1).cref());
 }
@@ -494,7 +494,7 @@ static void _call_f_setSqlType_767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setSqlType (arg1);
 }
@@ -514,7 +514,7 @@ static void _call_f_setType_1776 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QVariant::Type>::target_type & arg1 = args.read<const qt_gsi::Converter<QVariant::Type>::target_type & > (heap);
+  const qt_gsi::Converter<QVariant::Type>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QVariant::Type>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setType (qt_gsi::QtToCppAdaptor<QVariant::Type>(arg1).cref());
 }
@@ -534,7 +534,7 @@ static void _call_f_setValue_2119 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlField *)cls)->setValue (arg1);
 }

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlIndex.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlIndex.cc
@@ -54,8 +54,8 @@ static void _call_ctor_QSqlIndex_3942 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QSqlIndex *> (new QSqlIndex (arg1, arg2));
 }
 
@@ -74,7 +74,7 @@ static void _call_ctor_QSqlIndex_2202 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlIndex &arg1 = args.read<const QSqlIndex & > (heap);
+  const QSqlIndex &arg1 = gsi::arg_reader<const QSqlIndex & >() (args, heap);
   ret.write<QSqlIndex *> (new QSqlIndex (arg1));
 }
 
@@ -93,7 +93,7 @@ static void _call_f_append_2182 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlField &arg1 = args.read<const QSqlField & > (heap);
+  const QSqlField &arg1 = gsi::arg_reader<const QSqlField & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlIndex *)cls)->append (arg1);
 }
@@ -115,8 +115,8 @@ static void _call_f_append_2938 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlField &arg1 = args.read<const QSqlField & > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QSqlField &arg1 = gsi::arg_reader<const QSqlField & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlIndex *)cls)->append (arg1, arg2);
 }
@@ -151,7 +151,7 @@ static void _call_f_isDescending_c767 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlIndex *)cls)->isDescending (arg1));
 }
 
@@ -185,7 +185,7 @@ static void _call_f_operator_eq__2202 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlIndex &arg1 = args.read<const QSqlIndex & > (heap);
+  const QSqlIndex &arg1 = gsi::arg_reader<const QSqlIndex & >() (args, heap);
   ret.write<QSqlIndex & > ((QSqlIndex &)((QSqlIndex *)cls)->operator= (arg1));
 }
 
@@ -204,7 +204,7 @@ static void _call_f_setCursorName_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlIndex *)cls)->setCursorName (arg1);
 }
@@ -226,8 +226,8 @@ static void _call_f_setDescending_1523 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlIndex *)cls)->setDescending (arg1, arg2);
 }
@@ -247,7 +247,7 @@ static void _call_f_setName_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlIndex *)cls)->setName (arg1);
 }

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlQuery.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlQuery.cc
@@ -55,7 +55,7 @@ static void _call_ctor_QSqlQuery_1646 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QSqlResult *arg1 = args.read<QSqlResult * > (heap);
+  QSqlResult *arg1 = gsi::arg_reader<QSqlResult * >() (args, heap);
   ret.write<QSqlQuery *> (new QSqlQuery (arg1));
 }
 
@@ -76,8 +76,8 @@ static void _call_ctor_QSqlQuery_3527 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  QSqlDatabase arg2 = args ? args.read<QSqlDatabase > (heap) : (QSqlDatabase)(QSqlDatabase());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  QSqlDatabase arg2 = args ? gsi::arg_reader<QSqlDatabase >() (args, heap) : gsi::arg_maker<QSqlDatabase >() (QSqlDatabase(), heap);
   ret.write<QSqlQuery *> (new QSqlQuery (arg1, arg2));
 }
 
@@ -96,7 +96,7 @@ static void _call_ctor_QSqlQuery_1610 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QSqlDatabase arg1 = args.read<QSqlDatabase > (heap);
+  QSqlDatabase arg1 = gsi::arg_reader<QSqlDatabase >() (args, heap);
   ret.write<QSqlQuery *> (new QSqlQuery (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_ctor_QSqlQuery_2232 (const qt_gsi::GenericStaticMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlQuery &arg1 = args.read<const QSqlQuery & > (heap);
+  const QSqlQuery &arg1 = gsi::arg_reader<const QSqlQuery & >() (args, heap);
   ret.write<QSqlQuery *> (new QSqlQuery (arg1));
 }
 
@@ -136,8 +136,8 @@ static void _call_f_addBindValue_4937 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
-  QFlags<QSql::ParamTypeFlag> arg2 = args ? args.read<QFlags<QSql::ParamTypeFlag> > (heap) : (QFlags<QSql::ParamTypeFlag>)(QSql::In);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
+  QFlags<QSql::ParamTypeFlag> arg2 = args ? gsi::arg_reader<QFlags<QSql::ParamTypeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QSql::ParamTypeFlag> >() (QSql::In, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQuery *)cls)->addBindValue (arg1, arg2);
 }
@@ -176,9 +176,9 @@ static void _call_f_bindValue_6854 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  QFlags<QSql::ParamTypeFlag> arg3 = args ? args.read<QFlags<QSql::ParamTypeFlag> > (heap) : (QFlags<QSql::ParamTypeFlag>)(QSql::In);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  QFlags<QSql::ParamTypeFlag> arg3 = args ? gsi::arg_reader<QFlags<QSql::ParamTypeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QSql::ParamTypeFlag> >() (QSql::In, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQuery *)cls)->bindValue (arg1, arg2, arg3);
 }
@@ -202,9 +202,9 @@ static void _call_f_bindValue_5596 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  QFlags<QSql::ParamTypeFlag> arg3 = args ? args.read<QFlags<QSql::ParamTypeFlag> > (heap) : (QFlags<QSql::ParamTypeFlag>)(QSql::In);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  QFlags<QSql::ParamTypeFlag> arg3 = args ? gsi::arg_reader<QFlags<QSql::ParamTypeFlag> >() (args, heap) : gsi::arg_maker<QFlags<QSql::ParamTypeFlag> >() (QSql::In, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQuery *)cls)->bindValue (arg1, arg2, arg3);
 }
@@ -224,7 +224,7 @@ static void _call_f_boundValue_c2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QSqlQuery *)cls)->boundValue (arg1));
 }
 
@@ -243,7 +243,7 @@ static void _call_f_boundValue_c767 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QSqlQuery *)cls)->boundValue (arg1));
 }
 
@@ -308,7 +308,7 @@ static void _call_f_exec_2025 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlQuery *)cls)->exec (arg1));
 }
 
@@ -342,7 +342,7 @@ static void _call_f_execBatch_3290 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSqlQuery::BatchExecutionMode>::target_type & arg1 = args ? args.read<const qt_gsi::Converter<QSqlQuery::BatchExecutionMode>::target_type & > (heap) : (const qt_gsi::Converter<QSqlQuery::BatchExecutionMode>::target_type &)(qt_gsi::CppToQtReadAdaptor<QSqlQuery::BatchExecutionMode>(heap, QSqlQuery::ValuesAsRows));
+  const qt_gsi::Converter<QSqlQuery::BatchExecutionMode>::target_type & arg1 = args ? gsi::arg_reader<const qt_gsi::Converter<QSqlQuery::BatchExecutionMode>::target_type & >() (args, heap) : gsi::arg_maker<const qt_gsi::Converter<QSqlQuery::BatchExecutionMode>::target_type & >() (qt_gsi::CppToQtReadAdaptor<QSqlQuery::BatchExecutionMode>(heap, QSqlQuery::ValuesAsRows), heap);
   ret.write<bool > ((bool)((QSqlQuery *)cls)->execBatch (qt_gsi::QtToCppAdaptor<QSqlQuery::BatchExecutionMode>(arg1).cref()));
 }
 
@@ -437,7 +437,7 @@ static void _call_f_isNull_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlQuery *)cls)->isNull (arg1));
 }
 
@@ -606,7 +606,7 @@ static void _call_f_operator_eq__2232 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlQuery &arg1 = args.read<const QSqlQuery & > (heap);
+  const QSqlQuery &arg1 = gsi::arg_reader<const QSqlQuery & >() (args, heap);
   ret.write<QSqlQuery & > ((QSqlQuery &)((QSqlQuery *)cls)->operator= (arg1));
 }
 
@@ -625,7 +625,7 @@ static void _call_f_prepare_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlQuery *)cls)->prepare (arg1));
 }
 
@@ -691,8 +691,8 @@ static void _call_f_seek_1523 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args ? args.read<bool > (heap) : (bool)(false);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<bool > ((bool)((QSqlQuery *)cls)->seek (arg1, arg2));
 }
 
@@ -711,7 +711,7 @@ static void _call_f_setForwardOnly_864 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args.read<bool > (heap);
+  bool arg1 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQuery *)cls)->setForwardOnly (arg1);
 }
@@ -731,7 +731,7 @@ static void _call_f_setNumericalPrecisionPolicy_3429 (const qt_gsi::GenericMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQuery *)cls)->setNumericalPrecisionPolicy (qt_gsi::QtToCppAdaptor<QSql::NumericalPrecisionPolicy>(arg1).cref());
 }
@@ -766,7 +766,7 @@ static void _call_f_value_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QSqlQuery *)cls)->value (arg1));
 }
 

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlQueryModel.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlQueryModel.cc
@@ -76,7 +76,7 @@ static void _call_f_canFetchMore_c2395 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSqlQueryModel *)cls)->canFetchMore (arg1));
 }
 
@@ -111,7 +111,7 @@ static void _call_f_columnCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QSqlQueryModel *)cls)->columnCount (arg1));
 }
 
@@ -132,8 +132,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QSqlQueryModel *)cls)->data (arg1, arg2));
 }
 
@@ -152,7 +152,7 @@ static void _call_f_fetchMore_2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel *)cls)->fetchMore (arg1);
 }
@@ -176,9 +176,9 @@ static void _call_f_headerData_c3231 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QSqlQueryModel *)cls)->headerData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3));
 }
 
@@ -201,9 +201,9 @@ static void _call_f_insertColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSqlQueryModel *)cls)->insertColumns (arg1, arg2, arg3));
 }
 
@@ -252,7 +252,7 @@ static void _call_f_record_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QSqlRecord > ((QSqlRecord)((QSqlQueryModel *)cls)->record (arg1));
 }
 
@@ -290,9 +290,9 @@ static void _call_f_removeColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSqlQueryModel *)cls)->removeColumns (arg1, arg2, arg3));
 }
 
@@ -311,7 +311,7 @@ static void _call_f_rowCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QSqlQueryModel *)cls)->rowCount (arg1));
 }
 
@@ -336,10 +336,10 @@ static void _call_f_setHeaderData_5242 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  const QVariant &arg3 = args.read<const QVariant & > (heap);
-  int arg4 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  const QVariant &arg3 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg4 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QSqlQueryModel *)cls)->setHeaderData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3, arg4));
 }
 
@@ -358,7 +358,7 @@ static void _call_f_setQuery_2232 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlQuery &arg1 = args.read<const QSqlQuery & > (heap);
+  const QSqlQuery &arg1 = gsi::arg_reader<const QSqlQuery & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel *)cls)->setQuery (arg1);
 }
@@ -380,8 +380,8 @@ static void _call_f_setQuery_4404 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QSqlDatabase &arg2 = args ? args.read<const QSqlDatabase & > (heap) : (const QSqlDatabase &)(QSqlDatabase());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QSqlDatabase &arg2 = args ? gsi::arg_reader<const QSqlDatabase & >() (args, heap) : gsi::arg_maker<const QSqlDatabase & >() (QSqlDatabase(), heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel *)cls)->setQuery (arg1, arg2);
 }
@@ -403,8 +403,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSqlQueryModel::tr (arg1, arg2));
 }
 
@@ -427,9 +427,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSqlQueryModel::tr (arg1, arg2, arg3));
 }
 
@@ -450,8 +450,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSqlQueryModel::trUtf8 (arg1, arg2));
 }
 
@@ -474,9 +474,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSqlQueryModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1275,7 +1275,7 @@ static void _call_ctor_QSqlQueryModel_Adaptor_1302 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ret.write<QSqlQueryModel_Adaptor *> (new QSqlQueryModel_Adaptor (arg1));
 }
 
@@ -1297,9 +1297,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -1322,9 +1322,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1351,11 +1351,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1381,11 +1381,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1407,9 +1407,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -1432,9 +1432,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -1516,8 +1516,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -1538,8 +1538,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -1629,9 +1629,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -1653,9 +1653,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -1677,9 +1677,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -1749,8 +1749,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QSqlQueryModel_Adaptor *)cls)->emitter_QSqlQueryModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -1774,10 +1774,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -1795,7 +1795,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSqlQueryModel_Adaptor *)cls)->emitter_QSqlQueryModel_destroyed_1302 (arg1);
 }
 
@@ -1874,8 +1874,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_encodeData_c4599 (arg1, arg2);
 }
@@ -2128,9 +2128,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QSqlQueryModel_Adaptor *)cls)->emitter_QSqlQueryModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -2177,7 +2177,7 @@ static void _call_fp_indexInQuery_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_indexInQuery_c2395 (arg1));
 }
 
@@ -2415,7 +2415,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_receivers_c1731 (arg1));
 }
 
@@ -2650,7 +2650,7 @@ static void _call_fp_setLastError_2220 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlError &arg1 = args.read<const QSqlError & > (heap);
+  const QSqlError &arg1 = gsi::arg_reader<const QSqlError & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_setLastError_2220 (arg1);
 }
@@ -2669,7 +2669,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlQueryModel_Adaptor *)cls)->fp_QSqlQueryModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlRecord.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlRecord.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QSqlRecord_2305 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlRecord &arg1 = args.read<const QSqlRecord & > (heap);
+  const QSqlRecord &arg1 = gsi::arg_reader<const QSqlRecord & >() (args, heap);
   ret.write<QSqlRecord *> (new QSqlRecord (arg1));
 }
 
@@ -85,7 +85,7 @@ static void _call_f_append_2182 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlField &arg1 = args.read<const QSqlField & > (heap);
+  const QSqlField &arg1 = gsi::arg_reader<const QSqlField & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->append (arg1);
 }
@@ -137,7 +137,7 @@ static void _call_f_contains_c2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlRecord *)cls)->contains (arg1));
 }
 
@@ -171,7 +171,7 @@ static void _call_f_field_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QSqlField > ((QSqlField)((QSqlRecord *)cls)->field (arg1));
 }
 
@@ -190,7 +190,7 @@ static void _call_f_field_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QSqlField > ((QSqlField)((QSqlRecord *)cls)->field (arg1));
 }
 
@@ -209,7 +209,7 @@ static void _call_f_fieldName_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QSqlRecord *)cls)->fieldName (arg1));
 }
 
@@ -228,7 +228,7 @@ static void _call_f_indexOf_c2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QSqlRecord *)cls)->indexOf (arg1));
 }
 
@@ -249,8 +249,8 @@ static void _call_f_insert_2841 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QSqlField &arg2 = args.read<const QSqlField & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QSqlField &arg2 = gsi::arg_reader<const QSqlField & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->insert (arg1, arg2);
 }
@@ -285,7 +285,7 @@ static void _call_f_isGenerated_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlRecord *)cls)->isGenerated (arg1));
 }
 
@@ -304,7 +304,7 @@ static void _call_f_isGenerated_c2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlRecord *)cls)->isGenerated (arg1));
 }
 
@@ -323,7 +323,7 @@ static void _call_f_isNull_c767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlRecord *)cls)->isNull (arg1));
 }
 
@@ -342,7 +342,7 @@ static void _call_f_isNull_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QSqlRecord *)cls)->isNull (arg1));
 }
 
@@ -361,7 +361,7 @@ static void _call_f_operator_excl__eq__c2305 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlRecord &arg1 = args.read<const QSqlRecord & > (heap);
+  const QSqlRecord &arg1 = gsi::arg_reader<const QSqlRecord & >() (args, heap);
   ret.write<bool > ((bool)((QSqlRecord *)cls)->operator!= (arg1));
 }
 
@@ -380,7 +380,7 @@ static void _call_f_operator_eq__2305 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlRecord &arg1 = args.read<const QSqlRecord & > (heap);
+  const QSqlRecord &arg1 = gsi::arg_reader<const QSqlRecord & >() (args, heap);
   ret.write<QSqlRecord & > ((QSqlRecord &)((QSqlRecord *)cls)->operator= (arg1));
 }
 
@@ -399,7 +399,7 @@ static void _call_f_operator_eq__eq__c2305 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlRecord &arg1 = args.read<const QSqlRecord & > (heap);
+  const QSqlRecord &arg1 = gsi::arg_reader<const QSqlRecord & >() (args, heap);
   ret.write<bool > ((bool)((QSqlRecord *)cls)->operator== (arg1));
 }
 
@@ -418,7 +418,7 @@ static void _call_f_remove_767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->remove (arg1);
 }
@@ -440,8 +440,8 @@ static void _call_f_replace_2841 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QSqlField &arg2 = args.read<const QSqlField & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QSqlField &arg2 = gsi::arg_reader<const QSqlField & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->replace (arg1, arg2);
 }
@@ -463,8 +463,8 @@ static void _call_f_setGenerated_2781 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->setGenerated (arg1, arg2);
 }
@@ -486,8 +486,8 @@ static void _call_f_setGenerated_1523 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  bool arg2 = args.read<bool > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->setGenerated (arg1, arg2);
 }
@@ -507,7 +507,7 @@ static void _call_f_setNull_767 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->setNull (arg1);
 }
@@ -527,7 +527,7 @@ static void _call_f_setNull_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->setNull (arg1);
 }
@@ -549,8 +549,8 @@ static void _call_f_setValue_2778 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->setValue (arg1, arg2);
 }
@@ -572,8 +572,8 @@ static void _call_f_setValue_4036 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRecord *)cls)->setValue (arg1, arg2);
 }
@@ -593,7 +593,7 @@ static void _call_f_value_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QSqlRecord *)cls)->value (arg1));
 }
 
@@ -612,7 +612,7 @@ static void _call_f_value_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QSqlRecord *)cls)->value (arg1));
 }
 

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlRelation.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlRelation.cc
@@ -69,9 +69,9 @@ static void _call_ctor_QSqlRelation_5859 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QSqlRelation *> (new QSqlRelation (arg1, arg2, arg3));
 }
 

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlRelationalTableModel.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlRelationalTableModel.cc
@@ -97,8 +97,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QSqlRelationalTableModel *)cls)->data (arg1, arg2));
 }
 
@@ -117,7 +117,7 @@ static void _call_f_relation_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QSqlRelation > ((QSqlRelation)((QSqlRelationalTableModel *)cls)->relation (arg1));
 }
 
@@ -136,7 +136,7 @@ static void _call_f_relationModel_c767 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QSqlTableModel * > ((QSqlTableModel *)((QSqlRelationalTableModel *)cls)->relationModel (arg1));
 }
 
@@ -159,9 +159,9 @@ static void _call_f_removeColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSqlRelationalTableModel *)cls)->removeColumns (arg1, arg2, arg3));
 }
 
@@ -180,7 +180,7 @@ static void _call_f_revertRow_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel *)cls)->revertRow (arg1);
 }
@@ -219,9 +219,9 @@ static void _call_f_setData_5065 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QSqlRelationalTableModel *)cls)->setData (arg1, arg2, arg3));
 }
 
@@ -242,8 +242,8 @@ static void _call_f_setRelation_3187 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QSqlRelation &arg2 = args.read<const QSqlRelation & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QSqlRelation &arg2 = gsi::arg_reader<const QSqlRelation & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel *)cls)->setRelation (arg1, arg2);
 }
@@ -263,7 +263,7 @@ static void _call_f_setTable_2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel *)cls)->setTable (arg1);
 }
@@ -285,8 +285,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSqlRelationalTableModel::tr (arg1, arg2));
 }
 
@@ -309,9 +309,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSqlRelationalTableModel::tr (arg1, arg2, arg3));
 }
 
@@ -332,8 +332,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSqlRelationalTableModel::trUtf8 (arg1, arg2));
 }
 
@@ -356,9 +356,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSqlRelationalTableModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1405,8 +1405,8 @@ static void _call_ctor_QSqlRelationalTableModel_Adaptor_2804 (const qt_gsi::Gene
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
-  QSqlDatabase arg2 = args ? args.read<QSqlDatabase > (heap) : (QSqlDatabase)(QSqlDatabase());
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
+  QSqlDatabase arg2 = args ? gsi::arg_reader<QSqlDatabase >() (args, heap) : gsi::arg_maker<QSqlDatabase >() (QSqlDatabase(), heap);
   ret.write<QSqlRelationalTableModel_Adaptor *> (new QSqlRelationalTableModel_Adaptor (arg1, arg2));
 }
 
@@ -1424,7 +1424,7 @@ static void _call_emitter_beforeDelete_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QSqlRelationalTableModel_Adaptor *)cls)->emitter_QSqlRelationalTableModel_beforeDelete_767 (arg1);
 }
 
@@ -1442,7 +1442,7 @@ static void _call_emitter_beforeInsert_1610 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QSqlRecord &arg1 = args.read<QSqlRecord & > (heap);
+  QSqlRecord &arg1 = gsi::arg_reader<QSqlRecord & >() (args, heap);
   ((QSqlRelationalTableModel_Adaptor *)cls)->emitter_QSqlRelationalTableModel_beforeInsert_1610 (arg1);
 }
 
@@ -1462,8 +1462,8 @@ static void _call_emitter_beforeUpdate_2269 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QSqlRecord &arg2 = args.read<QSqlRecord & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QSqlRecord &arg2 = gsi::arg_reader<QSqlRecord & >() (args, heap);
   ((QSqlRelationalTableModel_Adaptor *)cls)->emitter_QSqlRelationalTableModel_beforeUpdate_2269 (arg1, arg2);
 }
 
@@ -1485,9 +1485,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -1510,9 +1510,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1539,11 +1539,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1569,11 +1569,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1595,9 +1595,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -1620,9 +1620,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -1704,8 +1704,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -1726,8 +1726,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -1817,9 +1817,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -1841,9 +1841,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -1865,9 +1865,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -1937,8 +1937,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QSqlRelationalTableModel_Adaptor *)cls)->emitter_QSqlRelationalTableModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -1962,10 +1962,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -2006,7 +2006,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSqlRelationalTableModel_Adaptor *)cls)->emitter_QSqlRelationalTableModel_destroyed_1302 (arg1);
 }
 
@@ -2085,8 +2085,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_encodeData_c4599 (arg1, arg2);
 }
@@ -2339,9 +2339,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QSqlRelationalTableModel_Adaptor *)cls)->emitter_QSqlRelationalTableModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -2388,7 +2388,7 @@ static void _call_fp_indexInQuery_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_indexInQuery_c2395 (arg1));
 }
 
@@ -2650,8 +2650,8 @@ static void _call_emitter_primeInsert_2269 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QSqlRecord &arg2 = args.read<QSqlRecord & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QSqlRecord &arg2 = gsi::arg_reader<QSqlRecord & >() (args, heap);
   ((QSqlRelationalTableModel_Adaptor *)cls)->emitter_QSqlRelationalTableModel_primeInsert_2269 (arg1, arg2);
 }
 
@@ -2689,7 +2689,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_receivers_c1731 (arg1));
 }
 
@@ -3057,7 +3057,7 @@ static void _call_fp_setLastError_2220 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlError &arg1 = args.read<const QSqlError & > (heap);
+  const QSqlError &arg1 = gsi::arg_reader<const QSqlError & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_setLastError_2220 (arg1);
 }
@@ -3076,7 +3076,7 @@ static void _call_fp_setPrimaryKey_2202 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlIndex &arg1 = args.read<const QSqlIndex & > (heap);
+  const QSqlIndex &arg1 = gsi::arg_reader<const QSqlIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_setPrimaryKey_2202 (arg1);
 }
@@ -3095,7 +3095,7 @@ static void _call_fp_setQuery_2232 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlQuery &arg1 = args.read<const QSqlQuery & > (heap);
+  const QSqlQuery &arg1 = gsi::arg_reader<const QSqlQuery & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_setQuery_2232 (arg1);
 }
@@ -3141,7 +3141,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlRelationalTableModel_Adaptor *)cls)->fp_QSqlRelationalTableModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlResult.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlResult.cc
@@ -626,8 +626,8 @@ static void _call_fp_addBindValue_4937 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QVariant &arg1 = args.read<const QVariant & > (heap);
-  QFlags<QSql::ParamTypeFlag> arg2 = args.read<QFlags<QSql::ParamTypeFlag> > (heap);
+  const QVariant &arg1 = gsi::arg_reader<const QVariant & >() (args, heap);
+  QFlags<QSql::ParamTypeFlag> arg2 = gsi::arg_reader<QFlags<QSql::ParamTypeFlag> >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlResult_Adaptor *)cls)->fp_QSqlResult_addBindValue_4937 (arg1, arg2);
 }
@@ -720,7 +720,7 @@ static void _call_fp_bindValueType_c2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QFlags<QSql::ParamTypeFlag> > ((QFlags<QSql::ParamTypeFlag>)((QSqlResult_Adaptor *)cls)->fp_QSqlResult_bindValueType_c2025 (arg1));
 }
 
@@ -738,7 +738,7 @@ static void _call_fp_bindValueType_c767 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QFlags<QSql::ParamTypeFlag> > ((QFlags<QSql::ParamTypeFlag>)((QSqlResult_Adaptor *)cls)->fp_QSqlResult_bindValueType_c767 (arg1));
 }
 
@@ -770,7 +770,7 @@ static void _call_fp_boundValue_c2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QVariant > ((QVariant)((QSqlResult_Adaptor *)cls)->fp_QSqlResult_boundValue_c2025 (arg1));
 }
 
@@ -788,7 +788,7 @@ static void _call_fp_boundValue_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QVariant > ((QVariant)((QSqlResult_Adaptor *)cls)->fp_QSqlResult_boundValue_c767 (arg1));
 }
 
@@ -820,7 +820,7 @@ static void _call_fp_boundValueName_c767 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QSqlResult_Adaptor *)cls)->fp_QSqlResult_boundValueName_c767 (arg1));
 }
 
@@ -938,7 +938,7 @@ static void _call_fp_execBatch_864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(false);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (false, heap);
   ret.write<bool > ((bool)((QSqlResult_Adaptor *)cls)->fp_QSqlResult_execBatch_864 (arg1));
 }
 
@@ -1459,7 +1459,7 @@ static void _call_fp_setNumericalPrecisionPolicy_3429 (const qt_gsi::GenericMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSql::NumericalPrecisionPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlResult_Adaptor *)cls)->fp_QSqlResult_setNumericalPrecisionPolicy_3429 (arg1);
 }

--- a/src/gsiqt/qt4/QtSql/gsiDeclQSqlTableModel.cc
+++ b/src/gsiqt/qt4/QtSql/gsiDeclQSqlTableModel.cc
@@ -95,8 +95,8 @@ static void _call_f_data_c3054 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QSqlTableModel *)cls)->data (arg1, arg2));
 }
 
@@ -145,7 +145,7 @@ static void _call_f_fieldIndex_c2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QSqlTableModel *)cls)->fieldIndex (arg1));
 }
 
@@ -179,7 +179,7 @@ static void _call_f_flags_c2395 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QFlags<Qt::ItemFlag> > ((QFlags<Qt::ItemFlag>)((QSqlTableModel *)cls)->flags (arg1));
 }
 
@@ -202,9 +202,9 @@ static void _call_f_headerData_c3231 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::DisplayRole);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::DisplayRole, heap);
   ret.write<QVariant > ((QVariant)((QSqlTableModel *)cls)->headerData (arg1, qt_gsi::QtToCppAdaptor<Qt::Orientation>(arg2).cref(), arg3));
 }
 
@@ -225,8 +225,8 @@ static void _call_f_insertRecord_2964 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QSqlRecord &arg2 = args.read<const QSqlRecord & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QSqlRecord &arg2 = gsi::arg_reader<const QSqlRecord & >() (args, heap);
   ret.write<bool > ((bool)((QSqlTableModel *)cls)->insertRecord (arg1, arg2));
 }
 
@@ -249,9 +249,9 @@ static void _call_f_insertRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSqlTableModel *)cls)->insertRows (arg1, arg2, arg3));
 }
 
@@ -270,7 +270,7 @@ static void _call_f_isDirty_c2395 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<bool > ((bool)((QSqlTableModel *)cls)->isDirty (arg1));
 }
 
@@ -308,9 +308,9 @@ static void _call_f_removeColumns_3713 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSqlTableModel *)cls)->removeColumns (arg1, arg2, arg3));
 }
 
@@ -333,9 +333,9 @@ static void _call_f_removeRows_3713 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<bool > ((bool)((QSqlTableModel *)cls)->removeRows (arg1, arg2, arg3));
 }
 
@@ -386,7 +386,7 @@ static void _call_f_revertRow_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel *)cls)->revertRow (arg1);
 }
@@ -406,7 +406,7 @@ static void _call_f_rowCount_c2395 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args ? args.read<const QModelIndex & > (heap) : (const QModelIndex &)(QModelIndex());
+  const QModelIndex &arg1 = args ? gsi::arg_reader<const QModelIndex & >() (args, heap) : gsi::arg_maker<const QModelIndex & >() (QModelIndex(), heap);
   ret.write<int > ((int)((QSqlTableModel *)cls)->rowCount (arg1));
 }
 
@@ -444,9 +444,9 @@ static void _call_f_setData_5065 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QVariant &arg2 = args.read<const QVariant & > (heap);
-  int arg3 = args ? args.read<int > (heap) : (int)(Qt::EditRole);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QVariant &arg2 = gsi::arg_reader<const QVariant & >() (args, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (Qt::EditRole, heap);
   ret.write<bool > ((bool)((QSqlTableModel *)cls)->setData (arg1, arg2, arg3));
 }
 
@@ -465,7 +465,7 @@ static void _call_f_setEditStrategy_3163 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QSqlTableModel::EditStrategy>::target_type & arg1 = args.read<const qt_gsi::Converter<QSqlTableModel::EditStrategy>::target_type & > (heap);
+  const qt_gsi::Converter<QSqlTableModel::EditStrategy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QSqlTableModel::EditStrategy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel *)cls)->setEditStrategy (qt_gsi::QtToCppAdaptor<QSqlTableModel::EditStrategy>(arg1).cref());
 }
@@ -485,7 +485,7 @@ static void _call_f_setFilter_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel *)cls)->setFilter (arg1);
 }
@@ -507,8 +507,8 @@ static void _call_f_setRecord_2964 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const QSqlRecord &arg2 = args.read<const QSqlRecord & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const QSqlRecord &arg2 = gsi::arg_reader<const QSqlRecord & >() (args, heap);
   ret.write<bool > ((bool)((QSqlTableModel *)cls)->setRecord (arg1, arg2));
 }
 
@@ -529,8 +529,8 @@ static void _call_f_setSort_2340 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel *)cls)->setSort (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -550,7 +550,7 @@ static void _call_f_setTable_2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel *)cls)->setTable (arg1);
 }
@@ -572,8 +572,8 @@ static void _call_f_sort_2340 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = args.read<const qt_gsi::Converter<Qt::SortOrder>::target_type & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<Qt::SortOrder>::target_type & arg2 = gsi::arg_reader<const qt_gsi::Converter<Qt::SortOrder>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel *)cls)->sort (arg1, qt_gsi::QtToCppAdaptor<Qt::SortOrder>(arg2).cref());
 }
@@ -640,8 +640,8 @@ static void _call_f_tr_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSqlTableModel::tr (arg1, arg2));
 }
 
@@ -664,9 +664,9 @@ static void _call_f_tr_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, gsi::
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSqlTableModel::tr (arg1, arg2, arg3));
 }
 
@@ -687,8 +687,8 @@ static void _call_f_trUtf8_3354 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args ? args.read<const char * > (heap) : (const char *)(0);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = args ? gsi::arg_reader<const char * >() (args, heap) : gsi::arg_maker<const char * >() (0, heap);
   ret.write<QString > ((QString)QSqlTableModel::trUtf8 (arg1, arg2));
 }
 
@@ -711,9 +711,9 @@ static void _call_f_trUtf8_4013 (const qt_gsi::GenericStaticMethod * /*decl*/, g
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
-  const char *arg2 = args.read<const char * > (heap);
-  int arg3 = args.read<int > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
+  const char *arg2 = gsi::arg_reader<const char * >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)QSqlTableModel::trUtf8 (arg1, arg2, arg3));
 }
 
@@ -1747,8 +1747,8 @@ static void _call_ctor_QSqlTableModel_Adaptor_2804 (const qt_gsi::GenericStaticM
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
-  QSqlDatabase arg2 = args ? args.read<QSqlDatabase > (heap) : (QSqlDatabase)(QSqlDatabase());
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
+  QSqlDatabase arg2 = args ? gsi::arg_reader<QSqlDatabase >() (args, heap) : gsi::arg_maker<QSqlDatabase >() (QSqlDatabase(), heap);
   ret.write<QSqlTableModel_Adaptor *> (new QSqlTableModel_Adaptor (arg1, arg2));
 }
 
@@ -1766,7 +1766,7 @@ static void _call_emitter_beforeDelete_767 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ((QSqlTableModel_Adaptor *)cls)->emitter_QSqlTableModel_beforeDelete_767 (arg1);
 }
 
@@ -1784,7 +1784,7 @@ static void _call_emitter_beforeInsert_1610 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QSqlRecord &arg1 = args.read<QSqlRecord & > (heap);
+  QSqlRecord &arg1 = gsi::arg_reader<QSqlRecord & >() (args, heap);
   ((QSqlTableModel_Adaptor *)cls)->emitter_QSqlTableModel_beforeInsert_1610 (arg1);
 }
 
@@ -1804,8 +1804,8 @@ static void _call_emitter_beforeUpdate_2269 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QSqlRecord &arg2 = args.read<QSqlRecord & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QSqlRecord &arg2 = gsi::arg_reader<QSqlRecord & >() (args, heap);
   ((QSqlTableModel_Adaptor *)cls)->emitter_QSqlTableModel_beforeUpdate_2269 (arg1, arg2);
 }
 
@@ -1827,9 +1827,9 @@ static void _call_fp_beginInsertColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_beginInsertColumns_3713 (arg1, arg2, arg3);
 }
@@ -1852,9 +1852,9 @@ static void _call_fp_beginInsertRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_beginInsertRows_3713 (arg1, arg2, arg3);
 }
@@ -1881,11 +1881,11 @@ static void _call_fp_beginMoveColumns_6659 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_beginMoveColumns_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1911,11 +1911,11 @@ static void _call_fp_beginMoveRows_6659 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
-  const QModelIndex &arg4 = args.read<const QModelIndex & > (heap);
-  int arg5 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg4 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg5 = gsi::arg_reader<int >() (args, heap);
   ret.write<bool > ((bool)((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_beginMoveRows_6659 (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -1937,9 +1937,9 @@ static void _call_fp_beginRemoveColumns_3713 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_beginRemoveColumns_3713 (arg1, arg2, arg3);
 }
@@ -1962,9 +1962,9 @@ static void _call_fp_beginRemoveRows_3713 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_beginRemoveRows_3713 (arg1, arg2, arg3);
 }
@@ -2046,8 +2046,8 @@ static void _call_fp_changePersistentIndex_4682 (const qt_gsi::GenericMethod * /
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_changePersistentIndex_4682 (arg1, arg2);
 }
@@ -2068,8 +2068,8 @@ static void _call_fp_changePersistentIndexList_5912 (const qt_gsi::GenericMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  const QList<QModelIndex> &arg2 = args.read<const QList<QModelIndex> & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  const QList<QModelIndex> &arg2 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_changePersistentIndexList_5912 (arg1, arg2);
 }
@@ -2159,9 +2159,9 @@ static void _call_fp_createIndex_c2374 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  void *arg3 = args ? args.read<void * > (heap) : (void *)(0);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  void *arg3 = args ? gsi::arg_reader<void * >() (args, heap) : gsi::arg_maker<void * >() (0, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_createIndex_c2374 (arg1, arg2, arg3));
 }
 
@@ -2183,9 +2183,9 @@ static void _call_fp_createIndex_c2085 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_createIndex_c2085 (arg1, arg2, arg3));
 }
 
@@ -2207,9 +2207,9 @@ static void _call_fp_createIndex_c2416 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  quint32 arg3 = args.read<quint32 > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  quint32 arg3 = gsi::arg_reader<quint32 >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_createIndex_c2416 (arg1, arg2, arg3));
 }
 
@@ -2279,8 +2279,8 @@ static void _call_emitter_dataChanged_4682 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
-  const QModelIndex &arg2 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  const QModelIndex &arg2 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ((QSqlTableModel_Adaptor *)cls)->emitter_QSqlTableModel_dataChanged_4682 (arg1, arg2);
 }
 
@@ -2304,10 +2304,10 @@ static void _call_fp_decodeData_5302 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  int arg2 = args.read<int > (heap);
-  const QModelIndex &arg3 = args.read<const QModelIndex & > (heap);
-  QDataStream &arg4 = args.read<QDataStream & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const QModelIndex &arg3 = gsi::arg_reader<const QModelIndex & >() (args, heap);
+  QDataStream &arg4 = gsi::arg_reader<QDataStream & >() (args, heap);
   ret.write<bool > ((bool)((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_decodeData_5302 (arg1, arg2, arg3, arg4));
 }
 
@@ -2348,7 +2348,7 @@ static void _call_emitter_destroyed_1302 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QObject *arg1 = args ? args.read<QObject * > (heap) : (QObject *)(0);
+  QObject *arg1 = args ? gsi::arg_reader<QObject * >() (args, heap) : gsi::arg_maker<QObject * >() (0, heap);
   ((QSqlTableModel_Adaptor *)cls)->emitter_QSqlTableModel_destroyed_1302 (arg1);
 }
 
@@ -2427,8 +2427,8 @@ static void _call_fp_encodeData_c4599 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QList<QModelIndex> &arg1 = args.read<const QList<QModelIndex> & > (heap);
-  QDataStream &arg2 = args.read<QDataStream & > (heap);
+  const QList<QModelIndex> &arg1 = gsi::arg_reader<const QList<QModelIndex> & >() (args, heap);
+  QDataStream &arg2 = gsi::arg_reader<QDataStream & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_encodeData_c4599 (arg1, arg2);
 }
@@ -2681,9 +2681,9 @@ static void _call_emitter_headerDataChanged_3231 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = args.read<const qt_gsi::Converter<Qt::Orientation>::target_type & > (heap);
-  int arg2 = args.read<int > (heap);
-  int arg3 = args.read<int > (heap);
+  const qt_gsi::Converter<Qt::Orientation>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<Qt::Orientation>::target_type & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   ((QSqlTableModel_Adaptor *)cls)->emitter_QSqlTableModel_headerDataChanged_3231 (arg1, arg2, arg3);
 }
 
@@ -2730,7 +2730,7 @@ static void _call_fp_indexInQuery_c2395 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QModelIndex &arg1 = args.read<const QModelIndex & > (heap);
+  const QModelIndex &arg1 = gsi::arg_reader<const QModelIndex & >() (args, heap);
   ret.write<QModelIndex > ((QModelIndex)((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_indexInQuery_c2395 (arg1));
 }
 
@@ -2992,8 +2992,8 @@ static void _call_emitter_primeInsert_2269 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
-  QSqlRecord &arg2 = args.read<QSqlRecord & > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
+  QSqlRecord &arg2 = gsi::arg_reader<QSqlRecord & >() (args, heap);
   ((QSqlTableModel_Adaptor *)cls)->emitter_QSqlTableModel_primeInsert_2269 (arg1, arg2);
 }
 
@@ -3031,7 +3031,7 @@ static void _call_fp_receivers_c1731 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const char *arg1 = args.read<const char * > (heap);
+  const char *arg1 = gsi::arg_reader<const char * >() (args, heap);
   ret.write<int > ((int)((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_receivers_c1731 (arg1));
 }
 
@@ -3376,7 +3376,7 @@ static void _call_fp_setLastError_2220 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlError &arg1 = args.read<const QSqlError & > (heap);
+  const QSqlError &arg1 = gsi::arg_reader<const QSqlError & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_setLastError_2220 (arg1);
 }
@@ -3395,7 +3395,7 @@ static void _call_fp_setPrimaryKey_2202 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlIndex &arg1 = args.read<const QSqlIndex & > (heap);
+  const QSqlIndex &arg1 = gsi::arg_reader<const QSqlIndex & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_setPrimaryKey_2202 (arg1);
 }
@@ -3414,7 +3414,7 @@ static void _call_fp_setQuery_2232 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QSqlQuery &arg1 = args.read<const QSqlQuery & > (heap);
+  const QSqlQuery &arg1 = gsi::arg_reader<const QSqlQuery & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_setQuery_2232 (arg1);
 }
@@ -3433,7 +3433,7 @@ static void _call_fp_setRoleNames_3419 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QHash<int, QByteArray> &arg1 = args.read<const QHash<int, QByteArray> & > (heap);
+  const QHash<int, QByteArray> &arg1 = gsi::arg_reader<const QHash<int, QByteArray> & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QSqlTableModel_Adaptor *)cls)->fp_QSqlTableModel_setRoleNames_3419 (arg1);
 }

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomAttr.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomAttr.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomAttr_2093 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomAttr &arg1 = args.read<const QDomAttr & > (heap);
+  const QDomAttr &arg1 = gsi::arg_reader<const QDomAttr & >() (args, heap);
   ret.write<QDomAttr *> (new QDomAttr (arg1));
 }
 
@@ -130,7 +130,7 @@ static void _call_f_operator_eq__2093 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomAttr &arg1 = args.read<const QDomAttr & > (heap);
+  const QDomAttr &arg1 = gsi::arg_reader<const QDomAttr & >() (args, heap);
   ret.write<QDomAttr & > ((QDomAttr &)((QDomAttr *)cls)->operator= (arg1));
 }
 
@@ -164,7 +164,7 @@ static void _call_f_setValue_2025 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomAttr *)cls)->setValue (arg1);
 }

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomCDATASection.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomCDATASection.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomCDATASection_2756 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomCDATASection &arg1 = args.read<const QDomCDATASection & > (heap);
+  const QDomCDATASection &arg1 = gsi::arg_reader<const QDomCDATASection & >() (args, heap);
   ret.write<QDomCDATASection *> (new QDomCDATASection (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_operator_eq__2756 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomCDATASection &arg1 = args.read<const QDomCDATASection & > (heap);
+  const QDomCDATASection &arg1 = gsi::arg_reader<const QDomCDATASection & >() (args, heap);
   ret.write<QDomCDATASection & > ((QDomCDATASection &)((QDomCDATASection *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomCharacterData.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomCharacterData.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomCharacterData_2969 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomCharacterData &arg1 = args.read<const QDomCharacterData & > (heap);
+  const QDomCharacterData &arg1 = gsi::arg_reader<const QDomCharacterData & >() (args, heap);
   ret.write<QDomCharacterData *> (new QDomCharacterData (arg1));
 }
 
@@ -100,7 +100,7 @@ static void _call_f_appendData_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomCharacterData *)cls)->appendData (arg1);
 }
@@ -137,8 +137,8 @@ static void _call_f_deleteData_4588 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned long int arg1 = args.read<unsigned long int > (heap);
-  unsigned long int arg2 = args.read<unsigned long int > (heap);
+  unsigned long int arg1 = gsi::arg_reader<unsigned long int >() (args, heap);
+  unsigned long int arg2 = gsi::arg_reader<unsigned long int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomCharacterData *)cls)->deleteData (arg1, arg2);
 }
@@ -160,8 +160,8 @@ static void _call_f_insertData_4265 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned long int arg1 = args.read<unsigned long int > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  unsigned long int arg1 = gsi::arg_reader<unsigned long int >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomCharacterData *)cls)->insertData (arg1, arg2);
 }
@@ -211,7 +211,7 @@ static void _call_f_operator_eq__2969 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomCharacterData &arg1 = args.read<const QDomCharacterData & > (heap);
+  const QDomCharacterData &arg1 = gsi::arg_reader<const QDomCharacterData & >() (args, heap);
   ret.write<QDomCharacterData & > ((QDomCharacterData &)((QDomCharacterData *)cls)->operator= (arg1));
 }
 
@@ -234,9 +234,9 @@ static void _call_f_replaceData_6505 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned long int arg1 = args.read<unsigned long int > (heap);
-  unsigned long int arg2 = args.read<unsigned long int > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  unsigned long int arg1 = gsi::arg_reader<unsigned long int >() (args, heap);
+  unsigned long int arg2 = gsi::arg_reader<unsigned long int >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomCharacterData *)cls)->replaceData (arg1, arg2, arg3);
 }
@@ -256,7 +256,7 @@ static void _call_f_setData_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomCharacterData *)cls)->setData (arg1);
 }
@@ -278,8 +278,8 @@ static void _call_f_substringData_4588 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  unsigned long int arg1 = args.read<unsigned long int > (heap);
-  unsigned long int arg2 = args.read<unsigned long int > (heap);
+  unsigned long int arg1 = gsi::arg_reader<unsigned long int >() (args, heap);
+  unsigned long int arg2 = gsi::arg_reader<unsigned long int >() (args, heap);
   ret.write<QString > ((QString)((QDomCharacterData *)cls)->substringData (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomComment.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomComment.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomComment_2405 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomComment &arg1 = args.read<const QDomComment & > (heap);
+  const QDomComment &arg1 = gsi::arg_reader<const QDomComment & >() (args, heap);
   ret.write<QDomComment *> (new QDomComment (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_operator_eq__2405 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomComment &arg1 = args.read<const QDomComment & > (heap);
+  const QDomComment &arg1 = gsi::arg_reader<const QDomComment & >() (args, heap);
   ret.write<QDomComment & > ((QDomComment &)((QDomComment *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomDocument.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomDocument.cc
@@ -85,7 +85,7 @@ static void _call_ctor_QDomDocument_2025 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomDocument *> (new QDomDocument (arg1));
 }
 
@@ -104,7 +104,7 @@ static void _call_ctor_QDomDocument_2931 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomDocumentType &arg1 = args.read<const QDomDocumentType & > (heap);
+  const QDomDocumentType &arg1 = gsi::arg_reader<const QDomDocumentType & >() (args, heap);
   ret.write<QDomDocument *> (new QDomDocument (arg1));
 }
 
@@ -123,7 +123,7 @@ static void _call_ctor_QDomDocument_2513 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomDocument &arg1 = args.read<const QDomDocument & > (heap);
+  const QDomDocument &arg1 = gsi::arg_reader<const QDomDocument & >() (args, heap);
   ret.write<QDomDocument *> (new QDomDocument (arg1));
 }
 
@@ -142,7 +142,7 @@ static void _call_f_createAttribute_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomAttr > ((QDomAttr)((QDomDocument *)cls)->createAttribute (arg1));
 }
 
@@ -163,8 +163,8 @@ static void _call_f_createAttributeNS_3942 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomAttr > ((QDomAttr)((QDomDocument *)cls)->createAttributeNS (arg1, arg2));
 }
 
@@ -183,7 +183,7 @@ static void _call_f_createCDATASection_2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomCDATASection > ((QDomCDATASection)((QDomDocument *)cls)->createCDATASection (arg1));
 }
 
@@ -202,7 +202,7 @@ static void _call_f_createComment_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomComment > ((QDomComment)((QDomDocument *)cls)->createComment (arg1));
 }
 
@@ -236,7 +236,7 @@ static void _call_f_createElement_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomElement > ((QDomElement)((QDomDocument *)cls)->createElement (arg1));
 }
 
@@ -257,8 +257,8 @@ static void _call_f_createElementNS_3942 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomElement > ((QDomElement)((QDomDocument *)cls)->createElementNS (arg1, arg2));
 }
 
@@ -277,7 +277,7 @@ static void _call_f_createEntityReference_2025 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomEntityReference > ((QDomEntityReference)((QDomDocument *)cls)->createEntityReference (arg1));
 }
 
@@ -298,8 +298,8 @@ static void _call_f_createProcessingInstruction_3942 (const qt_gsi::GenericMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomProcessingInstruction > ((QDomProcessingInstruction)((QDomDocument *)cls)->createProcessingInstruction (arg1, arg2));
 }
 
@@ -318,7 +318,7 @@ static void _call_f_createTextNode_2025 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomText > ((QDomText)((QDomDocument *)cls)->createTextNode (arg1));
 }
 
@@ -367,7 +367,7 @@ static void _call_f_elementById_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomElement > ((QDomElement)((QDomDocument *)cls)->elementById (arg1));
 }
 
@@ -386,7 +386,7 @@ static void _call_f_elementsByTagName_c2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomNodeList > ((QDomNodeList)((QDomDocument *)cls)->elementsByTagName (arg1));
 }
 
@@ -407,8 +407,8 @@ static void _call_f_elementsByTagNameNS_3942 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomNodeList > ((QDomNodeList)((QDomDocument *)cls)->elementsByTagNameNS (arg1, arg2));
 }
 
@@ -444,8 +444,8 @@ static void _call_f_importNode_2828 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomDocument *)cls)->importNode (arg1, arg2));
 }
 
@@ -479,7 +479,7 @@ static void _call_f_operator_eq__2513 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomDocument &arg1 = args.read<const QDomDocument & > (heap);
+  const QDomDocument &arg1 = gsi::arg_reader<const QDomDocument & >() (args, heap);
   ret.write<QDomDocument & > ((QDomDocument &)((QDomDocument *)cls)->operator= (arg1));
 }
 
@@ -506,11 +506,11 @@ static void _call_f_setContent_5697 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool arg2 = args.read<bool > (heap);
-  QString *arg3 = args ? args.read<QString * > (heap) : (QString *)(0);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
-  int *arg5 = args ? args.read<int * > (heap) : (int *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
+  QString *arg3 = args ? gsi::arg_reader<QString * >() (args, heap) : gsi::arg_maker<QString * >() (0, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
+  int *arg5 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<bool > ((bool)((QDomDocument *)cls)->setContent (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -537,11 +537,11 @@ static void _call_f_setContent_5119 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  bool arg2 = args.read<bool > (heap);
-  QString *arg3 = args ? args.read<QString * > (heap) : (QString *)(0);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
-  int *arg5 = args ? args.read<int * > (heap) : (int *)(0);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
+  QString *arg3 = args ? gsi::arg_reader<QString * >() (args, heap) : gsi::arg_maker<QString * >() (0, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
+  int *arg5 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<bool > ((bool)((QDomDocument *)cls)->setContent (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -568,11 +568,11 @@ static void _call_f_setContent_5833 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlInputSource *arg1 = args.read<QXmlInputSource * > (heap);
-  bool arg2 = args.read<bool > (heap);
-  QString *arg3 = args ? args.read<QString * > (heap) : (QString *)(0);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
-  int *arg5 = args ? args.read<int * > (heap) : (int *)(0);
+  QXmlInputSource *arg1 = gsi::arg_reader<QXmlInputSource * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
+  QString *arg3 = args ? gsi::arg_reader<QString * >() (args, heap) : gsi::arg_maker<QString * >() (0, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
+  int *arg5 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<bool > ((bool)((QDomDocument *)cls)->setContent (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -597,10 +597,10 @@ static void _call_f_setContent_4941 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QString *arg2 = args ? args.read<QString * > (heap) : (QString *)(0);
-  int *arg3 = args ? args.read<int * > (heap) : (int *)(0);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QString *arg2 = args ? gsi::arg_reader<QString * >() (args, heap) : gsi::arg_maker<QString * >() (0, heap);
+  int *arg3 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<bool > ((bool)((QDomDocument *)cls)->setContent (arg1, arg2, arg3, arg4));
 }
 
@@ -625,10 +625,10 @@ static void _call_f_setContent_4363 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
-  QString *arg2 = args ? args.read<QString * > (heap) : (QString *)(0);
-  int *arg3 = args ? args.read<int * > (heap) : (int *)(0);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
+  QString *arg2 = args ? gsi::arg_reader<QString * >() (args, heap) : gsi::arg_maker<QString * >() (0, heap);
+  int *arg3 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<bool > ((bool)((QDomDocument *)cls)->setContent (arg1, arg2, arg3, arg4));
 }
 
@@ -655,11 +655,11 @@ static void _call_f_setContent_6572 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlInputSource *arg1 = args.read<QXmlInputSource * > (heap);
-  QXmlReader *arg2 = args.read<QXmlReader * > (heap);
-  QString *arg3 = args ? args.read<QString * > (heap) : (QString *)(0);
-  int *arg4 = args ? args.read<int * > (heap) : (int *)(0);
-  int *arg5 = args ? args.read<int * > (heap) : (int *)(0);
+  QXmlInputSource *arg1 = gsi::arg_reader<QXmlInputSource * >() (args, heap);
+  QXmlReader *arg2 = gsi::arg_reader<QXmlReader * >() (args, heap);
+  QString *arg3 = args ? gsi::arg_reader<QString * >() (args, heap) : gsi::arg_maker<QString * >() (0, heap);
+  int *arg4 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
+  int *arg5 = args ? gsi::arg_reader<int * >() (args, heap) : gsi::arg_maker<int * >() (0, heap);
   ret.write<bool > ((bool)((QDomDocument *)cls)->setContent (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -678,7 +678,7 @@ static void _call_f_toByteArray_c767 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   ret.write<QByteArray > ((QByteArray)((QDomDocument *)cls)->toByteArray (arg1));
 }
 
@@ -697,7 +697,7 @@ static void _call_f_toString_c767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args ? args.read<int > (heap) : (int)(1);
+  int arg1 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (1, heap);
   ret.write<QString > ((QString)((QDomDocument *)cls)->toString (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomDocumentFragment.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomDocumentFragment.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomDocumentFragment_3333 (const qt_gsi::GenericStaticMet
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomDocumentFragment &arg1 = args.read<const QDomDocumentFragment & > (heap);
+  const QDomDocumentFragment &arg1 = gsi::arg_reader<const QDomDocumentFragment & >() (args, heap);
   ret.write<QDomDocumentFragment *> (new QDomDocumentFragment (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_operator_eq__3333 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomDocumentFragment &arg1 = args.read<const QDomDocumentFragment & > (heap);
+  const QDomDocumentFragment &arg1 = gsi::arg_reader<const QDomDocumentFragment & >() (args, heap);
   ret.write<QDomDocumentFragment & > ((QDomDocumentFragment &)((QDomDocumentFragment *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomDocumentType.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomDocumentType.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomDocumentType_2931 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomDocumentType &arg1 = args.read<const QDomDocumentType & > (heap);
+  const QDomDocumentType &arg1 = gsi::arg_reader<const QDomDocumentType & >() (args, heap);
   ret.write<QDomDocumentType *> (new QDomDocumentType (arg1));
 }
 
@@ -175,7 +175,7 @@ static void _call_f_operator_eq__2931 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomDocumentType &arg1 = args.read<const QDomDocumentType & > (heap);
+  const QDomDocumentType &arg1 = gsi::arg_reader<const QDomDocumentType & >() (args, heap);
   ret.write<QDomDocumentType & > ((QDomDocumentType &)((QDomDocumentType *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomElement.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomElement.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomElement_2396 (const qt_gsi::GenericStaticMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomElement &arg1 = args.read<const QDomElement & > (heap);
+  const QDomElement &arg1 = gsi::arg_reader<const QDomElement & >() (args, heap);
   ret.write<QDomElement *> (new QDomElement (arg1));
 }
 
@@ -102,8 +102,8 @@ static void _call_f_attribute_c3942 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QString > ((QString)((QDomElement *)cls)->attribute (arg1, arg2));
 }
 
@@ -126,9 +126,9 @@ static void _call_f_attributeNS_c5677 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString arg1 = args.read<const QString > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString arg1 = gsi::arg_reader<const QString >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QString > ((QString)((QDomElement *)cls)->attributeNS (arg1, arg2, arg3));
 }
 
@@ -147,7 +147,7 @@ static void _call_f_attributeNode_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomAttr > ((QDomAttr)((QDomElement *)cls)->attributeNode (arg1));
 }
 
@@ -168,8 +168,8 @@ static void _call_f_attributeNodeNS_3942 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomAttr > ((QDomAttr)((QDomElement *)cls)->attributeNodeNS (arg1, arg2));
 }
 
@@ -203,7 +203,7 @@ static void _call_f_elementsByTagName_c2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomNodeList > ((QDomNodeList)((QDomElement *)cls)->elementsByTagName (arg1));
 }
 
@@ -224,8 +224,8 @@ static void _call_f_elementsByTagNameNS_c3942 (const qt_gsi::GenericMethod * /*d
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomNodeList > ((QDomNodeList)((QDomElement *)cls)->elementsByTagNameNS (arg1, arg2));
 }
 
@@ -244,7 +244,7 @@ static void _call_f_hasAttribute_c2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDomElement *)cls)->hasAttribute (arg1));
 }
 
@@ -265,8 +265,8 @@ static void _call_f_hasAttributeNS_c3942 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDomElement *)cls)->hasAttributeNS (arg1, arg2));
 }
 
@@ -300,7 +300,7 @@ static void _call_f_operator_eq__2396 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomElement &arg1 = args.read<const QDomElement & > (heap);
+  const QDomElement &arg1 = gsi::arg_reader<const QDomElement & >() (args, heap);
   ret.write<QDomElement & > ((QDomElement &)((QDomElement *)cls)->operator= (arg1));
 }
 
@@ -319,7 +319,7 @@ static void _call_f_removeAttribute_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->removeAttribute (arg1);
 }
@@ -341,8 +341,8 @@ static void _call_f_removeAttributeNS_3942 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->removeAttributeNS (arg1, arg2);
 }
@@ -362,7 +362,7 @@ static void _call_f_removeAttributeNode_2093 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomAttr &arg1 = args.read<const QDomAttr & > (heap);
+  const QDomAttr &arg1 = gsi::arg_reader<const QDomAttr & >() (args, heap);
   ret.write<QDomAttr > ((QDomAttr)((QDomElement *)cls)->removeAttributeNode (arg1));
 }
 
@@ -383,8 +383,8 @@ static void _call_f_setAttribute_3942 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttribute (arg1, arg2);
 }
@@ -406,8 +406,8 @@ static void _call_f_setAttribute_3330 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  qlonglong arg2 = args.read<qlonglong > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  qlonglong arg2 = gsi::arg_reader<qlonglong >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttribute (arg1, arg2);
 }
@@ -429,8 +429,8 @@ static void _call_f_setAttribute_3447 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  qulonglong arg2 = args.read<qulonglong > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  qulonglong arg2 = gsi::arg_reader<qulonglong >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttribute (arg1, arg2);
 }
@@ -452,8 +452,8 @@ static void _call_f_setAttribute_2684 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  int arg2 = args.read<int > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttribute (arg1, arg2);
 }
@@ -475,8 +475,8 @@ static void _call_f_setAttribute_3689 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  unsigned int arg2 = args.read<unsigned int > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  unsigned int arg2 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttribute (arg1, arg2);
 }
@@ -498,8 +498,8 @@ static void _call_f_setAttribute_2887 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  float arg2 = args.read<float > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  float arg2 = gsi::arg_reader<float >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttribute (arg1, arg2);
 }
@@ -521,8 +521,8 @@ static void _call_f_setAttribute_2988 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  double arg2 = args.read<double > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  double arg2 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttribute (arg1, arg2);
 }
@@ -546,9 +546,9 @@ static void _call_f_setAttributeNS_5677 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString arg1 = args.read<const QString > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString arg1 = gsi::arg_reader<const QString >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttributeNS (arg1, arg2, arg3);
 }
@@ -572,9 +572,9 @@ static void _call_f_setAttributeNS_4419 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString arg1 = args.read<const QString > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  int arg3 = args.read<int > (heap);
+  const QString arg1 = gsi::arg_reader<const QString >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  int arg3 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttributeNS (arg1, arg2, arg3);
 }
@@ -598,9 +598,9 @@ static void _call_f_setAttributeNS_5424 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString arg1 = args.read<const QString > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  unsigned int arg3 = args.read<unsigned int > (heap);
+  const QString arg1 = gsi::arg_reader<const QString >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  unsigned int arg3 = gsi::arg_reader<unsigned int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttributeNS (arg1, arg2, arg3);
 }
@@ -624,9 +624,9 @@ static void _call_f_setAttributeNS_5065 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString arg1 = args.read<const QString > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  qlonglong arg3 = args.read<qlonglong > (heap);
+  const QString arg1 = gsi::arg_reader<const QString >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  qlonglong arg3 = gsi::arg_reader<qlonglong >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttributeNS (arg1, arg2, arg3);
 }
@@ -650,9 +650,9 @@ static void _call_f_setAttributeNS_5182 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString arg1 = args.read<const QString > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  qulonglong arg3 = args.read<qulonglong > (heap);
+  const QString arg1 = gsi::arg_reader<const QString >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  qulonglong arg3 = gsi::arg_reader<qulonglong >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttributeNS (arg1, arg2, arg3);
 }
@@ -676,9 +676,9 @@ static void _call_f_setAttributeNS_4723 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString arg1 = args.read<const QString > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  double arg3 = args.read<double > (heap);
+  const QString arg1 = gsi::arg_reader<const QString >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  double arg3 = gsi::arg_reader<double >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setAttributeNS (arg1, arg2, arg3);
 }
@@ -698,7 +698,7 @@ static void _call_f_setAttributeNode_2093 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomAttr &arg1 = args.read<const QDomAttr & > (heap);
+  const QDomAttr &arg1 = gsi::arg_reader<const QDomAttr & >() (args, heap);
   ret.write<QDomAttr > ((QDomAttr)((QDomElement *)cls)->setAttributeNode (arg1));
 }
 
@@ -717,7 +717,7 @@ static void _call_f_setAttributeNodeNS_2093 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomAttr &arg1 = args.read<const QDomAttr & > (heap);
+  const QDomAttr &arg1 = gsi::arg_reader<const QDomAttr & >() (args, heap);
   ret.write<QDomAttr > ((QDomAttr)((QDomElement *)cls)->setAttributeNodeNS (arg1));
 }
 
@@ -736,7 +736,7 @@ static void _call_f_setTagName_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomElement *)cls)->setTagName (arg1);
 }

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomEntity.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomEntity.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomEntity_2319 (const qt_gsi::GenericStaticMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomEntity &arg1 = args.read<const QDomEntity & > (heap);
+  const QDomEntity &arg1 = gsi::arg_reader<const QDomEntity & >() (args, heap);
   ret.write<QDomEntity *> (new QDomEntity (arg1));
 }
 
@@ -130,7 +130,7 @@ static void _call_f_operator_eq__2319 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomEntity &arg1 = args.read<const QDomEntity & > (heap);
+  const QDomEntity &arg1 = gsi::arg_reader<const QDomEntity & >() (args, heap);
   ret.write<QDomEntity & > ((QDomEntity &)((QDomEntity *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomEntityReference.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomEntityReference.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomEntityReference_3230 (const qt_gsi::GenericStaticMeth
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomEntityReference &arg1 = args.read<const QDomEntityReference & > (heap);
+  const QDomEntityReference &arg1 = gsi::arg_reader<const QDomEntityReference & >() (args, heap);
   ret.write<QDomEntityReference *> (new QDomEntityReference (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_operator_eq__3230 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomEntityReference &arg1 = args.read<const QDomEntityReference & > (heap);
+  const QDomEntityReference &arg1 = gsi::arg_reader<const QDomEntityReference & >() (args, heap);
   ret.write<QDomEntityReference & > ((QDomEntityReference &)((QDomEntityReference *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomImplementation.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomImplementation.cc
@@ -67,7 +67,7 @@ static void _call_ctor_QDomImplementation_3160 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomImplementation &arg1 = args.read<const QDomImplementation & > (heap);
+  const QDomImplementation &arg1 = gsi::arg_reader<const QDomImplementation & >() (args, heap);
   ret.write<QDomImplementation *> (new QDomImplementation (arg1));
 }
 
@@ -90,9 +90,9 @@ static void _call_f_createDocument_6765 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QDomDocumentType &arg3 = args.read<const QDomDocumentType & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QDomDocumentType &arg3 = gsi::arg_reader<const QDomDocumentType & >() (args, heap);
   ret.write<QDomDocument > ((QDomDocument)((QDomImplementation *)cls)->createDocument (arg1, arg2, arg3));
 }
 
@@ -115,9 +115,9 @@ static void _call_f_createDocumentType_5859 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomDocumentType > ((QDomDocumentType)((QDomImplementation *)cls)->createDocumentType (arg1, arg2, arg3));
 }
 
@@ -138,8 +138,8 @@ static void _call_f_hasFeature_c3942 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDomImplementation *)cls)->hasFeature (arg1, arg2));
 }
 
@@ -173,7 +173,7 @@ static void _call_f_operator_excl__eq__c3160 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomImplementation &arg1 = args.read<const QDomImplementation & > (heap);
+  const QDomImplementation &arg1 = gsi::arg_reader<const QDomImplementation & >() (args, heap);
   ret.write<bool > ((bool)((QDomImplementation *)cls)->operator!= (arg1));
 }
 
@@ -192,7 +192,7 @@ static void _call_f_operator_eq__3160 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomImplementation &arg1 = args.read<const QDomImplementation & > (heap);
+  const QDomImplementation &arg1 = gsi::arg_reader<const QDomImplementation & >() (args, heap);
   ret.write<QDomImplementation & > ((QDomImplementation &)((QDomImplementation *)cls)->operator= (arg1));
 }
 
@@ -211,7 +211,7 @@ static void _call_f_operator_eq__eq__c3160 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomImplementation &arg1 = args.read<const QDomImplementation & > (heap);
+  const QDomImplementation &arg1 = gsi::arg_reader<const QDomImplementation & >() (args, heap);
   ret.write<bool > ((bool)((QDomImplementation *)cls)->operator== (arg1));
 }
 
@@ -245,7 +245,7 @@ static void _call_f_setInvalidDataPolicy_4112 (const qt_gsi::GenericStaticMethod
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const qt_gsi::Converter<QDomImplementation::InvalidDataPolicy>::target_type & arg1 = args.read<const qt_gsi::Converter<QDomImplementation::InvalidDataPolicy>::target_type & > (heap);
+  const qt_gsi::Converter<QDomImplementation::InvalidDataPolicy>::target_type & arg1 = gsi::arg_reader<const qt_gsi::Converter<QDomImplementation::InvalidDataPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   QDomImplementation::setInvalidDataPolicy (qt_gsi::QtToCppAdaptor<QDomImplementation::InvalidDataPolicy>(arg1).cref());
 }

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomNamedNodeMap.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomNamedNodeMap.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QDomNamedNodeMap_2843 (const qt_gsi::GenericStaticMethod 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNamedNodeMap &arg1 = args.read<const QDomNamedNodeMap & > (heap);
+  const QDomNamedNodeMap &arg1 = gsi::arg_reader<const QDomNamedNodeMap & >() (args, heap);
   ret.write<QDomNamedNodeMap *> (new QDomNamedNodeMap (arg1));
 }
 
@@ -85,7 +85,7 @@ static void _call_f_contains_c2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDomNamedNodeMap *)cls)->contains (arg1));
 }
 
@@ -134,7 +134,7 @@ static void _call_f_item_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNamedNodeMap *)cls)->item (arg1));
 }
 
@@ -168,7 +168,7 @@ static void _call_f_namedItem_c2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNamedNodeMap *)cls)->namedItem (arg1));
 }
 
@@ -189,8 +189,8 @@ static void _call_f_namedItemNS_c3942 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNamedNodeMap *)cls)->namedItemNS (arg1, arg2));
 }
 
@@ -209,7 +209,7 @@ static void _call_f_operator_excl__eq__c2843 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNamedNodeMap &arg1 = args.read<const QDomNamedNodeMap & > (heap);
+  const QDomNamedNodeMap &arg1 = gsi::arg_reader<const QDomNamedNodeMap & >() (args, heap);
   ret.write<bool > ((bool)((QDomNamedNodeMap *)cls)->operator!= (arg1));
 }
 
@@ -228,7 +228,7 @@ static void _call_f_operator_eq__2843 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNamedNodeMap &arg1 = args.read<const QDomNamedNodeMap & > (heap);
+  const QDomNamedNodeMap &arg1 = gsi::arg_reader<const QDomNamedNodeMap & >() (args, heap);
   ret.write<QDomNamedNodeMap & > ((QDomNamedNodeMap &)((QDomNamedNodeMap *)cls)->operator= (arg1));
 }
 
@@ -247,7 +247,7 @@ static void _call_f_operator_eq__eq__c2843 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNamedNodeMap &arg1 = args.read<const QDomNamedNodeMap & > (heap);
+  const QDomNamedNodeMap &arg1 = gsi::arg_reader<const QDomNamedNodeMap & >() (args, heap);
   ret.write<bool > ((bool)((QDomNamedNodeMap *)cls)->operator== (arg1));
 }
 
@@ -266,7 +266,7 @@ static void _call_f_removeNamedItem_2025 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNamedNodeMap *)cls)->removeNamedItem (arg1));
 }
 
@@ -287,8 +287,8 @@ static void _call_f_removeNamedItemNS_3942 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNamedNodeMap *)cls)->removeNamedItemNS (arg1, arg2));
 }
 
@@ -307,7 +307,7 @@ static void _call_f_setNamedItem_2072 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNamedNodeMap *)cls)->setNamedItem (arg1));
 }
 
@@ -326,7 +326,7 @@ static void _call_f_setNamedItemNS_2072 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNamedNodeMap *)cls)->setNamedItemNS (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomNode.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomNode.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomNode_2072 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<QDomNode *> (new QDomNode (arg1));
 }
 
@@ -100,7 +100,7 @@ static void _call_f_appendChild_2072 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNode *)cls)->appendChild (arg1));
 }
 
@@ -165,7 +165,7 @@ static void _call_f_cloneNode_c864 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  bool arg1 = args ? args.read<bool > (heap) : (bool)(true);
+  bool arg1 = args ? gsi::arg_reader<bool >() (args, heap) : gsi::arg_maker<bool >() (true, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNode *)cls)->cloneNode (arg1));
 }
 
@@ -214,7 +214,7 @@ static void _call_f_firstChildElement_c2025 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QDomElement > ((QDomElement)((QDomNode *)cls)->firstChildElement (arg1));
 }
 
@@ -265,8 +265,8 @@ static void _call_f_insertAfter_4036 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
-  const QDomNode &arg2 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
+  const QDomNode &arg2 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNode *)cls)->insertAfter (arg1, arg2));
 }
 
@@ -287,8 +287,8 @@ static void _call_f_insertBefore_4036 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
-  const QDomNode &arg2 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
+  const QDomNode &arg2 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNode *)cls)->insertBefore (arg1, arg2));
 }
 
@@ -504,8 +504,8 @@ static void _call_f_isSupported_c3942 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QDomNode *)cls)->isSupported (arg1, arg2));
 }
 
@@ -554,7 +554,7 @@ static void _call_f_lastChildElement_c2025 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QDomElement > ((QDomElement)((QDomNode *)cls)->lastChildElement (arg1));
 }
 
@@ -603,7 +603,7 @@ static void _call_f_namedItem_c2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNode *)cls)->namedItem (arg1));
 }
 
@@ -652,7 +652,7 @@ static void _call_f_nextSiblingElement_c2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QDomElement > ((QDomElement)((QDomNode *)cls)->nextSiblingElement (arg1));
 }
 
@@ -732,7 +732,7 @@ static void _call_f_operator_excl__eq__c2072 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<bool > ((bool)((QDomNode *)cls)->operator!= (arg1));
 }
 
@@ -751,7 +751,7 @@ static void _call_f_operator_eq__2072 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<QDomNode & > ((QDomNode &)((QDomNode *)cls)->operator= (arg1));
 }
 
@@ -770,7 +770,7 @@ static void _call_f_operator_eq__eq__c2072 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<bool > ((bool)((QDomNode *)cls)->operator== (arg1));
 }
 
@@ -849,7 +849,7 @@ static void _call_f_previousSiblingElement_c2025 (const qt_gsi::GenericMethod * 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QDomElement > ((QDomElement)((QDomNode *)cls)->previousSiblingElement (arg1));
 }
 
@@ -868,7 +868,7 @@ static void _call_f_removeChild_2072 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNode *)cls)->removeChild (arg1));
 }
 
@@ -889,8 +889,8 @@ static void _call_f_replaceChild_4036 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNode &arg1 = args.read<const QDomNode & > (heap);
-  const QDomNode &arg2 = args.read<const QDomNode & > (heap);
+  const QDomNode &arg1 = gsi::arg_reader<const QDomNode & >() (args, heap);
+  const QDomNode &arg2 = gsi::arg_reader<const QDomNode & >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNode *)cls)->replaceChild (arg1, arg2));
 }
 
@@ -911,8 +911,8 @@ static void _call_f_save_c2399 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextStream &arg1 = args.read<QTextStream & > (heap);
-  int arg2 = args.read<int > (heap);
+  QTextStream &arg1 = gsi::arg_reader<QTextStream & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomNode *)cls)->save (arg1, arg2);
 }
@@ -936,9 +936,9 @@ static void _call_f_save_c5033 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QTextStream &arg1 = args.read<QTextStream & > (heap);
-  int arg2 = args.read<int > (heap);
-  const qt_gsi::Converter<QDomNode::EncodingPolicy>::target_type & arg3 = args.read<const qt_gsi::Converter<QDomNode::EncodingPolicy>::target_type & > (heap);
+  QTextStream &arg1 = gsi::arg_reader<QTextStream & >() (args, heap);
+  int arg2 = gsi::arg_reader<int >() (args, heap);
+  const qt_gsi::Converter<QDomNode::EncodingPolicy>::target_type & arg3 = gsi::arg_reader<const qt_gsi::Converter<QDomNode::EncodingPolicy>::target_type & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomNode *)cls)->save (arg1, arg2, qt_gsi::QtToCppAdaptor<QDomNode::EncodingPolicy>(arg3).cref());
 }
@@ -958,7 +958,7 @@ static void _call_f_setNodeValue_2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomNode *)cls)->setNodeValue (arg1);
 }
@@ -978,7 +978,7 @@ static void _call_f_setPrefix_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomNode *)cls)->setPrefix (arg1);
 }

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomNodeList.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomNodeList.cc
@@ -66,7 +66,7 @@ static void _call_ctor_QDomNodeList_2484 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNodeList &arg1 = args.read<const QDomNodeList & > (heap);
+  const QDomNodeList &arg1 = gsi::arg_reader<const QDomNodeList & >() (args, heap);
   ret.write<QDomNodeList *> (new QDomNodeList (arg1));
 }
 
@@ -85,7 +85,7 @@ static void _call_f_at_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNodeList *)cls)->at (arg1));
 }
 
@@ -134,7 +134,7 @@ static void _call_f_item_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDomNode > ((QDomNode)((QDomNodeList *)cls)->item (arg1));
 }
 
@@ -168,7 +168,7 @@ static void _call_f_operator_excl__eq__c2484 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNodeList &arg1 = args.read<const QDomNodeList & > (heap);
+  const QDomNodeList &arg1 = gsi::arg_reader<const QDomNodeList & >() (args, heap);
   ret.write<bool > ((bool)((QDomNodeList *)cls)->operator!= (arg1));
 }
 
@@ -187,7 +187,7 @@ static void _call_f_operator_eq__2484 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNodeList &arg1 = args.read<const QDomNodeList & > (heap);
+  const QDomNodeList &arg1 = gsi::arg_reader<const QDomNodeList & >() (args, heap);
   ret.write<QDomNodeList & > ((QDomNodeList &)((QDomNodeList *)cls)->operator= (arg1));
 }
 
@@ -206,7 +206,7 @@ static void _call_f_operator_eq__eq__c2484 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNodeList &arg1 = args.read<const QDomNodeList & > (heap);
+  const QDomNodeList &arg1 = gsi::arg_reader<const QDomNodeList & >() (args, heap);
   ret.write<bool > ((bool)((QDomNodeList *)cls)->operator== (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomNotation.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomNotation.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomNotation_2526 (const qt_gsi::GenericStaticMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNotation &arg1 = args.read<const QDomNotation & > (heap);
+  const QDomNotation &arg1 = gsi::arg_reader<const QDomNotation & >() (args, heap);
   ret.write<QDomNotation *> (new QDomNotation (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_operator_eq__2526 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomNotation &arg1 = args.read<const QDomNotation & > (heap);
+  const QDomNotation &arg1 = gsi::arg_reader<const QDomNotation & >() (args, heap);
   ret.write<QDomNotation & > ((QDomNotation &)((QDomNotation *)cls)->operator= (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomProcessingInstruction.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomProcessingInstruction.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomProcessingInstruction_3921 (const qt_gsi::GenericStat
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomProcessingInstruction &arg1 = args.read<const QDomProcessingInstruction & > (heap);
+  const QDomProcessingInstruction &arg1 = gsi::arg_reader<const QDomProcessingInstruction & >() (args, heap);
   ret.write<QDomProcessingInstruction *> (new QDomProcessingInstruction (arg1));
 }
 
@@ -130,7 +130,7 @@ static void _call_f_operator_eq__3921 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomProcessingInstruction &arg1 = args.read<const QDomProcessingInstruction & > (heap);
+  const QDomProcessingInstruction &arg1 = gsi::arg_reader<const QDomProcessingInstruction & >() (args, heap);
   ret.write<QDomProcessingInstruction & > ((QDomProcessingInstruction &)((QDomProcessingInstruction *)cls)->operator= (arg1));
 }
 
@@ -149,7 +149,7 @@ static void _call_f_setData_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QDomProcessingInstruction *)cls)->setData (arg1);
 }

--- a/src/gsiqt/qt4/QtXml/gsiDeclQDomText.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQDomText.cc
@@ -81,7 +81,7 @@ static void _call_ctor_QDomText_2103 (const qt_gsi::GenericStaticMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomText &arg1 = args.read<const QDomText & > (heap);
+  const QDomText &arg1 = gsi::arg_reader<const QDomText & >() (args, heap);
   ret.write<QDomText *> (new QDomText (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_operator_eq__2103 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QDomText &arg1 = args.read<const QDomText & > (heap);
+  const QDomText &arg1 = gsi::arg_reader<const QDomText & >() (args, heap);
   ret.write<QDomText & > ((QDomText &)((QDomText *)cls)->operator= (arg1));
 }
 
@@ -134,7 +134,7 @@ static void _call_f_splitText_767 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QDomText > ((QDomText)((QDomText *)cls)->splitText (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlAttributes.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlAttributes.cc
@@ -56,10 +56,10 @@ static void _call_f_append_7776 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlAttributes *)cls)->append (arg1, arg2, arg3, arg4);
 }
@@ -110,7 +110,7 @@ static void _call_f_index_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QXmlAttributes *)cls)->index (arg1));
 }
 
@@ -131,8 +131,8 @@ static void _call_f_index_c3942 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<int > ((int)((QXmlAttributes *)cls)->index (arg1, arg2));
 }
 
@@ -166,7 +166,7 @@ static void _call_f_localName_c767 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QXmlAttributes *)cls)->localName (arg1));
 }
 
@@ -185,7 +185,7 @@ static void _call_f_qName_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QXmlAttributes *)cls)->qName (arg1));
 }
 
@@ -204,7 +204,7 @@ static void _call_f_type_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QXmlAttributes *)cls)->type (arg1));
 }
 
@@ -223,7 +223,7 @@ static void _call_f_type_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QXmlAttributes *)cls)->type (arg1));
 }
 
@@ -244,8 +244,8 @@ static void _call_f_type_c3942 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QXmlAttributes *)cls)->type (arg1, arg2));
 }
 
@@ -264,7 +264,7 @@ static void _call_f_uri_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cls,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QXmlAttributes *)cls)->uri (arg1));
 }
 
@@ -283,7 +283,7 @@ static void _call_f_value_c767 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  int arg1 = args.read<int > (heap);
+  int arg1 = gsi::arg_reader<int >() (args, heap);
   ret.write<QString > ((QString)((QXmlAttributes *)cls)->value (arg1));
 }
 
@@ -302,7 +302,7 @@ static void _call_f_value_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QXmlAttributes *)cls)->value (arg1));
 }
 
@@ -323,8 +323,8 @@ static void _call_f_value_c3942 (const qt_gsi::GenericMethod * /*decl*/, void *c
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QXmlAttributes *)cls)->value (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlContentHandler.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlContentHandler.cc
@@ -52,7 +52,7 @@ static void _call_f_characters_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlContentHandler *)cls)->characters (arg1));
 }
 
@@ -90,9 +90,9 @@ static void _call_f_endElement_5859 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlContentHandler *)cls)->endElement (arg1, arg2, arg3));
 }
 
@@ -111,7 +111,7 @@ static void _call_f_endPrefixMapping_2025 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlContentHandler *)cls)->endPrefixMapping (arg1));
 }
 
@@ -145,7 +145,7 @@ static void _call_f_ignorableWhitespace_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlContentHandler *)cls)->ignorableWhitespace (arg1));
 }
 
@@ -166,8 +166,8 @@ static void _call_f_processingInstruction_3942 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlContentHandler *)cls)->processingInstruction (arg1, arg2));
 }
 
@@ -186,7 +186,7 @@ static void _call_f_setDocumentLocator_1732 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlLocator *arg1 = args.read<QXmlLocator * > (heap);
+  QXmlLocator *arg1 = gsi::arg_reader<QXmlLocator * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlContentHandler *)cls)->setDocumentLocator (arg1);
 }
@@ -206,7 +206,7 @@ static void _call_f_skippedEntity_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlContentHandler *)cls)->skippedEntity (arg1));
 }
 
@@ -246,10 +246,10 @@ static void _call_f_startElement_8513 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QXmlAttributes &arg4 = args.read<const QXmlAttributes & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QXmlAttributes &arg4 = gsi::arg_reader<const QXmlAttributes & >() (args, heap);
   ret.write<bool > ((bool)((QXmlContentHandler *)cls)->startElement (arg1, arg2, arg3, arg4));
 }
 
@@ -270,8 +270,8 @@ static void _call_f_startPrefixMapping_3942 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlContentHandler *)cls)->startPrefixMapping (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlDTDHandler.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlDTDHandler.cc
@@ -69,9 +69,9 @@ static void _call_f_notationDecl_5859 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDTDHandler *)cls)->notationDecl (arg1, arg2, arg3));
 }
 
@@ -96,10 +96,10 @@ static void _call_f_unparsedEntityDecl_7776 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDTDHandler *)cls)->unparsedEntityDecl (arg1, arg2, arg3, arg4));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlDeclHandler.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlDeclHandler.cc
@@ -58,11 +58,11 @@ static void _call_f_attributeDecl_9693 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
-  const QString &arg5 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg5 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDeclHandler *)cls)->attributeDecl (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -100,9 +100,9 @@ static void _call_f_externalEntityDecl_5859 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDeclHandler *)cls)->externalEntityDecl (arg1, arg2, arg3));
 }
 
@@ -123,8 +123,8 @@ static void _call_f_internalEntityDecl_3942 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDeclHandler *)cls)->internalEntityDecl (arg1, arg2));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlDefaultHandler.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlDefaultHandler.cc
@@ -61,11 +61,11 @@ static void _call_f_attributeDecl_9693 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
-  const QString &arg5 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg5 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->attributeDecl (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -84,7 +84,7 @@ static void _call_f_characters_2025 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->characters (arg1));
 }
 
@@ -103,7 +103,7 @@ static void _call_f_comment_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->comment (arg1));
 }
 
@@ -171,9 +171,9 @@ static void _call_f_endElement_5859 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->endElement (arg1, arg2, arg3));
 }
 
@@ -192,7 +192,7 @@ static void _call_f_endEntity_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->endEntity (arg1));
 }
 
@@ -211,7 +211,7 @@ static void _call_f_endPrefixMapping_2025 (const qt_gsi::GenericMethod * /*decl*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->endPrefixMapping (arg1));
 }
 
@@ -230,7 +230,7 @@ static void _call_f_error_3149 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlParseException &arg1 = args.read<const QXmlParseException & > (heap);
+  const QXmlParseException &arg1 = gsi::arg_reader<const QXmlParseException & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->error (arg1));
 }
 
@@ -268,9 +268,9 @@ static void _call_f_externalEntityDecl_5859 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->externalEntityDecl (arg1, arg2, arg3));
 }
 
@@ -289,7 +289,7 @@ static void _call_f_fatalError_3149 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlParseException &arg1 = args.read<const QXmlParseException & > (heap);
+  const QXmlParseException &arg1 = gsi::arg_reader<const QXmlParseException & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->fatalError (arg1));
 }
 
@@ -308,7 +308,7 @@ static void _call_f_ignorableWhitespace_2025 (const qt_gsi::GenericMethod * /*de
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->ignorableWhitespace (arg1));
 }
 
@@ -329,8 +329,8 @@ static void _call_f_internalEntityDecl_3942 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->internalEntityDecl (arg1, arg2));
 }
 
@@ -353,9 +353,9 @@ static void _call_f_notationDecl_5859 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->notationDecl (arg1, arg2, arg3));
 }
 
@@ -376,8 +376,8 @@ static void _call_f_processingInstruction_3942 (const qt_gsi::GenericMethod * /*
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->processingInstruction (arg1, arg2));
 }
 
@@ -396,7 +396,7 @@ static void _call_f_setDocumentLocator_1732 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlLocator *arg1 = args.read<QXmlLocator * > (heap);
+  QXmlLocator *arg1 = gsi::arg_reader<QXmlLocator * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlDefaultHandler *)cls)->setDocumentLocator (arg1);
 }
@@ -416,7 +416,7 @@ static void _call_f_skippedEntity_2025 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->skippedEntity (arg1));
 }
 
@@ -454,9 +454,9 @@ static void _call_f_startDTD_5859 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->startDTD (arg1, arg2, arg3));
 }
 
@@ -496,10 +496,10 @@ static void _call_f_startElement_8513 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QXmlAttributes &arg4 = args.read<const QXmlAttributes & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QXmlAttributes &arg4 = gsi::arg_reader<const QXmlAttributes & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->startElement (arg1, arg2, arg3, arg4));
 }
 
@@ -518,7 +518,7 @@ static void _call_f_startEntity_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->startEntity (arg1));
 }
 
@@ -539,8 +539,8 @@ static void _call_f_startPrefixMapping_3942 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->startPrefixMapping (arg1, arg2));
 }
 
@@ -565,10 +565,10 @@ static void _call_f_unparsedEntityDecl_7776 (const qt_gsi::GenericMethod * /*dec
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
-  const QString &arg4 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg4 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->unparsedEntityDecl (arg1, arg2, arg3, arg4));
 }
 
@@ -587,7 +587,7 @@ static void _call_f_warning_3149 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlParseException &arg1 = args.read<const QXmlParseException & > (heap);
+  const QXmlParseException &arg1 = gsi::arg_reader<const QXmlParseException & >() (args, heap);
   ret.write<bool > ((bool)((QXmlDefaultHandler *)cls)->warning (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlErrorHandler.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlErrorHandler.cc
@@ -51,7 +51,7 @@ static void _call_f_error_3149 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlParseException &arg1 = args.read<const QXmlParseException & > (heap);
+  const QXmlParseException &arg1 = gsi::arg_reader<const QXmlParseException & >() (args, heap);
   ret.write<bool > ((bool)((QXmlErrorHandler *)cls)->error (arg1));
 }
 
@@ -85,7 +85,7 @@ static void _call_f_fatalError_3149 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlParseException &arg1 = args.read<const QXmlParseException & > (heap);
+  const QXmlParseException &arg1 = gsi::arg_reader<const QXmlParseException & >() (args, heap);
   ret.write<bool > ((bool)((QXmlErrorHandler *)cls)->fatalError (arg1));
 }
 
@@ -104,7 +104,7 @@ static void _call_f_warning_3149 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlParseException &arg1 = args.read<const QXmlParseException & > (heap);
+  const QXmlParseException &arg1 = gsi::arg_reader<const QXmlParseException & >() (args, heap);
   ret.write<bool > ((bool)((QXmlErrorHandler *)cls)->warning (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlInputSource.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlInputSource.cc
@@ -113,7 +113,7 @@ static void _call_f_setData_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlInputSource *)cls)->setData (arg1);
 }
@@ -286,7 +286,7 @@ static void _call_ctor_QXmlInputSource_Adaptor_1447 (const qt_gsi::GenericStatic
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QIODevice *arg1 = args.read<QIODevice * > (heap);
+  QIODevice *arg1 = gsi::arg_reader<QIODevice * >() (args, heap);
   ret.write<QXmlInputSource_Adaptor *> (new QXmlInputSource_Adaptor (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlLexicalHandler.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlLexicalHandler.cc
@@ -50,7 +50,7 @@ static void _call_f_comment_2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlLexicalHandler *)cls)->comment (arg1));
 }
 
@@ -99,7 +99,7 @@ static void _call_f_endEntity_2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlLexicalHandler *)cls)->endEntity (arg1));
 }
 
@@ -152,9 +152,9 @@ static void _call_f_startDTD_5859 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
-  const QString &arg3 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg3 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlLexicalHandler *)cls)->startDTD (arg1, arg2, arg3));
 }
 
@@ -173,7 +173,7 @@ static void _call_f_startEntity_2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlLexicalHandler *)cls)->startEntity (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlNamespaceSupport.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlNamespaceSupport.cc
@@ -81,7 +81,7 @@ static void _call_f_prefix_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QXmlNamespaceSupport *)cls)->prefix (arg1));
 }
 
@@ -115,7 +115,7 @@ static void _call_f_prefixes_c2025 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QStringList > ((QStringList)((QXmlNamespaceSupport *)cls)->prefixes (arg1));
 }
 
@@ -140,10 +140,10 @@ static void _call_f_processName_c5225 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool arg2 = args.read<bool > (heap);
-  QString &arg3 = args.read<QString & > (heap);
-  QString &arg4 = args.read<QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
+  QString &arg3 = gsi::arg_reader<QString & >() (args, heap);
+  QString &arg4 = gsi::arg_reader<QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlNamespaceSupport *)cls)->processName (arg1, arg2, arg3, arg4);
 }
@@ -197,8 +197,8 @@ static void _call_f_setPrefix_3942 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  const QString &arg2 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  const QString &arg2 = gsi::arg_reader<const QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlNamespaceSupport *)cls)->setPrefix (arg1, arg2);
 }
@@ -222,9 +222,9 @@ static void _call_f_splitName_c4469 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  QString &arg2 = args.read<QString & > (heap);
-  QString &arg3 = args.read<QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  QString &arg2 = gsi::arg_reader<QString & >() (args, heap);
+  QString &arg3 = gsi::arg_reader<QString & >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlNamespaceSupport *)cls)->splitName (arg1, arg2, arg3);
 }
@@ -244,7 +244,7 @@ static void _call_f_uri_c2025 (const qt_gsi::GenericMethod * /*decl*/, void *cls
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<QString > ((QString)((QXmlNamespaceSupport *)cls)->uri (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlParseException.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlParseException.cc
@@ -58,11 +58,11 @@ static void _call_ctor_QXmlParseException_7177 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  int arg2 = args ? args.read<int > (heap) : (int)(-1);
-  int arg3 = args ? args.read<int > (heap) : (int)(-1);
-  const QString &arg4 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
-  const QString &arg5 = args ? args.read<const QString & > (heap) : (const QString &)(QString());
+  const QString &arg1 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  int arg2 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  int arg3 = args ? gsi::arg_reader<int >() (args, heap) : gsi::arg_maker<int >() (-1, heap);
+  const QString &arg4 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
+  const QString &arg5 = args ? gsi::arg_reader<const QString & >() (args, heap) : gsi::arg_maker<const QString & >() (QString(), heap);
   ret.write<QXmlParseException *> (new QXmlParseException (arg1, arg2, arg3, arg4, arg5));
 }
 
@@ -81,7 +81,7 @@ static void _call_ctor_QXmlParseException_3149 (const qt_gsi::GenericStaticMetho
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlParseException &arg1 = args.read<const QXmlParseException & > (heap);
+  const QXmlParseException &arg1 = gsi::arg_reader<const QXmlParseException & >() (args, heap);
   ret.write<QXmlParseException *> (new QXmlParseException (arg1));
 }
 

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlReader.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlReader.cc
@@ -134,8 +134,8 @@ static void _call_f_feature_c2967 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<bool > ((bool)((QXmlReader *)cls)->feature (arg1, arg2));
 }
 
@@ -154,7 +154,7 @@ static void _call_f_hasFeature_c2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlReader *)cls)->hasFeature (arg1));
 }
 
@@ -173,7 +173,7 @@ static void _call_f_hasProperty_c2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlReader *)cls)->hasProperty (arg1));
 }
 
@@ -207,7 +207,7 @@ static void _call_f_parse_2852 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlInputSource &arg1 = args.read<const QXmlInputSource & > (heap);
+  const QXmlInputSource &arg1 = gsi::arg_reader<const QXmlInputSource & >() (args, heap);
   ret.write<bool > ((bool)((QXmlReader *)cls)->parse (arg1));
 }
 
@@ -226,7 +226,7 @@ static void _call_f_parse_2856 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlInputSource *arg1 = args.read<const QXmlInputSource * > (heap);
+  const QXmlInputSource *arg1 = gsi::arg_reader<const QXmlInputSource * >() (args, heap);
   ret.write<bool > ((bool)((QXmlReader *)cls)->parse (arg1));
 }
 
@@ -247,8 +247,8 @@ static void _call_f_property_c2967 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<void * > ((void *)((QXmlReader *)cls)->property (arg1, arg2));
 }
 
@@ -267,7 +267,7 @@ static void _call_f_setContentHandler_2441 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlContentHandler *arg1 = args.read<QXmlContentHandler * > (heap);
+  QXmlContentHandler *arg1 = gsi::arg_reader<QXmlContentHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlReader *)cls)->setContentHandler (arg1);
 }
@@ -287,7 +287,7 @@ static void _call_f_setDTDHandler_1930 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlDTDHandler *arg1 = args.read<QXmlDTDHandler * > (heap);
+  QXmlDTDHandler *arg1 = gsi::arg_reader<QXmlDTDHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlReader *)cls)->setDTDHandler (arg1);
 }
@@ -307,7 +307,7 @@ static void _call_f_setDeclHandler_2086 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlDeclHandler *arg1 = args.read<QXmlDeclHandler * > (heap);
+  QXmlDeclHandler *arg1 = gsi::arg_reader<QXmlDeclHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlReader *)cls)->setDeclHandler (arg1);
 }
@@ -327,7 +327,7 @@ static void _call_f_setEntityResolver_2495 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlEntityResolver *arg1 = args.read<QXmlEntityResolver * > (heap);
+  QXmlEntityResolver *arg1 = gsi::arg_reader<QXmlEntityResolver * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlReader *)cls)->setEntityResolver (arg1);
 }
@@ -347,7 +347,7 @@ static void _call_f_setErrorHandler_2232 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlErrorHandler *arg1 = args.read<QXmlErrorHandler * > (heap);
+  QXmlErrorHandler *arg1 = gsi::arg_reader<QXmlErrorHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlReader *)cls)->setErrorHandler (arg1);
 }
@@ -369,8 +369,8 @@ static void _call_f_setFeature_2781 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlReader *)cls)->setFeature (arg1, arg2);
 }
@@ -390,7 +390,7 @@ static void _call_f_setLexicalHandler_2416 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlLexicalHandler *arg1 = args.read<QXmlLexicalHandler * > (heap);
+  QXmlLexicalHandler *arg1 = gsi::arg_reader<QXmlLexicalHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlReader *)cls)->setLexicalHandler (arg1);
 }
@@ -412,8 +412,8 @@ static void _call_f_setProperty_2973 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  void *arg2 = args.read<void * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  void *arg2 = gsi::arg_reader<void * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlReader *)cls)->setProperty (arg1, arg2);
 }

--- a/src/gsiqt/qt4/QtXml/gsiDeclQXmlSimpleReader.cc
+++ b/src/gsiqt/qt4/QtXml/gsiDeclQXmlSimpleReader.cc
@@ -134,8 +134,8 @@ static void _call_f_feature_c2967 (const qt_gsi::GenericMethod * /*decl*/, void 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<bool > ((bool)((QXmlSimpleReader *)cls)->feature (arg1, arg2));
 }
 
@@ -154,7 +154,7 @@ static void _call_f_hasFeature_c2025 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlSimpleReader *)cls)->hasFeature (arg1));
 }
 
@@ -173,7 +173,7 @@ static void _call_f_hasProperty_c2025 (const qt_gsi::GenericMethod * /*decl*/, v
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
   ret.write<bool > ((bool)((QXmlSimpleReader *)cls)->hasProperty (arg1));
 }
 
@@ -207,7 +207,7 @@ static void _call_f_parse_2856 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlInputSource *arg1 = args.read<const QXmlInputSource * > (heap);
+  const QXmlInputSource *arg1 = gsi::arg_reader<const QXmlInputSource * >() (args, heap);
   ret.write<bool > ((bool)((QXmlSimpleReader *)cls)->parse (arg1));
 }
 
@@ -228,8 +228,8 @@ static void _call_f_parse_3612 (const qt_gsi::GenericMethod * /*decl*/, void *cl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QXmlInputSource *arg1 = args.read<const QXmlInputSource * > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QXmlInputSource *arg1 = gsi::arg_reader<const QXmlInputSource * >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   ret.write<bool > ((bool)((QXmlSimpleReader *)cls)->parse (arg1, arg2));
 }
 
@@ -265,8 +265,8 @@ static void _call_f_property_c2967 (const qt_gsi::GenericMethod * /*decl*/, void
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool *arg2 = args ? args.read<bool * > (heap) : (bool *)(0);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool *arg2 = args ? gsi::arg_reader<bool * >() (args, heap) : gsi::arg_maker<bool * >() (0, heap);
   ret.write<void * > ((void *)((QXmlSimpleReader *)cls)->property (arg1, arg2));
 }
 
@@ -285,7 +285,7 @@ static void _call_f_setContentHandler_2441 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlContentHandler *arg1 = args.read<QXmlContentHandler * > (heap);
+  QXmlContentHandler *arg1 = gsi::arg_reader<QXmlContentHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlSimpleReader *)cls)->setContentHandler (arg1);
 }
@@ -305,7 +305,7 @@ static void _call_f_setDTDHandler_1930 (const qt_gsi::GenericMethod * /*decl*/, 
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlDTDHandler *arg1 = args.read<QXmlDTDHandler * > (heap);
+  QXmlDTDHandler *arg1 = gsi::arg_reader<QXmlDTDHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlSimpleReader *)cls)->setDTDHandler (arg1);
 }
@@ -325,7 +325,7 @@ static void _call_f_setDeclHandler_2086 (const qt_gsi::GenericMethod * /*decl*/,
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlDeclHandler *arg1 = args.read<QXmlDeclHandler * > (heap);
+  QXmlDeclHandler *arg1 = gsi::arg_reader<QXmlDeclHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlSimpleReader *)cls)->setDeclHandler (arg1);
 }
@@ -345,7 +345,7 @@ static void _call_f_setEntityResolver_2495 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlEntityResolver *arg1 = args.read<QXmlEntityResolver * > (heap);
+  QXmlEntityResolver *arg1 = gsi::arg_reader<QXmlEntityResolver * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlSimpleReader *)cls)->setEntityResolver (arg1);
 }
@@ -365,7 +365,7 @@ static void _call_f_setErrorHandler_2232 (const qt_gsi::GenericMethod * /*decl*/
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlErrorHandler *arg1 = args.read<QXmlErrorHandler * > (heap);
+  QXmlErrorHandler *arg1 = gsi::arg_reader<QXmlErrorHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlSimpleReader *)cls)->setErrorHandler (arg1);
 }
@@ -387,8 +387,8 @@ static void _call_f_setFeature_2781 (const qt_gsi::GenericMethod * /*decl*/, voi
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  bool arg2 = args.read<bool > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  bool arg2 = gsi::arg_reader<bool >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlSimpleReader *)cls)->setFeature (arg1, arg2);
 }
@@ -408,7 +408,7 @@ static void _call_f_setLexicalHandler_2416 (const qt_gsi::GenericMethod * /*decl
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  QXmlLexicalHandler *arg1 = args.read<QXmlLexicalHandler * > (heap);
+  QXmlLexicalHandler *arg1 = gsi::arg_reader<QXmlLexicalHandler * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlSimpleReader *)cls)->setLexicalHandler (arg1);
 }
@@ -430,8 +430,8 @@ static void _call_f_setProperty_2973 (const qt_gsi::GenericMethod * /*decl*/, vo
 {
   __SUPPRESS_UNUSED_WARNING(args);
   tl::Heap heap;
-  const QString &arg1 = args.read<const QString & > (heap);
-  void *arg2 = args.read<void * > (heap);
+  const QString &arg1 = gsi::arg_reader<const QString & >() (args, heap);
+  void *arg2 = gsi::arg_reader<void * >() (args, heap);
   __SUPPRESS_UNUSED_WARNING(ret);
   ((QXmlSimpleReader *)cls)->setProperty (arg1, arg2);
 }


### PR DESCRIPTION
Reason: a reference to a temporary object was passed
to a function. This happened for a default value.
The solution is to create a heap object to such default values.