### PR TITLE
Fixed #265: put CIF at the end of the detection chain

### DIFF
--- a/src/plugins/streamers/cif/db_plugin/dbCIF.cc
+++ b/src/plugins/streamers/cif/db_plugin/dbCIF.cc
@@ -185,7 +185,9 @@ public:
   }
 };
 
-static tl::RegisteredClass<db::StreamFormatDeclaration> reader_decl (new CIFFormatDeclaration (), 100, "CIF");
+//  NOTE: Because CIF has such a high degree of syntactic freedom, the detection is somewhat
+//  fuzzy: do CIF at the very end of the detection chain
+static tl::RegisteredClass<db::StreamFormatDeclaration> reader_decl (new CIFFormatDeclaration (), 2100, "CIF");
 
 //  provide a symbol to force linking against
 int force_link_CIF = 0;

--- a/src/plugins/streamers/dxf/db_plugin/dbDXF.cc
+++ b/src/plugins/streamers/dxf/db_plugin/dbDXF.cc
@@ -166,7 +166,7 @@ public:
   }
 };
 
-static tl::RegisteredClass<db::StreamFormatDeclaration> reader_decl (new DXFFormatDeclaration (), 100, "DXF");
+static tl::RegisteredClass<db::StreamFormatDeclaration> reader_decl (new DXFFormatDeclaration (), 2000, "DXF");
 
 //  provide a symbol to force linking against
 int force_link_DXF = 0;


### PR DESCRIPTION
The CIF format is kind of fuzzy and supports a high
degree of syntactic freedom. Hence the format detection
is not quite reliable. Do CIF as last resort.