### PR TITLE
Fixed #376 - PCell callbacks invoked on value change

### DIFF
--- a/src/edt/edt/edtPCellParametersPage.cc
+++ b/src/edt/edt/edtPCellParametersPage.cc
@@ -284,6 +284,8 @@ PCellParametersPage::setup (const db::Layout *layout, lay::LayoutView *view, int
           ul->setText (tl::to_qstring (p->get_unit ()));
 
           inner_grid->addWidget (f, row, 1);
+
+          connect (le, SIGNAL (editingFinished ()), this, SLOT (activated ()));
         }
         break;
 
@@ -295,6 +297,8 @@ PCellParametersPage::setup (const db::Layout *layout, lay::LayoutView *view, int
           le->setEnabled (! p->is_readonly ());
           m_widgets.push_back (le);
           inner_grid->addWidget (le, row, 1);
+
+          connect (le, SIGNAL (editingFinished ()), this, SLOT (activated ()));
         }
         break;
 
@@ -315,6 +319,8 @@ PCellParametersPage::setup (const db::Layout *layout, lay::LayoutView *view, int
           cbx->setEnabled (! p->is_readonly ());
           m_widgets.push_back (cbx);
           inner_grid->addWidget (cbx, row, 1);
+
+          connect (cbx, SIGNAL (stateChanged (int)), this, SLOT (activated ()));
         }
         break;
 
@@ -336,7 +342,7 @@ PCellParametersPage::setup (const db::Layout *layout, lay::LayoutView *view, int
         }
       }
 
-      connect (cb, SIGNAL (activated (int)), this, SLOT (activated (int)));
+      connect (cb, SIGNAL (activated (int)), this, SLOT (activated ()));
       cb->setEnabled (! p->is_readonly ());
       cb->setMinimumContentsLength (30);
       cb->setSizeAdjustPolicy (QComboBox::AdjustToMinimumContentsLengthWithIcon);
@@ -381,7 +387,7 @@ PCellParametersPage::set_state (const State &s)
 }
 
 void  
-PCellParametersPage::activated (int)
+PCellParametersPage::activated ()
 {
   //  does a coerce and update
   get_parameters ();

--- a/src/edt/edt/edtPCellParametersPage.h
+++ b/src/edt/edt/edtPCellParametersPage.h
@@ -111,7 +111,7 @@ public:
   void set_parameters (const  std::vector<tl::Variant> &values);
 
 public slots:
-  void activated (int);
+  void activated ();
   void clicked ();
   
 private:


### PR DESCRIPTION
Callback invoked when an item loses its focus, or its status changed.