### PR TITLE
Fixed: help link not working

### DIFF
--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -460,13 +460,13 @@ MainWindow::MainWindow (QApplication *app, lay::Plugin *plugin_parent, const cha
   }
   mw_instance = this;
 
+  lay::register_help_handler (this, SLOT (show_help (const QString &)), SLOT (show_modal_help (const QString &)));
+
   mp_setup_form = new SettingsForm (0, plugin_root (), "setup_form"),
 
   db::LibraryManager::instance ().changed_event.add (this, &MainWindow::libraries_changed);
 
   init_menu ();
-
-  lay::register_help_handler (this, SLOT (show_help (const QString &)), SLOT (show_modal_help (const QString &)));
 
   mp_assistant = new lay::HelpDialog (this);
 
@@ -4792,7 +4792,9 @@ MainWindow::cm_show_assistant ()
 void
 MainWindow::show_help (const QString &url)
 {
-  show_assistant_url (tl::to_string (url), false);
+  //  NOTE: from inside a modal widget we show the help dialog modal too
+  //  (otherwise it's not usable)
+  show_assistant_url (tl::to_string (url), QApplication::activeModalWidget () != 0);
 }
 
 void


### PR DESCRIPTION
The help link wasn't working for File/Setup/Rulers/Templates
("here"). Also: if clicked from the model "Ruler and annotations setup"
the link was working but the help window wasn't usable. The modal
setup dialog was hiding the help window.