### PR TITLE
Follow-up on #353 (sessions paths relative to session file)

### DIFF
--- a/src/ant/ant/antObject.cc
+++ b/src/ant/ant/antObject.cc
@@ -341,7 +341,7 @@ Object::class_name () const
 }
 
 void 
-Object::from_string (const char *s)
+Object::from_string (const char *s, const char * /*base_dir*/)
 {
   tl::Extractor ex (s);
   while (! ex.at_end ()) {

--- a/src/ant/ant/antObject.h
+++ b/src/ant/ant/antObject.h
@@ -678,7 +678,7 @@ public:
    *  This method needs to be implemented mainly if the object is to be created from the
    *  generic factory.
    */
-  virtual void from_string (const char *);
+  virtual void from_string (const char *s, const char *base_dir = 0);
 
   /**
    *  @brief Converts the object to a string

--- a/src/db/db/dbUserObject.h
+++ b/src/db/db/dbUserObject.h
@@ -147,7 +147,7 @@ public:
    *  This method needs to be implemented mainly if the object is to be created from the
    *  generic factory.
    */
-  virtual void from_string (const char *) { }
+  virtual void from_string (const char * /*str*/, const char * /*base_path*/) { }
 
   /**
    *  @brief Convert to a string
@@ -447,14 +447,14 @@ public:
    *
    *  If the class name is not registered, no object is created and 0 is returned.
    */
-  static user_object_base<C> *create (const char *class_name, const char *string)
+  static user_object_base<C> *create (const char *class_name, const char *string, const char *base_path)
   {
     tl::Registrar< user_object_factory_base<C> > *factory = tl::Registrar< user_object_factory_base<C> >::get_instance ();
     if (factory != 0) {
       for (typename tl::Registrar< user_object_factory_base<C> >::iterator i = factory->begin (); i != factory->end (); ++i) {
         if (strcmp (class_name, i->class_name ()) == 0) {
           user_object_base<C> *obj = i->create ();
-          obj->from_string (string);
+          obj->from_string (string, base_path);
           return obj;
         }
       }

--- a/src/img/img/imgObject.cc
+++ b/src/img/img/imgObject.cc
@@ -28,6 +28,8 @@
 #include "layPlugin.h"
 #include "layConverters.h"
 #include "dbPolygonTools.h"
+#include "tlFileUtils.h"
+#include "tlUri.h"
 
 #include <cmath>
 #include <cstring>
@@ -1205,7 +1207,7 @@ Object::transform (const db::DFTrans &t)
 }
 
 void 
-Object::from_string (const char *str)
+Object::from_string (const char *str, const char *base_dir)
 {
   bool en = m_updates_enabled;
   m_updates_enabled = false;
@@ -1306,6 +1308,12 @@ Object::from_string (const char *str)
       } else if (ex.test ("file=")) {
 
         ex.read_word_or_quoted (m_filename);
+
+        tl::URI fp_uri (m_filename);
+        if (base_dir && ! tl::is_absolute (fp_uri.path ())) {
+          m_filename = tl::URI (base_dir).resolved (fp_uri).to_string ();
+        }
+
         read_file ();
 
       } else if (ex.test ("byte_data=")) {
@@ -1427,7 +1435,7 @@ Object::load_data (const std::string &filename, bool adjust_min_max)
   m_min_value_set = ! adjust_min_max;
   m_max_value_set = ! adjust_min_max;
 
-  m_filename = filename;
+  m_filename = tl::absolute_file_path (filename);
 
   read_file ();
 

--- a/src/img/img/imgObject.h
+++ b/src/img/img/imgObject.h
@@ -927,7 +927,7 @@ public:
    *  This method needs to be implemented mainly if the object is to be created from the
    *  generic factory.
    */
-  virtual void from_string (const char *);
+  virtual void from_string (const char *str, const char *base_dir = 0);
 
   /**
    *  @brief Convert to a string

--- a/src/lay/lay/laySession.cc
+++ b/src/lay/lay/laySession.cc
@@ -264,7 +264,7 @@ Session::restore (lay::MainWindow &mw)
     lay::AnnotationShapes &as = view->annotation_shapes ();
     as.reserve (vd.annotation_shapes.annotation_shapes.size ());
     for (std::vector<SessionAnnotationDescriptor>::const_iterator ad = vd.annotation_shapes.annotation_shapes.begin (); ad != vd.annotation_shapes.annotation_shapes.end (); ++ad) {
-      db::DUserObjectBase *obj = db::DUserObjectFactory::create (ad->class_name.c_str (), ad->value_string.c_str ());
+      db::DUserObjectBase *obj = db::DUserObjectFactory::create (ad->class_name.c_str (), ad->value_string.c_str (), ! m_base_dir.empty () ? m_base_dir.c_str () : 0);
       as.insert (db::DUserObject (obj));
     }
 

--- a/testdata/sessions/test_with_relative_paths.lys
+++ b/testdata/sessions/test_with_relative_paths.lys
@@ -386,7 +386,7 @@
    </annotation>
    <annotation>
     <class>img::Object</class>
-    <value>color:matrix=(1,0,0) (0,1,0) (0,0,1);min_value=0;max_value=255;is_visible=true;z_position=0;brightness=0;contrast=0;gamma=1;red_gain=1;green_gain=1;blue_gain=1;color_mapping=[0,'#000000';1,'#ffffff';];file='../testdata/sessions/test.png'</value>
+    <value>color:matrix=(1,0,0) (0,1,0) (0,0,1);min_value=0;max_value=255;is_visible=true;z_position=0;brightness=0;contrast=0;gamma=1;red_gain=1;green_gain=1;blue_gain=1;color_mapping=[0,'#000000';1,'#ffffff';];file='test.png'</value>
    </annotation>
   </annotations>
  </view>


### PR DESCRIPTION
Consistent behavior for file paths for images too.
Plus: image paths are not kept as absolute paths
inside the session.
This makes regeneration of images stable.