### PR TITLE
Continuous Deployment to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -585,6 +585,6 @@ after_success:
   # uploading to pypi using twine
   # need TWINE_USERNAME, TWINE_PASSWORD and TWINE_REPOSITORY_URL env variable
   - if [ "$PYTHON_BUILD" = true ] || [ "$DOCKER_BUILD" = true ]; then
-      pip install -U twine;
+      pip install -U twine || sudo pip install -U twine;
       twine upload --skip-existing deploy/dist-pymod/$klayout_version/*;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -578,4 +578,13 @@ script:
     fi
 
 after_success:
+  # upload to dropbox
+  # need DROPBOX_OAUTH_BEARER environment variable
   - dropbox-deployment
+
+  # uploading to pypi using twine
+  # need TWINE_USERNAME, TWINE_PASSWORD and TWINE_REPOSITORY_URL env variable
+  - if [ "$PYTHON_BUILD" = true ] || [ "$DOCKER_BUILD" = true ]; then
+      pip install -U twine;
+      twine upload --skip-existing deploy/dist-pymod/$klayout_version/*;
+    fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
       artifactName: 'wheel-$(python.version).$(python.architecture)'
 
 - job: 'Deploy'
-  displayName: 'Combine Windows wheels'
+  displayName: 'Combine Windows wheels and deploy to PyPI'
   dependsOn: Build
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
@@ -149,4 +149,12 @@ jobs:
       inputs:
         pathtoPublish: '$(Build.ArtifactStagingDirectory)'
         artifactName: 'windows_wheels'
+    - bash: |
+        pip install -U twine
+        twine upload --skip-existing $BUILD_ARTIFACTSTAGINGDIRECTORY/*
+      env:
+        TWINE_USERNAME: $(TWINE_USERNAME)
+        TWINE_PASSWORD: $(TWINE_PASSWORD)
+        TWINE_REPOSITORY_URL: $(TWINE_REPOSITORY_URL)
+      displayName: 'Uploading to PyPI'
 

--- a/setup.py
+++ b/setup.py
@@ -322,7 +322,7 @@ class Config(object):
         """
         Gets the version string
         """
-        return "0.26.0.dev13"
+        return "0.26.0.dev14"
 
 
 config = Config()

--- a/setup.py
+++ b/setup.py
@@ -310,6 +310,10 @@ class Config(object):
             else:
                 loader_path = '$ORIGIN/..'
             args += ['-Wl,-rpath,' + loader_path]
+            # default linux shared object compilation uses the '-g' flag,
+            # which generates unnecessary debug information
+            # removing with strip-all during the linking stage
+            args += ['-Wl,--strip-all']
             return args
 
     def macros(self):


### PR DESCRIPTION
- Automatically upload wheels to PyPI (configured azure and travis with my credentials)
- Stripped shared objects in linux pymod build to reduce wheel size by 90%
- Upgraded version to klayout 0.26.0.dev14
- Preview of the wheels in https://test.pypi.org/project/klayout/#files (will trigger upload to main pypi when this PR is merged)