### PR TITLE
0.25.9 mac anaconda3

### DIFF
--- a/macbuild/ReadMe.md
+++ b/macbuild/ReadMe.md
@@ -1,4 +1,4 @@
-Relevant KLayout version: 0.25.2
+Relevant KLayout version: 0.25.9
 
 # 1. Introduction
 This directory "macbuild" contains different files required for building KLayout (http://www.klayout.de/) version 0.25 or later for different 64-bit Mac OSXs including:
@@ -6,33 +6,27 @@ This directory "macbuild" contains different files required for building KLayout
 * El Capitan  (10.11)
 * Sierra      (10.12)
 * High Sierra (10.13)
+* Mojave      (10.14)
 
-By default, Qt framework is "Qt5" from MacPorts (https://www.macports.org/) which is usually located under:
+By default, Qt framework is "Qt5" from **MacPorts** (https://www.macports.org/) which is usually located under:
 ```
 /opt/local/libexec/qt5/
 ```
 
-Alternatively, you can use "Qt5" from Homebrew (https://brew.sh/) which is usually located under:
+Alternatively, you can use "Qt5" from **Homebrew** (https://brew.sh/) which is usually located under:
 ```
 /usr/local/opt/qt/
 ```
-Please refer to Section # 5. of this document regarding use of Homebrew.
-
-KLayout 0.25.2 was successfully built with "Qt 5.10.0" from MacPorts and "Qt 5.10.1" from Homebrew.
+Please refer to Section # 5.1 of this document regarding the use of Qt5 from **Homebrew**.
 
 ### IMPORTANT
-```
-* Please DO NOT USE "Qt 4.x" which is problematic in compilation.
-```
-
-Also by default, supported script languages, i.e, Ruby and Python, are those standard ones bundled with the OS.
+By default, the supported script languages, i.e., Ruby and Python, are those standard ones bundled with the OS.
 
 # 2. Non-OS-standard script language support
-You may want to use a non-OS-standard script language such as Python 3.6 from Anaconda2 (https://www.anaconda.com/download/#macos) in combination with KLayout.
+You may want to use a non-OS-standard script language such as Python 3.7 from **Homebrew** or **Anaconda3** (https://www.anaconda.com/download/#macos) in combination with KLayout.
 
-Since Anaconda2 is a popular Python development environment, this is worth trying. Unfortunately, however, some dynamic linkage problems are observed as of today. 
-On the other hand, Python 3.7 provided by MacPorts or Homebrew is usable.
-Please try this (refer to 3B below or Section #5) if you feel it's useful.
+Section # 5.1 of this document explains the use of **Homebrew**; Section # 5.2, **Anaconda3**.<br>
+Please try these if you feel they are useful.
 
 # 3. Use-cases
 ### 3A. Debug build using the OS-standard script languages
@@ -41,16 +35,16 @@ Please try this (refer to 3B below or Section #5) if you feel it's useful.
   build4mac.py -> macbuild/build4mac.py
 ```
 2. Invoke 'build4mac.py' with appropriate options ("-d" for debug build):
-``` 
+```
 $ cd /where/'build.sh'/exists
 $ ./build4mac.py -d
 ```
 3. Confirm successful build (it will take about one hour).
-4. Run 'build4mac.py' again with the same options used in 2. PLUS "-y" to deploy executables and libraries (including Qt's frameworks) under "klayout.app" bundle. The buddy command line tools (strm*) will also be deployed in this step.
+4. Run 'build4mac.py' again with the same options used in 2. PLUS "-y" to deploy executables and libraries (including Qt's frameworks) under "klayout.app" bundle. The buddy command-line tools (strm*) will also be deployed in this step.
 ```
 $ ./build4mac.py -d -y
 ```
-5. Copy/move generated bundles ("klayout.app" and "klayout.scripts/") to your "/Applications" directory for installation.
+5. Copy/move the generated bundle ("klayout.app") to your "/Applications" directory for installation.
 
 ### 3B. Release build using the non-OS-standard Ruby 2.4 and Python 3.6 both from MacPorts
 1. Make a symbolic link (if it does not exist) from the parent directory (where 'build.sh' exists) to 'build4mac.py', that is,
@@ -63,14 +57,14 @@ $ cd /where/'build.sh'/exists
 $ ./build4mac.py -r mp24 -p mp36
 ```
 3. Confirm successful build (it will take about one hour).
-4. Run 'build4mac.py' again with the same options used in 2. PLUS "-Y" to deploy executables and libraries under "klayout.app" bundle. The buddy command line tools (strm*) will also be deployed in this step.
+4. Run 'build4mac.py' again with the same options used in 2. PLUS "-Y" to deploy executables and libraries under "klayout.app" bundle. The buddy command-line tools (strm*) will also be deployed in this step.
 ```
 $ ./build4mac.py -r mp24 -p mp36 -Y
 ```
 * [-Y|--DEPLOY] option deploys KLayout's dylibs and executables only.
 That is, paths to other modules (Ruby, Python, and Qt5 Frameworks) remain unchanged (absolute paths in your development environment).
 
-5. Copy/move generated bundles ("klayout.app" and "klayout.scripts/") to your "/Applications" directory for installation.
+5. Copy/move the generated bundle ("klayout.app") to your "/Applications" directory for installation.
 
 ----
 
@@ -85,9 +79,9 @@ makeDMG4mac.py -> macbuild/makeDMG4mac.py
 2. Invoke 'makeDMG4mac.py' with -p and -m options, for example,
 ```
 $ cd /where/'build.sh'/exists
-$ ./makeDMG4mac.py -p qt5.pkg.macos-HighSierra-release -m 
+$ ./makeDMG4mac.py -p qt5.pkg.macos-HighSierra-release -m
 ```
-
+----
 
 # 5. Alternative building options
 ### 5.1 Python 3.7 from Homebrew, Qt 5.10.1 from Homebrew
@@ -114,9 +108,43 @@ Homebrew's installation of python3 (`brew install python3`) places a `Python.fra
 
 Because we link python to `/usr/local/opt/python/Frameworks/Python.framework/`, updating python from brew might break KLayout if the new version is incompatible. To fix this, it is better to link python directly to `/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework`, but that might complicate release builds, because that assumes users have the exact version of python installed by brew.
 
-[End of File] 
+### 5.2 Qt 5.9.7, Ruby 2.5, Python 3.7 (as of Sep. 2019) from Anaconda3
+If you wish to use all the three components (Qt5, Ruby, and Python) bundled with **Anaconda3**, this is the case, <br>
+where the build script assumes **Anaconda3** is installed under **$HOME/anaconda3/**. <br>
+This case does not support the standard packaging step due to a known issue in solving inter-library dependencies.<br>
+Instead, you need to move/copy the deployed application bundle ("klayout.app") to your "/Applications" directory for installation.
 
+```
+# Build step
+./build4mac.py -q Qt5Ana3 -r ana3 -p ana3
 
+# Deploy step
+./build4mac.py -q Qt5Ana3 -r ana3 -p ana3 -Y  # not '-y'
+
+# Packaging step
+-- N/A --
+
+# Manual installation step
+$ cd  qt5.pkg.macos-{OS_NAME}-release
+
+$ mv  klayout.app  klayout-anaconda3.app
+
+$ cp -Rp  klayout-anaconda3.app  /Applications
+```
+
+#### Additional steps to start KLayout using the Python in **Anaconda3**
+```
+$ export PYTHONHOME=$HOME/anaconda3
+
+$ open /Applications/klayout-anaconda3.app
+```
+
+You can make an application bundle (icon) for the above Bash script using MacOS' **Automator** tool.<br>
+A related Github ticket is [here](https://github.com/Kazzz-S/klayout/issues/34).
+
+[End of File]
+
+----
 #### Creating a template DMG file
 
 Starting from a `klayout-0.25.8-macOS-Mojave-1-Qt5101.dmg` file:

--- a/macbuild/build4mac.py
+++ b/macbuild/build4mac.py
@@ -65,9 +65,9 @@ def SetGlobals():
   Usage += "                        :   'nil' = not to support the script language                   | \n"
   Usage += "                        :   'Sys' = using the OS standard script language                | \n"
   Usage += "                        : Refer to 'macbuild/build4mac_env.py' for details               | \n"
-  Usage += "   [-q|--qt <type>]     : type=['Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3']      | qt5macports \n"
-  Usage += "   [-r|--ruby <type>]   : type=['nil', 'Sys', 'Src24', 'MP24', 'B25', 'Ana3']            | sys \n"
-  Usage += "   [-p|--python <type>] : type=['nil', 'Sys', 'Ana27', 'Ana36', 'MP36', 'B37', 'Ana3']   | sys \n"
+  Usage += "   [-q|--qt <type>]     : type=['Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3']                     | qt5macports \n"
+  Usage += "   [-r|--ruby <type>]   : type=['nil', 'Sys', 'MP24', 'B25', 'Ana3']                     | sys \n"
+  Usage += "   [-p|--python <type>] : type=['nil', 'Sys', 'MP36', 'B37', 'Ana3']                     | sys \n"
   Usage += "   [-n|--noqtbinding]   : don't create Qt bindings for ruby scripts                      | disabled \n"
   Usage += "   [-m|--make <option>] : option passed to 'make'                                        | -j4 \n"
   Usage += "   [-d|--debug]         : enable debug mode build                                        | disabled \n"
@@ -94,7 +94,7 @@ def SetGlobals():
     print("")
     print( "!!! Sorry. Your system <%s> looks like non-Mac" % System, file=sys.stderr )
     print(Usage)
-    exit()
+    sys.exit(1)
 
   release = int( Release.split(".")[0] ) # take the first of ['14', '5', '0']
   if release == 14:
@@ -112,13 +112,13 @@ def SetGlobals():
     print("")
     print( "!!! Sorry. Unsupported major OS release <%d>" % release, file=sys.stderr )
     print(Usage)
-    exit()
+    sys.exit(1)
 
   if not Machine == "x86_64":
     print("")
     print( "!!! Sorry. Only x86_64 architecture machine is supported but found <%s>" % Machine, file=sys.stderr )
     print(Usage)
-    exit()
+    sys.exit(1)
 
   # default modules
   ModuleQt = "Qt5MacPorts"
@@ -172,15 +172,15 @@ def ParseCommandLineArguments():
   p = optparse.OptionParser( usage=Usage )
   p.add_option( '-q', '--qt',
                 dest='type_qt',
-                help="Qt type=['Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3']" )
+                help="Qt type=['Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3']" )
 
   p.add_option( '-r', '--ruby',
                 dest='type_ruby',
-                help="Ruby type=['nil', 'Sys', 'Src24', 'MP24', 'B25', 'Ana3']" )
+                help="Ruby type=['nil', 'Sys', 'MP24', 'B25', 'Ana3']" )
 
   p.add_option( '-p', '--python',
                 dest='type_python',
-                help="Python type=['nil', 'Sys', 'Ana27', 'Ana36', 'MP36', 'B37', 'Ana3']" )
+                help="Python type=['nil', 'Sys', 'MP36', 'B37', 'Ana3']" )
 
   p.add_option( '-n', '--noqtbinding',
                 action='store_true',
@@ -241,13 +241,13 @@ def ParseCommandLineArguments():
   opt, args = p.parse_args()
   if (opt.checkusage):
     print(Usage)
-    exit()
+    sys.exit(0)
 
   # Determine Qt type
-  candidates = ['Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3']
+  candidates = ['Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3']
   candidates_upper = [ i.upper() for i in candidates ]
-  ModuleQt   = ""
-  index      = 0
+  ModuleQt = ""
+  index    = 0
   if opt.type_qt.upper() in candidates_upper:
     idx = candidates_upper.index(opt.type_qt.upper())
     ModuleQt = candidates[idx]
@@ -255,13 +255,13 @@ def ParseCommandLineArguments():
     print("")
     print( "!!! Unknown Qt type %s. Candidates: %s" % (opt.type_qt, candidates), file=sys.stderr )
     print(Usage)
-    exit(1)
+    sys.exit(1)
 
   # By default, OS-standard script languages (Ruby and Python) are used
   NonOSStdLang = False
 
   # Determine Ruby type
-  candidates = [ i.upper() for i in ['nil', 'Sys', 'Src24', 'MP24', 'B25', 'Ana3'] ]
+  candidates = [ i.upper() for i in ['nil', 'Sys', 'MP24', 'B25', 'Ana3'] ]
   ModuleRuby = ""
   index      = 0
   for item in candidates:
@@ -284,15 +284,12 @@ def ParseCommandLineArguments():
           ModuleRuby = ''
         break
       elif index == 2:
-        ModuleRuby   = 'Ruby24SrcBuild'
-        NonOSStdLang = True
-      elif index == 3:
         ModuleRuby   = 'Ruby24MacPorts'
         NonOSStdLang = True
-      elif index == 4:
+      elif index == 3:
         ModuleRuby   = 'Ruby25Brew'
         NonOSStdLang = True
-      elif index == 5:
+      elif index == 4:
         ModuleRuby   = 'RubyAnaconda3'
         NonOSStdLang = True
     else:
@@ -301,10 +298,10 @@ def ParseCommandLineArguments():
     print("")
     print( "!!! Unknown Ruby type", file=sys.stderr )
     print(Usage)
-    exit()
+    sys.exit(1)
 
   # Determine Python type
-  candidates   = [ i.upper() for i in ['nil', 'Sys', 'Ana27', 'Ana36', 'MP36', 'B37', 'Ana3'] ]
+  candidates   = [ i.upper() for i in ['nil', 'Sys', 'MP36', 'B37', 'Ana3'] ]
   ModulePython = ""
   index        = 0
   for item in candidates:
@@ -327,18 +324,12 @@ def ParseCommandLineArguments():
           ModulePython = ''
         break
       elif index == 2:
-        ModulePython = 'Anaconda27'
-        NonOSStdLang = True
-      elif index == 3:
-        ModulePython = 'Anaconda36'
-        NonOSStdLang = True
-      elif index == 4:
         ModulePython = 'Python36MacPorts'
         NonOSStdLang = True
-      elif index == 5:
+      elif index == 3:
         ModulePython = 'Python37Brew'
         NonOSStdLang = True
-      elif index == 6:
+      elif index == 4:
         ModulePython = 'PythonAnaconda3'
         NonOSStdLang = True
     else:
@@ -347,7 +338,7 @@ def ParseCommandLineArguments():
     print("")
     print( "!!! Unknown Python type", file=sys.stderr )
     print(Usage)
-    exit()
+    sys.exit(1)
 
   NoQtBindings  = opt.no_qt_binding
   MakeOptions   = opt.make_option
@@ -360,14 +351,14 @@ def ParseCommandLineArguments():
     print("")
     print( "!!! Choose either [-y|--deploy] or [-Y|--DEPLOY]", file=sys.stderr )
     print(Usage)
-    exit()
+    sys.exit(1)
 
   DeployVerbose = int(opt.deploy_verbose)
   if not DeployVerbose in [0, 1, 2, 3]:
     print("")
     print( "!!! Unsupported verbose level passed to `macdeployqt` tool", file=sys.stderr )
     print(Usage)
-    exit()
+    sys.exit(1)
 
   if not DeploymentF and not DeploymentP:
     target  = "%s %s %s" % (Platform, Release, Machine)
@@ -415,21 +406,8 @@ def RunMainBuildBash():
     mode        = "release"
     parameters += "  -release"
 
-  # (B) Qt4 or Qt5
-  if ModuleQt == 'Qt4MacPorts':
-    parameters    += " \\\n  -qt4"
-    parameters    += " \\\n  -qmake  %s" % Qt4MacPorts['qmake']
-    MacPkgDir      = "./qt4.pkg.macos-%s-%s"        % (Platform, mode)
-    MacBinDir      = "./qt4.bin.macos-%s-%s"        % (Platform, mode)
-    MacBuildDir    = "./qt4.build.macos-%s-%s"      % (Platform, mode)
-    MacBuildLog    = "./qt4.build.macos-%s-%s.log"  % (Platform, mode)
-    AbsMacPkgDir   = "%s/qt4.pkg.macos-%s-%s"       % (ProjectDir, Platform, mode)
-    AbsMacBinDir   = "%s/qt4.bin.macos-%s-%s"       % (ProjectDir, Platform, mode)
-    AbsMacBuildDir = "%s/qt4.build.macos-%s-%s"     % (ProjectDir, Platform, mode)
-    AbsMacBuildLog = "%s/qt4.build.macos-%s-%s.log" % (ProjectDir, Platform, mode)
-    parameters    += " \\\n  -bin    %s" % MacBinDir
-    parameters    += " \\\n  -build  %s" % MacBuildDir
-  elif ModuleQt == 'Qt5MacPorts':
+  # (B) Qt5
+  if ModuleQt == 'Qt5MacPorts':
     parameters    += " \\\n  -qt5"
     parameters    += " \\\n  -qmake  %s" % Qt5MacPorts['qmake']
     MacPkgDir      = "./qt5.pkg.macos-%s-%s"        % (Platform, mode)
@@ -468,7 +446,7 @@ def RunMainBuildBash():
     AbsMacBuildLog = "%s/qt5.build.macos-%s-%s.log" % (ProjectDir, Platform, mode)
     parameters    += " \\\n  -bin    %s" % MacBinDir
     parameters    += " \\\n  -build  %s" % MacBuildDir
-  parameters    += " \\\n  -rpath    %s" % "@executable_path/../Frameworks"
+  parameters += " \\\n  -rpath    %s" % "@executable_path/../Frameworks"
 
   # (C) want Qt bindings with Ruby scripts?
   if NoQtBindings:
@@ -505,7 +483,7 @@ def RunMainBuildBash():
   command += "  2>&1 | tee %s" % MacBuildLog
   if CheckComOnly:
     print(command)
-    exit()
+    sys.exit(0)
 
   #-----------------------------------------------------
   # [3] Invoke the main Bash script; takes time:-)
@@ -681,7 +659,7 @@ def DeployBinariesForBundle():
       depDicOrdinary.update(dependDic)
   '''
   PrintLibraryDependencyDictionary( depDicOrdinary, "Style (3)" )
-  exit()
+  sys.exit(0)
   '''
 
   print( " [5] Setting and changing the identification names among KLayout's libraries ..." )
@@ -764,11 +742,7 @@ def DeployBinariesForBundle():
     # [8] Deploy Qt Frameworks
     #-------------------------------------------------------------
     verbose = " -verbose=%d" % DeployVerbose
-    if ModuleQt == 'Qt4MacPorts':
-      deploytool = Qt4MacPorts['deploy']
-      app_bundle = "klayout.app"
-      options    = macdepQtOpt + verbose
-    elif ModuleQt == 'Qt5MacPorts':
+    if ModuleQt == 'Qt5MacPorts':
       deploytool = Qt5MacPorts['deploy']
       app_bundle = "klayout.app"
       options    = macdepQtOpt + verbose
@@ -822,7 +796,7 @@ def DeployBinariesForBundle():
         if subprocess.call( command, shell=True ) != 0:
           msg = "command failed: %s"
           print( msg % command, file=sys.stderr )
-          exit(1)
+          sys.exit(1)
 
       shutil.copy2( sourceDir2 + "/start-console.py", targetDirM )
       shutil.copy2( sourceDir2 + "/klayout_console", targetDirM )

--- a/macbuild/build4mac.py
+++ b/macbuild/build4mac.py
@@ -54,37 +54,37 @@ def SetGlobals():
   global Bit                # machine bit-size
 
   Usage  = "\n"
-  Usage += "--------------------------------------------------------------------------------------------------------\n"
+  Usage += "---------------------------------------------------------------------------------------------------------\n"
   Usage += "<< Usage of 'build4mac.py' >>\n"
   Usage += "       for building KLayout 0.25 or later on different Apple Mac OSX platforms.\n"
   Usage += "\n"
   Usage += "$ [python] ./build4mac.py \n"
-  Usage += "   option & argument    : descriptions                                               | default value\n"
-  Usage += "   ----------------------------------------------------------------------------------+---------------\n"
-  Usage += "                        : * key type names below are case insensitive *              | \n"
-  Usage += "                        :   'nil' = not to support the script language               | \n"
-  Usage += "                        :   'Sys' = using the OS standard script language            | \n"
-  Usage += "                        : Refer to 'macbuild/build4mac_env.py' for details           | \n"
-  Usage += "   [-q|--qt <type>]     : type=['Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew']             | qt5macports \n"
-  Usage += "   [-r|--ruby <type>]   : type=['nil', 'Sys', 'Src24', 'MP24', 'B25']                | sys \n"
-  Usage += "   [-p|--python <type>] : type=['nil', 'Sys', 'Ana27', 'Ana36', 'MP36', 'B37']       | sys \n"
-  Usage += "   [-n|--noqtbinding]   : don't create Qt bindings for ruby scripts                  | disabled \n"
-  Usage += "   [-m|--make <option>] : option passed to 'make'                                    | -j4 \n"
-  Usage += "   [-d|--debug]         : enable debug mode build                                    | disabled \n"
-  Usage += "   [-c|--checkcom]      : check command line and exit without building               | disabled \n"
-  Usage += "   [-y|--deploy]        : deploy executables and dylibs including Qt's Frameworks    | disabled \n"
-  Usage += "   [-Y|--DEPLOY]        : deploy executables and dylibs for those who built KLayout  | disabled \n"
-  Usage += "                        : from the source code and use the tools in the same machine | \n"
-  Usage += "                        : ! After confirmation of successful build of                | \n"
-  Usage += "                        :   KLayout, rerun this script with BOTH:                    | \n"
-  Usage += "                        :     1) the same options used for building AND              | \n"
-  Usage += "                        :     2) <-y|--deploy> OR <-Y|--DEPLOY>                      | \n"
-  Usage += "                        :   optionally with [-v|--verbose <0-3>]                     | \n"
-  Usage += "   [-v|--verbose <0-3>] : verbose level of `macdeployqt' (effective with -y only)    | 1 \n"
-  Usage += "                        : 0 = no output, 1 = error/warning (default),                | \n"
-  Usage += "                        : 2 = normal,    3 = debug                                   | \n"
-  Usage += "   [-?|--?]             : print this usage and exit                                  | disabled \n"
-  Usage += "--------------------------------------------------------------------------------------------------------\n"
+  Usage += "   option & argument    : descriptions                                                   | default value\n"
+  Usage += "   --------------------------------------------------------------------------------------+---------------\n"
+  Usage += "                        : * key type names below are case insensitive *                  | \n"
+  Usage += "                        :   'nil' = not to support the script language                   | \n"
+  Usage += "                        :   'Sys' = using the OS standard script language                | \n"
+  Usage += "                        : Refer to 'macbuild/build4mac_env.py' for details               | \n"
+  Usage += "   [-q|--qt <type>]     : type=['Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3']      | qt5macports \n"
+  Usage += "   [-r|--ruby <type>]   : type=['nil', 'Sys', 'Src24', 'MP24', 'B25', 'Ana3']            | sys \n"
+  Usage += "   [-p|--python <type>] : type=['nil', 'Sys', 'Ana27', 'Ana36', 'MP36', 'B37', 'Ana3']   | sys \n"
+  Usage += "   [-n|--noqtbinding]   : don't create Qt bindings for ruby scripts                      | disabled \n"
+  Usage += "   [-m|--make <option>] : option passed to 'make'                                        | -j4 \n"
+  Usage += "   [-d|--debug]         : enable debug mode build                                        | disabled \n"
+  Usage += "   [-c|--checkcom]      : check command line and exit without building                   | disabled \n"
+  Usage += "   [-y|--deploy]        : deploy executables and dylibs including Qt's Frameworks        | disabled \n"
+  Usage += "   [-Y|--DEPLOY]        : deploy executables and dylibs for those who built KLayout      | disabled \n"
+  Usage += "                        : from the source code and use the tools in the same machine     | \n"
+  Usage += "                        : ! After confirmation of successful build of                    | \n"
+  Usage += "                        :   KLayout, rerun this script with BOTH:                        | \n"
+  Usage += "                        :     1) the same options used for building AND                  | \n"
+  Usage += "                        :     2) <-y|--deploy> OR <-Y|--DEPLOY>                          | \n"
+  Usage += "                        :   optionally with [-v|--verbose <0-3>]                         | \n"
+  Usage += "   [-v|--verbose <0-3>] : verbose level of `macdeployqt' (effective with -y only)        | 1 \n"
+  Usage += "                        : 0 = no output, 1 = error/warning (default),                    | \n"
+  Usage += "                        : 2 = normal,    3 = debug                                       | \n"
+  Usage += "   [-?|--?]             : print this usage and exit                                      | disabled \n"
+  Usage += "---------------------------------------------------------------------------------------------------------\n"
 
   ProjectDir = os.getcwd()
   BuildBash  = "./build.sh"
@@ -172,15 +172,15 @@ def ParseCommandLineArguments():
   p = optparse.OptionParser( usage=Usage )
   p.add_option( '-q', '--qt',
                 dest='type_qt',
-                help="Qt type=['Qt4MacPorts', 'Qt5MacPorts']" )
+                help="Qt type=['Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3']" )
 
   p.add_option( '-r', '--ruby',
                 dest='type_ruby',
-                help="Ruby type=['nil', 'Sys', 'Src24', 'MP24']" )
+                help="Ruby type=['nil', 'Sys', 'Src24', 'MP24', 'B25', 'Ana3']" )
 
   p.add_option( '-p', '--python',
                 dest='type_python',
-                help="Python type=['nil', 'Sys', 'Ana27', 'Ana36', 'MP36', 'B37']" )
+                help="Python type=['nil', 'Sys', 'Ana27', 'Ana36', 'MP36', 'B37', 'Ana3']" )
 
   p.add_option( '-n', '--noqtbinding',
                 action='store_true',
@@ -244,7 +244,7 @@ def ParseCommandLineArguments():
     exit()
 
   # Determine Qt type
-  candidates = ['Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew']
+  candidates = ['Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3']
   candidates_upper = [ i.upper() for i in candidates ]
   ModuleQt   = ""
   index      = 0
@@ -261,7 +261,7 @@ def ParseCommandLineArguments():
   NonOSStdLang = False
 
   # Determine Ruby type
-  candidates = [ i.upper() for i in ['nil', 'Sys', 'Src24', 'MP24', 'B25'] ]
+  candidates = [ i.upper() for i in ['nil', 'Sys', 'Src24', 'MP24', 'B25', 'Ana3'] ]
   ModuleRuby = ""
   index      = 0
   for item in candidates:
@@ -292,6 +292,9 @@ def ParseCommandLineArguments():
       elif index == 4:
         ModuleRuby   = 'Ruby25Brew'
         NonOSStdLang = True
+      elif index == 5:
+        ModuleRuby   = 'RubyAnaconda3'
+        NonOSStdLang = True
     else:
       index += 1
   if ModuleRuby == "":
@@ -301,7 +304,7 @@ def ParseCommandLineArguments():
     exit()
 
   # Determine Python type
-  candidates   = [ i.upper() for i in ['nil', 'Sys', 'Ana27', 'Ana36', 'MP36', 'B37'] ]
+  candidates   = [ i.upper() for i in ['nil', 'Sys', 'Ana27', 'Ana36', 'MP36', 'B37', 'Ana3'] ]
   ModulePython = ""
   index        = 0
   for item in candidates:
@@ -334,6 +337,9 @@ def ParseCommandLineArguments():
         NonOSStdLang = True
       elif index == 5:
         ModulePython = 'Python37Brew'
+        NonOSStdLang = True
+      elif index == 6:
+        ModulePython = 'PythonAnaconda3'
         NonOSStdLang = True
     else:
       index += 1
@@ -439,6 +445,19 @@ def RunMainBuildBash():
   elif ModuleQt == 'Qt5Brew':
     parameters    += " \\\n  -qt5"
     parameters    += " \\\n  -qmake  %s" % Qt5Brew['qmake']
+    MacPkgDir      = "./qt5.pkg.macos-%s-%s"        % (Platform, mode)
+    MacBinDir      = "./qt5.bin.macos-%s-%s"        % (Platform, mode)
+    MacBuildDir    = "./qt5.build.macos-%s-%s"      % (Platform, mode)
+    MacBuildLog    = "./qt5.build.macos-%s-%s.log"  % (Platform, mode)
+    AbsMacPkgDir   = "%s/qt5.pkg.macos-%s-%s"       % (ProjectDir, Platform, mode)
+    AbsMacBinDir   = "%s/qt5.bin.macos-%s-%s"       % (ProjectDir, Platform, mode)
+    AbsMacBuildDir = "%s/qt5.build.macos-%s-%s"     % (ProjectDir, Platform, mode)
+    AbsMacBuildLog = "%s/qt5.build.macos-%s-%s.log" % (ProjectDir, Platform, mode)
+    parameters    += " \\\n  -bin    %s" % MacBinDir
+    parameters    += " \\\n  -build  %s" % MacBuildDir
+  elif ModuleQt == 'Qt5Ana3':
+    parameters    += " \\\n  -qt5"
+    parameters    += " \\\n  -qmake  %s" % Qt5Ana3['qmake']
     MacPkgDir      = "./qt5.pkg.macos-%s-%s"        % (Platform, mode)
     MacBinDir      = "./qt5.bin.macos-%s-%s"        % (Platform, mode)
     MacBuildDir    = "./qt5.build.macos-%s-%s"      % (Platform, mode)
@@ -757,6 +776,10 @@ def DeployBinariesForBundle():
       deploytool = Qt5Brew['deploy']
       app_bundle = "klayout.app"
       options    = macdepQtOpt + verbose
+    elif ModuleQt == 'Qt5Ana3':
+      deploytool = Qt5Ana3['deploy']
+      app_bundle = "klayout.app"
+      options    = macdepQtOpt + verbose
 
     # Without the following, the plugin cocoa would not be found properly.
     shutil.copy2( sourceDir2 + "/qt.conf", targetDirM )
@@ -772,7 +795,8 @@ def DeployBinariesForBundle():
       os.chdir(ProjectDir)
       return 1
 
-    deploymentPython = True
+    deploymentPython = (ModulePython == 'Python37Brew')
+    #deploymentPython = True
     if deploymentPython and NonOSStdLang:
       from build4mac_util import WalkFrameworkPaths, PerformChanges
 

--- a/macbuild/build4mac_env.py
+++ b/macbuild/build4mac_env.py
@@ -10,6 +10,8 @@
 #
 # This file is imported by 'build4mac.py' script.
 #===============================================================================
+import os
+MyHome = os.environ['HOME']
 
 #-----------------------------------------------------
 # [0] Xcode's tools
@@ -21,7 +23,7 @@ XcodeToolChain = { 'nameID': '/usr/bin/install_name_tool -id ',
 #-----------------------------------------------------
 # [1] Qt
 #-----------------------------------------------------
-Qts = [ 'Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew' ]
+Qts = [ 'Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3' ]
 
 #-----------------------------------------------------
 # Whereabout of different components of Qt4
@@ -49,6 +51,12 @@ Qt5Brew = { 'qmake' : '/usr/local/opt/qt/bin/qmake',
             'deploy': '/usr/local/opt/qt/bin/macdeployqt'
           }
 
+# Qt5 bundled with anaconda3 installed under $HOME/anaconda3/
+# [Key Type Name] = 'Qt5Ana3'
+Qt5Ana3 = { 'qmake' : '%s/anaconda3/bin/qmake' % MyHome,
+            'deploy': '%s/anaconda3/bin/macdeployqt' % MyHome
+          }
+
 # Qt5 Custom (https://www1.qt.io/offline-installers/)
 
 #-----------------------------------------------------
@@ -56,6 +64,7 @@ Qt5Brew = { 'qmake' : '/usr/local/opt/qt/bin/qmake',
 #-----------------------------------------------------
 Rubies  = [ 'nil', 'RubyYosemite', 'RubyElCapitan', 'RubySierra', 'RubyHighSierra' ]
 Rubies += [ 'RubyMojave', 'Ruby24SrcBuild', 'Ruby24MacPorts', 'Ruby24Brew' ]
+Rubies += [ 'RubyAnaconda3' ]
 
 #-----------------------------------------------------
 # Whereabout of different components of Ruby
@@ -99,9 +108,9 @@ RubyMojave      = { 'exe': '/System/Library/Frameworks/Ruby.framework/Versions/2
 #   configured by:
 #       $ ./configure --prefix=$HOME/Ruby24/ --enable-shared --program-suffix=2.4
 # [Key Type Name] = 'Src24'
-Ruby24SrcBuild  = { 'exe': '$HOME/Ruby24/bin/ruby2.4',
-                    'inc': '$HOME/Ruby24/include/ruby-2.4.0',
-                    'lib': '$HOME/Ruby24/lib/libruby.2.4.dylib'
+Ruby24SrcBuild  = { 'exe': '%s/Ruby24/bin/ruby2.4' % MyHome,
+                    'inc': '%s/Ruby24/include/ruby-2.4.0'  % MyHome,
+                    'lib': '%s/Ruby24/lib/libruby.2.4.dylib'  % MyHome
                   }
 
 # Ruby 2.4 from MacPorts (https://www.macports.org/) *+*+*+ EXPERIMENTAL *+*+*+
@@ -118,6 +127,14 @@ Ruby25Brew  = { 'exe': '/usr/local/bin/ruby',
                 'lib': '/usr/local/lib/libruby.2.5.0.dylib'
               }
 
+# Ruby 2.5 bundled with anaconda3 installed under $HOME/anaconda3/ *+*+*+ EXPERIMENTAL *+*+*+
+# If the version is 2.4.x in your anaconda3, change the version strings accordingly.
+# [Key Type Name] = 'RubyAnaconda3'
+RubyAnaconda3 = { 'exe': '%s/anaconda3/bin/ruby' % MyHome,
+                  'inc': '%s/anaconda3/include/ruby-2.5.0' % MyHome,
+                  'lib': '%s/anaconda3/lib/libruby.2.5.1.dylib' % MyHome
+                }
+
 # Consolidated dictionary kit for Ruby
 RubyDictionary  = { 'nil'           : None,
                     'RubyYosemite'  : RubyYosemite,
@@ -127,7 +144,8 @@ RubyDictionary  = { 'nil'           : None,
                     'RubyMojave'    : RubyMojave,
                     'Ruby24SrcBuild': Ruby24SrcBuild,
                     'Ruby24MacPorts': Ruby24MacPorts,
-                    'Ruby25Brew'    : Ruby25Brew
+                    'Ruby25Brew'    : Ruby25Brew,
+                    'RubyAnaconda3' : RubyAnaconda3
                   }
 
 #-----------------------------------------------------
@@ -135,6 +153,7 @@ RubyDictionary  = { 'nil'           : None,
 #-----------------------------------------------------
 Pythons  = [ 'nil', 'PythonYosemite', 'PythonElCapitan', 'PythonSierra', 'PythonHighSierra' ]
 Pythons += [ 'PythonMojave', 'Anaconda27', 'Anaconda36', 'Python36MacPorts', 'Python37Brew' ]
+Pythons += [ 'PythonAnaconda3' ]
 
 #-----------------------------------------------------
 # Whereabout of different components of Python
@@ -180,9 +199,9 @@ PythonMojave    = { 'exe': '/System/Library/Frameworks/Python.framework/Versions
 #
 #   No additional modules are installed in the experiment.
 # [Key Type Name] = 'Ana27'
-Anaconda27      = { 'exe': '$HOME/anaconda2/envs/py27klayout/bin/python2.7' ,
-                    'inc': '$HOME/anaconda2/envs/py27klayout/include/python2.7',
-                    'lib': '$HOME/anaconda2/envs/py27klayout/lib/libpython2.7.dylib'
+Anaconda27      = { 'exe': '%s/anaconda2/envs/py27klayout/bin/python2.7' % MyHome,
+                    'inc': '%s/anaconda2/envs/py27klayout/include/python2.7' % MyHome,
+                    'lib': '%s/anaconda2/envs/py27klayout/lib/libpython2.7.dylib' % MyHome
                   }
 
 # Using anaconda2 (https://www.anaconda.com/download/#macos) 5.0.1: *+*+*+ EXPERIMENTAL *+*+*+
@@ -191,9 +210,9 @@ Anaconda27      = { 'exe': '$HOME/anaconda2/envs/py27klayout/bin/python2.7' ,
 #
 #   No additional modules are installed in the experiment.
 # [Key Type Name] = 'Ana36'
-Anaconda36      = { 'exe': '$HOME/anaconda2/envs/py36klayout/bin/python3.6' ,
-                    'inc': '$HOME/anaconda2/envs/py36klayout/include/python3.6m',
-                    'lib': '$HOME/anaconda2/envs/py36klayout/lib/libpython3.6m.dylib'
+Anaconda36      = { 'exe': '%s/anaconda2/envs/py36klayout/bin/python3.6' % MyHome,
+                    'inc': '%s/anaconda2/envs/py36klayout/include/python3.6m' % MyHome,
+                    'lib': '%s/anaconda2/envs/py36klayout/lib/libpython3.6m.dylib' % MyHome
                   }
 
 # Python 3.6 from MacPorts (https://www.macports.org/) *+*+*+ EXPERIMENTAL *+*+*+
@@ -210,6 +229,13 @@ Python37Brew= { 'exe': '/usr/local/opt/python/libexec/bin/python' ,
                 'lib': '/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/Python'
               }
 
+# Python 3.7 bundled with anaconda3 installed under $HOME/anaconda3/ *+*+*+ EXPERIMENTAL *+*+*+
+# [Key Type Name] = 'PythonAnaconda3'
+PythonAnaconda3= { 'exe': '%s/anaconda3/bin/python' % MyHome,
+                   'inc': '%s/anaconda3/include/python3.7m' % MyHome,
+                   'lib': '%s/anaconda3/lib/libpython3.7m.dylib' % MyHome
+                 }
+
 # Consolidated dictionary kit for Python
 PythonDictionary= { 'nil'             : None,
                     'PythonYosemite'  : PythonYosemite,
@@ -221,6 +247,7 @@ PythonDictionary= { 'nil'             : None,
                     'Anaconda36'      : Anaconda36,
                     'Python36MacPorts': Python36MacPorts,
                     'Python37Brew'    : Python37Brew,
+                    'PythonAnaconda3' : PythonAnaconda3
                   }
 
 #-----------------------------------------------------

--- a/macbuild/build4mac_env.py
+++ b/macbuild/build4mac_env.py
@@ -85,9 +85,9 @@ RubyElCapitan   = { 'exe': '/System/Library/Frameworks/Ruby.framework/Versions/2
 
 # Bundled with Sierra (10.12)
 # [Key Type Name] = 'Sys'
-RubySierra      = { 'exe': '/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby' ,
+RubySierra      = { 'exe': '/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby' ,
                     'inc': '/System/Library/Frameworks/Ruby.framework/Headers',
-                    'lib': '/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/libruby.dylib'
+                    'lib': '/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/libruby.dylib'
                   }
 
 # Bundled with High Sierra (10.13)

--- a/macbuild/build4mac_env.py
+++ b/macbuild/build4mac_env.py
@@ -23,16 +23,7 @@ XcodeToolChain = { 'nameID': '/usr/bin/install_name_tool -id ',
 #-----------------------------------------------------
 # [1] Qt
 #-----------------------------------------------------
-Qts = [ 'Qt4MacPorts', 'Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3' ]
-
-#-----------------------------------------------------
-# Whereabout of different components of Qt4
-#-----------------------------------------------------
-# Qt4 from MacPorts (https://www.macports.org/)
-# [Key Type Name] = 'Qt4MacPorts'
-Qt4MacPorts = { 'qmake' : '/opt/local/libexec/qt4/bin/qmake',
-                'deploy': '/opt/local/libexec/qt4/bin/macdeployqt'
-              }
+Qts = [ 'Qt5MacPorts', 'Qt5Brew', 'Qt5Ana3' ]
 
 #-----------------------------------------------------
 # Whereabout of different components of Qt5
@@ -42,7 +33,6 @@ Qt4MacPorts = { 'qmake' : '/opt/local/libexec/qt4/bin/qmake',
 Qt5MacPorts = { 'qmake' : '/opt/local/libexec/qt5/bin/qmake',
                 'deploy': '/opt/local/libexec/qt5/bin/macdeployqt'
               }
-
 
 # Qt5 from Homebrew (https://brew.sh/)
 # install with 'brew install qt'
@@ -63,7 +53,7 @@ Qt5Ana3 = { 'qmake' : '%s/anaconda3/bin/qmake' % MyHome,
 # [2] Ruby
 #-----------------------------------------------------
 Rubies  = [ 'nil', 'RubyYosemite', 'RubyElCapitan', 'RubySierra', 'RubyHighSierra' ]
-Rubies += [ 'RubyMojave', 'Ruby24SrcBuild', 'Ruby24MacPorts', 'Ruby24Brew' ]
+Rubies += [ 'RubyMojave', 'Ruby24MacPorts', 'Ruby25Brew' ]
 Rubies += [ 'RubyAnaconda3' ]
 
 #-----------------------------------------------------
@@ -104,15 +94,6 @@ RubyMojave      = { 'exe': '/System/Library/Frameworks/Ruby.framework/Versions/2
                     'lib': '/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/libruby.dylib'
                   }
 
-# Ruby 2.4 built from source code (https://github.com/ruby): *+*+*+ EXPERIMENTAL *+*+*+
-#   configured by:
-#       $ ./configure --prefix=$HOME/Ruby24/ --enable-shared --program-suffix=2.4
-# [Key Type Name] = 'Src24'
-Ruby24SrcBuild  = { 'exe': '%s/Ruby24/bin/ruby2.4' % MyHome,
-                    'inc': '%s/Ruby24/include/ruby-2.4.0'  % MyHome,
-                    'lib': '%s/Ruby24/lib/libruby.2.4.dylib'  % MyHome
-                  }
-
 # Ruby 2.4 from MacPorts (https://www.macports.org/) *+*+*+ EXPERIMENTAL *+*+*+
 # [Key Type Name] = 'MP24'
 Ruby24MacPorts  = { 'exe': '/opt/local/bin/ruby2.4',
@@ -142,7 +123,6 @@ RubyDictionary  = { 'nil'           : None,
                     'RubySierra'    : RubySierra,
                     'RubyHighSierra': RubyHighSierra,
                     'RubyMojave'    : RubyMojave,
-                    'Ruby24SrcBuild': Ruby24SrcBuild,
                     'Ruby24MacPorts': Ruby24MacPorts,
                     'Ruby25Brew'    : Ruby25Brew,
                     'RubyAnaconda3' : RubyAnaconda3
@@ -152,7 +132,7 @@ RubyDictionary  = { 'nil'           : None,
 # [3] Python
 #-----------------------------------------------------
 Pythons  = [ 'nil', 'PythonYosemite', 'PythonElCapitan', 'PythonSierra', 'PythonHighSierra' ]
-Pythons += [ 'PythonMojave', 'Anaconda27', 'Anaconda36', 'Python36MacPorts', 'Python37Brew' ]
+Pythons += [ 'PythonMojave', 'Python36MacPorts', 'Python37Brew' ]
 Pythons += [ 'PythonAnaconda3' ]
 
 #-----------------------------------------------------
@@ -193,28 +173,6 @@ PythonMojave    = { 'exe': '/System/Library/Frameworks/Python.framework/Versions
                     'lib': '/System/Library/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib'
                   }
 
-# Using anaconda2 (https://www.anaconda.com/download/#macos) 5.0.1: *+*+*+ EXPERIMENTAL *+*+*+
-#   If the path to your `conda` command is '$HOME/anaconda2/bin/conda'
-#   and your Python environment was prepared by: $ conda create -n py27klayout python=2.7
-#
-#   No additional modules are installed in the experiment.
-# [Key Type Name] = 'Ana27'
-Anaconda27      = { 'exe': '%s/anaconda2/envs/py27klayout/bin/python2.7' % MyHome,
-                    'inc': '%s/anaconda2/envs/py27klayout/include/python2.7' % MyHome,
-                    'lib': '%s/anaconda2/envs/py27klayout/lib/libpython2.7.dylib' % MyHome
-                  }
-
-# Using anaconda2 (https://www.anaconda.com/download/#macos) 5.0.1: *+*+*+ EXPERIMENTAL *+*+*+
-#   If the path to your `conda` command is '$HOME/anaconda2/bin/conda'
-#   and your Python environment was prepared by: $ conda create -n py36klayout python=3.6
-#
-#   No additional modules are installed in the experiment.
-# [Key Type Name] = 'Ana36'
-Anaconda36      = { 'exe': '%s/anaconda2/envs/py36klayout/bin/python3.6' % MyHome,
-                    'inc': '%s/anaconda2/envs/py36klayout/include/python3.6m' % MyHome,
-                    'lib': '%s/anaconda2/envs/py36klayout/lib/libpython3.6m.dylib' % MyHome
-                  }
-
 # Python 3.6 from MacPorts (https://www.macports.org/) *+*+*+ EXPERIMENTAL *+*+*+
 # [Key Type Name] = 'MP36'
 Python36MacPorts= { 'exe': '/opt/local/Library/Frameworks/Python.framework/Versions/3.6/bin/python3.6m' ,
@@ -224,17 +182,17 @@ Python36MacPorts= { 'exe': '/opt/local/Library/Frameworks/Python.framework/Versi
 
 # Python 3.7 from Brew *+*+*+ EXPERIMENTAL *+*+*+
 # [Key Type Name] = 'pybrew'
-Python37Brew= { 'exe': '/usr/local/opt/python/libexec/bin/python' ,
-                'inc': '/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/Headers',
-                'lib': '/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/Python'
-              }
+Python37Brew    = { 'exe': '/usr/local/opt/python/libexec/bin/python' ,
+                    'inc': '/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/Headers',
+                    'lib': '/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/Python'
+                  }
 
 # Python 3.7 bundled with anaconda3 installed under $HOME/anaconda3/ *+*+*+ EXPERIMENTAL *+*+*+
 # [Key Type Name] = 'PythonAnaconda3'
-PythonAnaconda3= { 'exe': '%s/anaconda3/bin/python' % MyHome,
-                   'inc': '%s/anaconda3/include/python3.7m' % MyHome,
-                   'lib': '%s/anaconda3/lib/libpython3.7m.dylib' % MyHome
-                 }
+PythonAnaconda3 = { 'exe': '%s/anaconda3/bin/python' % MyHome,
+                    'inc': '%s/anaconda3/include/python3.7m' % MyHome,
+                    'lib': '%s/anaconda3/lib/libpython3.7m.dylib' % MyHome
+                  }
 
 # Consolidated dictionary kit for Python
 PythonDictionary= { 'nil'             : None,
@@ -243,8 +201,6 @@ PythonDictionary= { 'nil'             : None,
                     'PythonSierra'    : PythonSierra,
                     'PythonHighSierra': PythonHighSierra,
                     'PythonMojave'    : PythonMojave,
-                    'Anaconda27'      : Anaconda27,
-                    'Anaconda36'      : Anaconda36,
                     'Python36MacPorts': Python36MacPorts,
                     'Python37Brew'    : Python37Brew,
                     'PythonAnaconda3' : PythonAnaconda3


### PR DESCRIPTION
Update of the build-environment for macOS for the next maintenance release.

```
Drop: unused settings
  - Qt    : Qt4MacPorts
  - Ruby  : Ruby24SrcBuild
  - Python: Anaconda27
  - Python: Anaconda36

Add:
  + Qt    : Qt5Ana3
  + Ruby  : RubyAnaconda3
  + Python: PythonAnaconda3

Update:
  * Sierra's Ruby is now Ruby2.3
  * "ReadMe.md" accordingly

```