### PR TITLE
Fixed issue #321

### DIFF
--- a/src/laybasic/laybasic/layNetlistBrowserDialog.cc
+++ b/src/laybasic/laybasic/layNetlistBrowserDialog.cc
@@ -674,9 +674,7 @@ void
 NetlistBrowserDialog::activated ()
 {
   std::string state;
-  if (lay::PluginRoot::instance ()) {
-    lay::PluginRoot::instance ()->config_get (cfg_l2ndb_window_state, state);
-  }
+  view ()->config_get (cfg_l2ndb_window_state, state);
   lay::restore_dialog_state (this, state, false /*don't adjust the section sizes*/);
 
   //  Switch to the active cellview index when no valid one is set.

--- a/src/laybasic/laybasic/layPlugin.cc
+++ b/src/laybasic/laybasic/layPlugin.cc
@@ -346,6 +346,8 @@ Plugin::config_get (const std::string &name, std::string &value) const
   if (p != m_repository.end ()) {
     value = p->second;
     return true;
+  } else if (mp_parent) {
+    return mp_parent->config_get (name, value);
   } else {
     value = "";
     return false;

--- a/src/laybasic/laybasic/rdbMarkerBrowserDialog.cc
+++ b/src/laybasic/laybasic/rdbMarkerBrowserDialog.cc
@@ -636,9 +636,7 @@ void
 MarkerBrowserDialog::activated ()
 {
   std::string state;
-  if (lay::PluginRoot::instance ()) {
-    lay::PluginRoot::instance ()->config_get (cfg_rdb_window_state, state);
-  }
+  view ()->config_get (cfg_rdb_window_state, state);
   lay::restore_dialog_state (this, state);
 
   //  Switch to the active cellview index when no valid one is set.


### PR DESCRIPTION
This is a small paradigm shift in the configuration hierarchy:
plugins (as children of root) now inherit the configuration
from the parent - now only through configure, but also through
config_get (pull with config_get vs. push with configure).

TODO: both methods are not entirely consistent as configure
can block propagation of configuration settings. But that's a
feature hardly used anyway and rather an optimization thing.