### PR TITLE
Fixed #251 - exit handler missing? [skip ci]

### DIFF
--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -689,6 +689,14 @@ MainWindow::MainWindow (QApplication *app, lay::Plugin *plugin_parent, const cha
 
 MainWindow::~MainWindow ()
 {
+  //  avoid deferred execution later on where there isn't a valid main window anymore
+  //  (problem case: showing a dialog inside main windows's destroyed signal - this will
+  //  process events and trigger execution if not disabled)
+  if (! tl::DeferredMethodScheduler::instance ()->is_disabled ()) {
+    tl::DeferredMethodScheduler::instance ()->execute ();
+  }
+  tl::DeferredMethodScheduler::instance ()->enable (false);
+
   lay::register_help_handler (0, 0);
 
   //  since the configuration actions unregister themselves, we need to do this before the main

--- a/src/rba/rba/rbaUtils.h
+++ b/src/rba/rba/rbaUtils.h
@@ -180,12 +180,12 @@ inline void rb_protect_init ()
 
 #define RUBY_BEGIN_EXEC \
   try { \
-    rba::RubyInterpreter::instance()->begin_exec ();
+    if (rba::RubyInterpreter::instance ()) { rba::RubyInterpreter::instance ()->begin_exec (); }
 
 #define RUBY_END_EXEC \
-    rba::RubyInterpreter::instance()->end_exec (); \
+    if (rba::RubyInterpreter::instance ()) { rba::RubyInterpreter::instance()->end_exec (); } \
   } catch (...) { \
-    rba::RubyInterpreter::instance()->end_exec (); \
+    if (rba::RubyInterpreter::instance ()) { rba::RubyInterpreter::instance()->end_exec (); } \
     throw; \
   }
 


### PR DESCRIPTION
RBA::MainWindow::instance.destroyed do
  RBA::MessageBox::info("It's Over!", "The main window was destroyed", RBA::MessageBox::Ok)
end

at_exit do
  puts "It's over!"
end

RBA::Application::instance.aboutToQuit do
  RBA::MessageBox::info("It's Over!", "The main window was destroyed", RBA::MessageBox::Ok)
end