### PR TITLE
Fixed issue #333 (automation of auto-measure rulers)

### DIFF
--- a/src/ant/ant/antService.cc
+++ b/src/ant/ant/antService.cc
@@ -1499,6 +1499,22 @@ Service::mouse_click_event (const db::DPoint &p, unsigned int buttons, bool prio
   return false;
 }
 
+ant::Object
+Service::create_measure_ruler (const db::DPoint &pt, lay::angle_constraint_type ac)
+{
+  double snap_range = widget ()->mouse_event_trans ().inverted ().ctrans (m_snap_range);
+  snap_range *= 0.5;
+
+  ant::Template tpl;
+
+  std::pair<bool, db::DEdge> ee = lay::obj_snap2 (mp_view, pt, db::DVector (), ac, snap_range, snap_range * 1000.0);
+  if (ee.first) {
+    return ant::Object (ee.second.p1 (), ee.second.p2 (), 0, tpl);
+  } else {
+    return ant::Object (pt, pt, 0, tpl);
+  }
+}
+
 bool 
 Service::mouse_move_event (const db::DPoint &p, unsigned int buttons, bool prio) 
 {

--- a/src/ant/ant/antService.h
+++ b/src/ant/ant/antService.h
@@ -427,6 +427,11 @@ public:
   AnnotationIterator begin_annotations () const;
 
   /**
+   *  @brief Creates an auto-measure ruler at the given point with the given angle constraint
+   */
+  ant::Object create_measure_ruler(const db::DPoint &pt, lay::angle_constraint_type ac);
+
+  /**
    *  @brief An event triggered when the annotations changed
    *  When an annotation is added or removed, this event is triggered.
    */


### PR DESCRIPTION
The implementation provides a new method called "create_measure_ruler" in LayoutView:

```
view = RBA::LayoutView::current

# create the ruler with auto-measurement with seed point 111.8/840
ant = view.create_measure_ruler(RBA::DPoint::new(111.8, 840.0))
# style the ruler
ant.style = RBA::Annotation::StyleRuler
...
# remove the ruler
ant.delete
```
