### PR TITLE
A few more spelling fixes

### DIFF
--- a/src/gsi/gsi/gsiSerialisation.cc
+++ b/src/gsi/gsi/gsiSerialisation.cc
@@ -65,7 +65,7 @@ void AdaptorBase::tie_copies (AdaptorBase *target, tl::Heap &heap)
   copy_to (target, heap);
 
   //  This object (which will be destroyed before this is responsible for copying back 
-  //  the contents ot target into this once the heap goes out of scope)
+  //  the contents of target into this once the heap goes out of scope)
   heap.push (new AdaptorSynchronizer (t.release (), this, &heap));
 }
 

--- a/src/lay/lay/doc/about/lef_def_import.xml
+++ b/src/lay/lay/doc/about/lef_def_import.xml
@@ -85,7 +85,7 @@
 
   <p>
   By default, no layer mapping is specified. Layer mapping can be employed to confine input to 
-  certain layers or layer/purpose pairs and to specifiy mapping of LEF layers/purposes to GDS
+  certain layers or layer/purpose pairs and to specify mapping of LEF layers/purposes to GDS
   layer/datatypes.
   </p>
 

--- a/testdata/oasis/tests.txt
+++ b/testdata/oasis/tests.txt
@@ -1,6 +1,6 @@
 
 t1.x   Empty file. 
-       Various ways to specifiy a float (database unit).
+       Various ways to specify a float (database unit).
 t2.x   Cells. 
        Various ways to specify cell names (id, string) and refer to them.
 t3.x   Texts.


### PR DESCRIPTION
Please check if the fixes are correct.

Also lintian complains about a number of:
 "allow to"/ "allows to"
which apparently are supposed to be:
 "allow one to" / "allows one to"

I have not corrected those since I am not sure if it is correct in all cases.

Cheers.