### PR TITLE
Library Browser updates

### DIFF
--- a/src/db/db/dbLayoutQuery.cc
+++ b/src/db/db/dbLayoutQuery.cc
@@ -561,23 +561,13 @@ public:
 
       }
 
-    } else if (m_pattern.is_const ()) {
-
-      objectives ().set_wants_all_cells (false);
-
-      //  include the cell with the name we look for into the objectives
-      std::pair<bool, db::cell_index_type> cell_by_name = layout ()->cell_by_name (m_pattern.pattern ().c_str ());
-      if (cell_by_name.first) {
-        objectives ().request_cell (cell_by_name.second);
-      }
-
     } else {
 
       objectives ().set_wants_all_cells (false);
 
       //  include all matching cells into the objectives
       for (db::Layout::const_iterator c = layout ()->begin (); c != layout ()->end(); ++c) {
-        if (m_pattern.match (layout ()->cell_name (c->cell_index()))) {
+        if (m_pattern.match (c->get_qualified_name ())) {
           objectives ().request_cell (c->cell_index ());
         }
       }

--- a/src/db/db/dbNetlistCompare.cc
+++ b/src/db/db/dbNetlistCompare.cc
@@ -692,6 +692,12 @@ public:
 
   typedef std::pair<std::vector<Transition>, std::pair<size_t, const db::Net *> > edge_type;
 
+  static void swap_edges (edge_type &e1, edge_type &e2)
+  {
+    e1.first.swap (e2.first);
+    std::swap (e1.second, e2.second);
+  }
+
   struct EdgeToEdgeOnlyCompare
   {
     bool operator() (const edge_type &a, const std::vector<Transition> &b) const
@@ -1149,16 +1155,21 @@ NetGraphNode::expand_subcircuit_nodes (NetGraph *graph)
 
   std::list<edge_type> sc_edges;
 
-  for (size_t i = 0; i < m_edges.size (); ) {
-    if (m_edges [i].second.second == 0) {
+  size_t ii = 0;
+  for (size_t i = 0; i < m_edges.size (); ++i) {
+    if (ii != i) {
+      swap_edges (m_edges [ii], m_edges [i]);
+    }
+    if (m_edges [ii].second.second == 0) {
       //  subcircuit pin
-      sc_edges.push_back (m_edges [i]);
-      m_edges.erase (m_edges.begin () + i);
+      sc_edges.push_back (m_edges [ii]);
     } else {
-      n2entry.insert (std::make_pair (m_edges [i].second.second, i));
-      ++i;
+      n2entry.insert (std::make_pair (m_edges [ii].second.second, ii));
+      ++ii;
     }
   }
+
+  m_edges.erase (m_edges.begin () + ii, m_edges.end ());
 
   for (std::list<edge_type>::const_iterator e = sc_edges.begin (); e != sc_edges.end (); ++e) {
 

--- a/src/db/unit_tests/dbLayoutQueryTests.cc
+++ b/src/db/unit_tests/dbLayoutQueryTests.cc
@@ -1382,6 +1382,8 @@ TEST(62)
   for (std::vector<db::PCellParameterDeclaration>::const_iterator p = pd.begin (); p != pd.end (); ++p) {
     if (p->get_name () == "text") {
       values.push_back (tl::Variant ("T1"));
+    } else if (p->get_name () == "layer") {
+      values.push_back (tl::Variant (db::LayerProperties (1, 0)));
     } else {
       values.push_back (p->get_default ());
     }
@@ -1393,6 +1395,8 @@ TEST(62)
   for (std::vector<db::PCellParameterDeclaration>::const_iterator p = pd.begin (); p != pd.end (); ++p) {
     if (p->get_name () == "text") {
       values.push_back (tl::Variant ("T2"));
+    } else if (p->get_name () == "layer") {
+      values.push_back (tl::Variant (db::LayerProperties (2, 0)));
     } else {
       values.push_back (p->get_default ());
     }
@@ -1436,7 +1440,7 @@ TEST(62)
     db::LayoutQuery q ("instances of ...\"Basic.*\"");
     db::LayoutQueryIterator iq (q, &g);
     std::string s = q2s_expr (iq, "inst.cell.display_title");
-    EXPECT_EQ (s, "Basic.TEXT('T2'),Basic.TEXT('T1'),Basic.TEXT('T1')");
+    EXPECT_EQ (s, "Basic.TEXT(l=2/0,'T2'),Basic.TEXT(l=1/0,'T1'),Basic.TEXT(l=1/0,'T1')");
   }
 
   {

--- a/src/db/unit_tests/dbPolygonToolsTests.cc
+++ b/src/db/unit_tests/dbPolygonToolsTests.cc
@@ -1555,6 +1555,120 @@ TEST(204)
   EXPECT_EQ (pr.to_string (),  "(0,0;0,40000;40000,40000;40000,0/10000,10000;30000,10000;30000,30000;10000,30000)");
 }
 
+//  rounding
+TEST(205_issue318)
+{
+  db::Point pattern [] = {
+    db::Point (0, 0),
+    db::Point (0, 420000),
+    db::Point (400000, 400000),
+    db::Point (400000, 0),
+  };
+
+  db::Polygon p;
+  p.assign_hull (&pattern[0], &pattern[0] + sizeof (pattern) / sizeof (pattern[0]));
+
+  double rinner = 0.0, router = 0.0;
+  unsigned int n;
+  db::Polygon pr;
+  db::Polygon pp = compute_rounded (p, 100000, 200000, 64);
+  EXPECT_EQ (extract_rad (pp, rinner, router, n, &pr), true);
+
+  EXPECT_EQ (tl::to_string (rinner),  "0");
+  EXPECT_EQ (tl::to_string (router),  "200000");
+  EXPECT_EQ (tl::to_string (n),  "64");
+  //  slight rounding errors, but still a good approximation ...
+  EXPECT_EQ (pr.to_string (),  "(0,0;0,419998;400000,400002;400000,0)");
+
+  pp = compute_rounded (p, 50000, 100000, 64);
+  EXPECT_EQ (extract_rad (pp, rinner, router, n, &pr), true);
+
+  EXPECT_EQ (tl::to_string (rinner),  "0");
+  EXPECT_EQ (tl::to_string (router),  "100000");
+  EXPECT_EQ (tl::to_string (n),  "64");
+  //  slight rounding issue due to  ...
+  EXPECT_EQ (pr.to_string (),  "(0,0;0,420001;400000,400000;400000,0)");
+}
+
+//  rounding
+TEST(206_issue318)
+{
+  db::Point pattern [] = {
+    db::Point (0, 0),
+    db::Point (0, 40000000),
+    db::Point (400000, 400000),
+    db::Point (400000, 0),
+  };
+
+  db::Polygon p;
+  p.assign_hull (&pattern[0], &pattern[0] + sizeof (pattern) / sizeof (pattern[0]));
+
+  double rinner = 0.0, router = 0.0;
+  unsigned int n;
+  db::Polygon pr;
+  db::Polygon pp = compute_rounded (p, 100000, 200000, 64);
+  EXPECT_EQ (extract_rad (pp, rinner, router, n, &pr), true);
+
+  EXPECT_EQ (tl::to_string (rinner),  "0");
+  EXPECT_EQ (tl::to_string (router),  "199992");
+  EXPECT_EQ (tl::to_string (n),  "65");
+  //  good approximation of a top edge ...
+  EXPECT_EQ (pr.to_string (),  "(0,0;0,618467;400000,581242;400000,0)");
+
+  pp = compute_rounded (p, 50000, 100000, 64);
+  EXPECT_EQ (extract_rad (pp, rinner, router, n, &pr), true);
+
+  EXPECT_EQ (tl::to_string (rinner),  "0");
+  EXPECT_EQ (tl::to_string (router),  "100000");
+  EXPECT_EQ (tl::to_string (n),  "64");
+  //  the acute corner is split into two parts
+  EXPECT_EQ (pr.to_string (),  "(0,0;0,20309228;199083,20290710;400000,400000;400000,0)");
+}
+
+//  rounding
+TEST(207_issue318)
+{
+  db::Point pattern [] = {
+    db::Point(-2523825, -4693678),
+    db::Point(-2627783, -4676814),
+    db::Point(-2705532, -4629488),
+    db::Point(-2747861, -4559084),
+    db::Point(-2750596, -4499543),
+    db::Point(-2753284, -4335751),
+    db::Point(-2764621, -4271381),
+    db::Point(-2828260, -4154562),
+    db::Point(-2808940, -4144038),
+    db::Point(-2743579, -4264019),
+    db::Point(-2731316, -4333649),
+    db::Point(-2728604, -4498857),
+    db::Point(-2726139, -4552516),
+    db::Point(-2689468, -4613512),
+    db::Point(-2620017, -4655786),
+    db::Point(-2529175, -4670522),
+    db::Point(-2468652, -4627768),
+    db::Point(-2437469, -4536777),
+    db::Point(-2434902, -4384723),
+    db::Point(-2436252, -4320529),
+    db::Point(-2395450, -4234678),
+    db::Point(-2338494, -4144716),
+    db::Point(-2319906, -4156484),
+    db::Point(-2376150, -4245322),
+    db::Point(-2414148, -4325271),
+    db::Point(-2412898, -4384677),
+    db::Point(-2415531, -4540623),
+    db::Point(-2450148, -4641632)
+  };
+
+  db::Polygon p;
+  p.assign_hull (&pattern[0], &pattern[0] + sizeof (pattern) / sizeof (pattern[0]));
+
+  double rinner = 0.0, router = 0.0;
+  unsigned int n;
+  db::Polygon pr;
+  //  this polygon should not be recognized as rounded - it kind of looks like ...
+  EXPECT_EQ (extract_rad (p, rinner, router, n, &pr), false);
+}
+
 //  is_convex
 TEST(300)
 {

--- a/src/db/unit_tests/unit_tests.pro
+++ b/src/db/unit_tests/unit_tests.pro
@@ -36,7 +36,6 @@ SOURCES = \
   dbPCells.cc \
   dbPoint.cc \
   dbPolygon.cc \
-  dbPolygonTools.cc \
   dbPropertiesRepository.cc \
   dbRegion.cc \
   dbShapeArray.cc \
@@ -72,7 +71,8 @@ SOURCES = \
     dbNetlistCompareTests.cc \
     dbNetlistReaderTests.cc \
     dbLayoutVsSchematicTests.cc \
-    dbLayoutQueryTests.cc
+    dbLayoutQueryTests.cc \
+    dbPolygonToolsTests.cc
 
 INCLUDEPATH += $$TL_INC $$DB_INC $$GSI_INC
 DEPENDPATH += $$TL_INC $$DB_INC $$GSI_INC

--- a/src/edt/edt/PCellParametersDialog.ui
+++ b/src/edt/edt/PCellParametersDialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Instantiation Path</string>
+   <string>PCell Parameters</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/edt/edt/RoundCornerOptionsDialog.ui
+++ b/src/edt/edt/RoundCornerOptionsDialog.ui
@@ -1,70 +1,78 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>RoundCornerOptionsDialog</class>
- <widget class="QDialog" name="RoundCornerOptionsDialog" >
-  <property name="geometry" >
+ <widget class="QDialog" name="RoundCornerOptionsDialog">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>469</width>
-    <height>241</height>
+    <height>271</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" >
-   <item row="2" column="1" >
-    <widget class="QLineEdit" name="router_le" />
-   </item>
-   <item row="2" column="0" >
-    <widget class="QLabel" name="label" >
-     <property name="text" >
-      <string>Outer corner radius</string>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0" colspan="3">
+    <widget class="QCheckBox" name="amend_cb">
+     <property name="text">
+      <string>Amend mode (undo existing rounding before applying new one)</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" >
-    <widget class="QLabel" name="label_2" >
-     <property name="text" >
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
       <string>Number of points (for full circle)</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0" >
-    <widget class="QLabel" name="label_3" >
-     <property name="text" >
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
       <string>Inner corner radius</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1" >
-    <widget class="QLineEdit" name="rinner_le" />
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="rinner_le"/>
    </item>
-   <item row="5" column="1" >
-    <widget class="QLineEdit" name="points_le" />
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="router_le"/>
    </item>
-   <item row="4" column="0" colspan="3" >
-    <widget class="Line" name="line" >
-     <property name="orientation" >
+   <item row="4" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Outer corner radius</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="points_le"/>
+   </item>
+   <item row="6" column="0" colspan="3">
+    <widget class="Line" name="line">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="3" >
-    <widget class="QLabel" name="label_4" >
-     <property name="text" >
+   <item row="0" column="0" colspan="3">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
       <string>Radius to apply on polygon corners
 (Radius for inner corners can be specified separately.
 Leave empty to get the same radius than for outer corners)</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3" >
-    <spacer name="verticalSpacer" >
-     <property name="orientation" >
+   <item row="8" column="0" colspan="3">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" stdset="0" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>448</width>
        <height>11</height>
@@ -72,29 +80,29 @@ Leave empty to get the same radius than for outer corners)</string>
      </property>
     </spacer>
    </item>
-   <item row="2" column="2" >
-    <widget class="QLabel" name="label_5" >
-     <property name="text" >
+   <item row="4" column="2">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
       <string>micron</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="2" >
-    <widget class="QLabel" name="label_6" >
-     <property name="text" >
+   <item row="5" column="2">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
       <string>micron</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="3" >
-    <spacer name="verticalSpacer_2" >
-     <property name="orientation" >
+   <item row="3" column="0" colspan="3">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeType" >
+     <property name="sizeType">
       <enum>QSizePolicy::Fixed</enum>
      </property>
-     <property name="sizeHint" stdset="0" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
        <height>10</height>
@@ -102,28 +110,33 @@ Leave empty to get the same radius than for outer corners)</string>
      </property>
     </spacer>
    </item>
-   <item row="7" column="0" colspan="3" >
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="orientation" >
+   <item row="9" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons" >
+     <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
+   <item row="1" column="0" colspan="3">
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>5</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
-  <zorder>router_le</zorder>
-  <zorder>label</zorder>
-  <zorder>label_2</zorder>
-  <zorder>label_3</zorder>
-  <zorder>rinner_le</zorder>
-  <zorder>points_le</zorder>
-  <zorder>line</zorder>
-  <zorder>label_4</zorder>
-  <zorder>label_5</zorder>
-  <zorder>label_6</zorder>
-  <zorder>buttonBox</zorder>
  </widget>
  <resources/>
  <connections>
@@ -133,11 +146,11 @@ Leave empty to get the same radius than for outer corners)</string>
    <receiver>RoundCornerOptionsDialog</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>248</x>
      <y>254</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>157</x>
      <y>274</y>
     </hint>
@@ -149,11 +162,11 @@ Leave empty to get the same radius than for outer corners)</string>
    <receiver>RoundCornerOptionsDialog</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>316</x>
      <y>260</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
     </hint>

--- a/src/edt/edt/edtDialogs.h
+++ b/src/edt/edt/edtDialogs.h
@@ -173,12 +173,18 @@ public:
   RoundCornerOptionsDialog (QWidget *parent);
   ~RoundCornerOptionsDialog ();
 
-  bool exec_dialog (const db::Layout &layout, double &rhull, double &rholes, unsigned int &npoints);
+  bool exec_dialog (const db::Layout &layout, double &router, double &rinner, unsigned int &npoints, bool &undo_before_apply, double router_extracted, double rinner_extracted, unsigned int npoints_extracted, bool has_extracted);
 
   virtual void accept ();
 
+private slots:
+  void amend_changed ();
+
 private:
   const db::Layout *mp_layout;
+  double m_router_extracted, m_rinner_extracted;
+  unsigned int m_npoints_extracted;
+  bool m_has_extracted;
 };
 
 } // namespace edt

--- a/src/edt/edt/edtMainService.h
+++ b/src/edt/edt/edtMainService.h
@@ -39,6 +39,7 @@
 
 namespace lay {
   class PluginRoot;
+  class FlattenInstOptionsDialog;
 }
 
 namespace edt {
@@ -46,6 +47,10 @@ namespace edt {
 class Service;
 class EditorOptionsPages;
 class EditorOptionsPage;
+class RoundCornerOptionsDialog;
+class MakeCellOptionsDialog;
+class MakeArrayOptionsDialog;
+class AlignOptionsDialog;
 
 // -------------------------------------------------------------
 
@@ -205,9 +210,22 @@ private:
   bool m_origin_visible_layers_for_bbox;
   db::DVector m_array_a, m_array_b;
   unsigned int m_array_na, m_array_nb;
+  double m_router, m_rinner;
+  unsigned int m_npoints;
+  bool m_undo_before_apply;
+  edt::RoundCornerOptionsDialog *mp_round_corners_dialog;
+  edt::AlignOptionsDialog *mp_align_options_dialog;
+  lay::FlattenInstOptionsDialog *mp_flatten_inst_options_dialog;
+  edt::MakeCellOptionsDialog *mp_make_cell_options_dialog;
+  edt::MakeArrayOptionsDialog *mp_make_array_options_dialog;
 
   void boolean_op (int mode);
   void check_no_guiding_shapes ();
+  edt::RoundCornerOptionsDialog *round_corners_dialog ();
+  edt::AlignOptionsDialog *align_options_dialog ();
+  lay::FlattenInstOptionsDialog *flatten_inst_options_dialog ();
+  edt::MakeCellOptionsDialog *make_cell_options_dialog ();
+  edt::MakeArrayOptionsDialog *make_array_options_dialog ();
 };
 
 }

--- a/src/lay/lay/TechBaseEditorPage.ui
+++ b/src/lay/lay/TechBaseEditorPage.ui
@@ -6,23 +6,54 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>568</width>
-    <height>353</height>
+    <width>604</width>
+    <height>498</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="3">
+    <widget class="QToolButton" name="browse_pb">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="desc_le"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="name_le">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="3">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>The base path is used to locate auxiliary files if those are specified with a relative path. If none is specified, the default path is used. The default path is the one from which a technology was imported.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Description</string>
      </property>
     </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QLineEdit" name="base_path_le"/>
    </item>
    <item row="8" column="0" colspan="4">
     <spacer name="verticalSpacer">
@@ -39,135 +70,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="6" column="1" colspan="3">
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QLineEdit" name="dbu_le">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>µm</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="4">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>27</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0" colspan="4">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="3">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>The base path is used to locate auxiliary files if those are specified with a relative path. If none is specified, the default path is used. The default path is the one from which a technology was imported.</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Base path</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="4">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="3">
-    <widget class="QToolButton" name="browse_pb">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2" colspan="2">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="name_le">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2" colspan="2">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>(Use the rename button to change this)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="desc_le"/>
    </item>
    <item row="9" column="1" colspan="3">
     <widget class="QGroupBox" name="lyp_grp">
@@ -223,10 +125,10 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="1" colspan="3">
-    <widget class="QLabel" name="label_8">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>The default database unit is used as database unit for freshly created layouts</string>
+      <string>Base path</string>
      </property>
     </widget>
    </item>
@@ -249,6 +151,127 @@ unit</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="4">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="4">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2" colspan="2">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>(Use the rename button to change this)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="3">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>The default database unit is used as database unit for freshly created layouts</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="3">
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLineEdit" name="dbu_le">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>µm</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="2" colspan="2">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QLineEdit" name="base_path_le"/>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="libs_lbl">
+     <property name="text">
+      <string>Technology
+specific
+libraries</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="4">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="11" column="1" rowspan="2" colspan="3">
+    <widget class="QListWidget" name="libs_lw">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
      </property>
     </widget>
    </item>

--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -2414,7 +2414,6 @@ MainWindow::cm_undo ()
       (*vp)->cancel ();
     }
     m_manager.undo ();
-    current_view ()->update_content ();
   }
 
   END_PROTECTED
@@ -2431,7 +2430,6 @@ MainWindow::cm_redo ()
       (*vp)->cancel ();
     }
     m_manager.redo ();
-    current_view ()->update_content ();
   }
 
   END_PROTECTED

--- a/src/lay/lay/layTechSetupDialog.cc
+++ b/src/lay/lay/layTechSetupDialog.cc
@@ -37,6 +37,8 @@
 #include "tlStream.h"
 #include "tlClassRegistry.h"
 #include "dbStream.h"
+#include "dbLibraryManager.h"
+#include "dbLibrary.h"
 
 #include "ui_TechSetupDialog.h"
 #include "ui_TechMacrosPage.h"
@@ -51,6 +53,7 @@
 #include <QHeaderView>
 #include <QFileDialog>
 #include <QScrollArea>
+#include <QListWidgetItem>
 
 #include <stdio.h>
 #include <fstream>
@@ -114,6 +117,38 @@ TechBaseEditorPage::setup ()
   mp_ui->lyp_grp->setChecked (! lyp.empty ());
   mp_ui->lyp_le->setText (tl::to_qstring (lyp));
   mp_ui->add_other_layers_cbx->setChecked (tech ()->add_other_layers ());
+
+  mp_ui->libs_lw->clear ();
+
+  if (! tech ()->name ().empty ()) {
+
+    mp_ui->libs_lbl->setEnabled (true);
+    mp_ui->libs_lw->setEnabled (true);
+
+    std::vector<std::string> libs;
+
+    for (db::LibraryManager::iterator l = db::LibraryManager::instance ().begin (); l != db::LibraryManager::instance ().end (); ++l) {
+      const db::Library *lib = db::LibraryManager::instance ().lib (l->second);
+      if (lib->get_technology () == tech ()->name ()) {
+        std::string text = lib->get_name ();
+        if (! lib->get_description ().empty ()) {
+          text += " - " + lib->get_description ();
+        }
+        libs.push_back (text);
+      }
+    }
+
+    std::sort (libs.begin (), libs.end ());
+
+    for (std::vector<std::string>::const_iterator l = libs.begin (); l != libs.end (); ++l) {
+      mp_ui->libs_lw->addItem (new QListWidgetItem (tl::to_qstring (*l)));
+    }
+
+  } else {
+    mp_ui->libs_lbl->setEnabled (false);
+    mp_ui->libs_lw->setEnabled (false);
+    mp_ui->libs_lw->addItem (tr ("The default technology can't have libraries"));
+  }
 }
 
 void 

--- a/src/laybasic/laybasic/layLayoutView.cc
+++ b/src/laybasic/laybasic/layLayoutView.cc
@@ -1706,9 +1706,12 @@ LayoutView::insert_layer_list (unsigned index, const LayerPropertiesList &props)
 
   m_current_layer_list = index;
   current_layer_list_changed_event (index);
+
   layer_list_inserted_event (index);
 
   redraw ();
+
+  dm_prop_changed ();
 }
 
 void 
@@ -1750,6 +1753,7 @@ LayoutView::delete_layer_list (unsigned index)
   }
 
   layer_list_deleted_event (index);
+  dm_prop_changed ();
 }
 
 void 
@@ -1986,6 +1990,7 @@ LayoutView::insert_layer (unsigned int index, const LayerPropertiesConstIterator
   if (index == current_layer_list ()) {
     layer_list_changed_event (2);
     redraw ();
+    dm_prop_changed ();
   }
 
   return ret;
@@ -2013,6 +2018,7 @@ LayoutView::delete_layer (unsigned int index, LayerPropertiesConstIterator &iter
   if (index == current_layer_list ()) {
     layer_list_changed_event (2);
     redraw ();
+    dm_prop_changed ();
   }
 
   //  invalidate the iterator so it can be used to refer to the next element

--- a/src/laybasic/laybasic/layLibrariesView.cc
+++ b/src/laybasic/laybasic/layLibrariesView.cc
@@ -795,6 +795,10 @@ LibrariesView::display_string (int n) const
   if (! lib->get_description ().empty ()) {
     text += " - " + lib->get_description ();
   }
+  if (! lib->get_technology ().empty ()) {
+    text += " ";
+    text += tl::to_string (QObject::tr ("[Technology %1]").arg (tl::to_qstring (lib->get_technology ())));
+  }
   return text;
 }
 

--- a/src/laybasic/laybasic/layLibrariesView.cc
+++ b/src/laybasic/laybasic/layLibrariesView.cc
@@ -588,10 +588,6 @@ LibrariesView::do_update_content (int lib_index)
       m_force_close [i] = true;
     }
 
-    if (m_needs_update [i]) {
-      mp_cell_lists [i]->doItemsLayout ();   //  triggers a redraw
-    }
-
     m_libraries [i].reset (libraries [i]);
 
   }
@@ -714,6 +710,8 @@ LibrariesView::do_update_content (int lib_index)
       }
 
       m_needs_update [i] = false;
+
+      mp_cell_lists [i]->doItemsLayout ();   //  triggers a redraw -> the model might need this
 
     }
 

--- a/src/plugins/streamers/oasis/unit_tests/dbOASISWriter.cc
+++ b/src/plugins/streamers/oasis/unit_tests/dbOASISWriter.cc
@@ -1769,7 +1769,7 @@ TEST(119_WithAndWithoutContext)
 
     const db::Cell &text_cell = gg.cell (tc.second);
     EXPECT_EQ (text_cell.is_proxy (), true);
-    EXPECT_EQ (text_cell.get_display_name (), "Basic.TEXT('KLAYOUT RULES')");
+    EXPECT_EQ (text_cell.get_display_name (), "Basic.TEXT(l=1/0,'KLAYOUT RULES')");
 
     CHECKPOINT ();
     db::compare_layouts (_this, gg, tl::testsrc () + "/testdata/oasis/dbOASISWriter119_au.gds", db::NoNormalization);


### PR DESCRIPTION
* The libraries in the browser now list the technology they are attached to (CAUTION: it's still possible to place a library cell from a foreign tech)
* The tech manager dialog now also shows the libraries associated with a tech
* Fixed a drawing issue when a lib cell was dragged to the canvas and then dragged out (missing call to LayoutView::set_view_ops)