### PR TITLE
Implemented issue-387 (python version in grain.xml)

### DIFF
--- a/src/lay/lay/SaltGrainPropertiesDialog.ui
+++ b/src/lay/lay/SaltGrainPropertiesDialog.ui
@@ -279,7 +279,7 @@
          </font>
         </property>
         <property name="text">
-         <string>API version</string>
+         <string>API features</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -842,7 +842,7 @@
          </font>
         </property>
         <property name="text">
-         <string>(API version required - i.e. &quot;0.25&quot;)</string>
+         <string>(API version and features - e.g. &quot;0.26; ruby 2.0&quot;)</string>
         </property>
        </widget>
       </item>

--- a/src/lay/lay/laySaltGrain.cc
+++ b/src/lay/lay/laySaltGrain.cc
@@ -313,7 +313,7 @@ SaltGrain::valid_api_version (const std::string &v)
   while (! ex.at_end ()) {
 
     std::string feature;
-    ex.try_read_word (feature);
+    ex.try_read_name (feature);
 
     bool first = true;
     while (! ex.at_end () && ! ex.test (";")) {

--- a/src/lay/lay/laySaltGrain.cc
+++ b/src/lay/lay/laySaltGrain.cc
@@ -306,6 +306,33 @@ SaltGrain::valid_name (const std::string &n)
 }
 
 bool
+SaltGrain::valid_api_version (const std::string &v)
+{
+  tl::Extractor ex (v.c_str ());
+
+  while (! ex.at_end ()) {
+
+    std::string feature;
+    ex.try_read_word (feature);
+
+    bool first = true;
+    while (! ex.at_end () && ! ex.test (";")) {
+      int n = 0;
+      if (! first && ! ex.test (".")) {
+        return false;
+      }
+      if (! ex.try_read (n)) {
+        return false;
+      }
+      first = false;
+    }
+
+  }
+
+  return true;
+}
+
+bool
 SaltGrain::valid_version (const std::string &v)
 {
   tl::Extractor ex (v.c_str ());

--- a/src/lay/lay/laySaltGrain.h
+++ b/src/lay/lay/laySaltGrain.h
@@ -198,6 +198,11 @@ public:
    *  The API version is the KLayout version required to run the grain's macros.
    *  A version string is of the form "x.y..." where x, y and other version
    *  components are integer numbers.
+   *
+   *  The version string can also list other features such as ruby version etc.
+   *  The components are separated with a semicolon.
+   *  For example, "0.26; ruby; python 3.0" means: requires KLayout API 0.26,
+   *  ruby (any version) any python (>= 3.0).
    */
   const std::string &api_version () const
   {
@@ -432,6 +437,11 @@ public:
    *  @brief Gets a value indicating whether the given version string is a valid version
    */
   static bool valid_version (const std::string &v);
+
+  /**
+   *  @brief Gets a value indicating whether the given version string is a valid API version string
+   */
+  static bool valid_api_version (const std::string &v);
 
   /**
    *  @brief Checks whether the given string is a valid name

--- a/src/lay/lay/laySaltGrainDetailsTextWidget.cc
+++ b/src/lay/lay/laySaltGrainDetailsTextWidget.cc
@@ -252,7 +252,7 @@ SaltGrainDetailsTextWidget::details_text ()
 
   stream << "<p>";
   if (! g->api_version ().empty ()) {
-    stream << "<b>" << QObject::tr ("API version") << ":</b> " << tl::to_qstring (tl::escaped_to_html (g->api_version ())) << " ";
+    stream << "<b>" << QObject::tr ("API version and features") << ":</b> " << tl::to_qstring (tl::escaped_to_html (g->api_version ())) << " ";
   }
   stream << "</p>";
 

--- a/src/lay/lay/laySaltGrainPropertiesDialog.cc
+++ b/src/lay/lay/laySaltGrainPropertiesDialog.cc
@@ -529,8 +529,8 @@ SaltGrainPropertiesDialog::accept ()
 
   //  API version
   api_version_alert->clear ();
-  if (! m_grain.api_version ().empty () && ! SaltGrain::valid_version (m_grain.api_version ())) {
-    api_version_alert->error () << tr ("'%1' is not a valid API version string. An API version string needs to be numeric (like '0.25'').").arg (tl::to_qstring (m_grain.api_version ()));
+  if (! m_grain.api_version ().empty () && ! SaltGrain::valid_api_version (m_grain.api_version ())) {
+    api_version_alert->error () << tr ("'%1' is not a valid API version string. An API version string needs to be a semicolon-separated list of features with optional numeric versions (like '0.26' or 'ruby 2.0; python').").arg (tl::to_qstring (m_grain.api_version ()));
   }
 
   //  doc URL

--- a/src/lay/lay/laySaltManagerDialog.cc
+++ b/src/lay/lay/laySaltManagerDialog.cc
@@ -162,7 +162,7 @@ SaltAPIVersionCheck::check (const std::string &api_version)
   while (! ex.at_end ()) {
 
     std::string fname;
-    ex.try_read_word (fname);
+    ex.try_read_name (fname);
 
     std::string v;
     while (! ex.at_end () && ! ex.test (";")) {

--- a/src/lay/lay/laySaltManagerDialog.cc
+++ b/src/lay/lay/laySaltManagerDialog.cc
@@ -246,15 +246,34 @@ SaltAPIVersionCheck::populate_features ()
   m_features.push_back (APIFeature (std::string (), lay::Version::version (), "KLayout API"));
 
   if (rba::RubyInterpreter::instance () && rba::RubyInterpreter::instance ()->available ()) {
-    m_features.push_back (APIFeature ("ruby", rba::RubyInterpreter::instance ()->version (), "Ruby"));
+    std::string v = rba::RubyInterpreter::instance ()->version ();
+    m_features.push_back (APIFeature ("ruby", v, "Ruby"));
+    if (SaltGrain::compare_versions (v, "2") < 0) {
+      m_features.push_back (APIFeature ("ruby1", v, "Ruby 1"));
+    } else if (SaltGrain::compare_versions (v, "3") < 0) {
+      m_features.push_back (APIFeature ("ruby2", v, "Ruby 2"));
+    }
   }
 
   if (pya::PythonInterpreter::instance () && pya::PythonInterpreter::instance ()->available ()) {
-    m_features.push_back (APIFeature ("python", pya::PythonInterpreter::instance ()->version (), "Python"));
+    std::string v = pya::PythonInterpreter::instance ()->version ();
+    m_features.push_back (APIFeature ("python", v, "Python"));
+    if (SaltGrain::compare_versions (v, "3") < 0) {
+      m_features.push_back (APIFeature ("python2", v, "Python 2"));
+    } else if (SaltGrain::compare_versions (v, "4") < 0) {
+      m_features.push_back (APIFeature ("python3", v, "Python 3"));
+    }
   }
 
 #if defined(HAVE_QTBINDINGS)
   m_features.push_back (APIFeature ("qt_binding", std::string (), "Qt Binding for RBA or PYA"));
+#endif
+#if defined(HAVE_QT)
+#  if QT_VERSION >= 0x040000 && QT_VERSION < 0x050000
+  m_features.push_back (APIFeature ("qt4", std::string (), "Qt 4"));
+#  elif QT_VERSION >= 0x050000 && QT_VERSION < 0x060000
+  m_features.push_back (APIFeature ("qt5", std::string (), "Qt 5"));
+#  endif
 #endif
 
 #if defined(HAVE_64BIT_COORD)

--- a/src/tl/tl/tlString.cc
+++ b/src/tl/tl/tlString.cc
@@ -1235,10 +1235,20 @@ Extractor::try_read_word (std::string &string, const char *non_term)
   }
 
   string.clear ();
+
+  //  first character must not be a digit
+  if (*m_cp && (safe_isalpha (*m_cp) || strchr (non_term, *m_cp) != NULL)) {
+    string += *m_cp;
+    ++m_cp;
+  } else {
+    return false;
+  }
+
   while (*m_cp && (safe_isalnum (*m_cp) || strchr (non_term, *m_cp) != NULL)) {
     string += *m_cp;
     ++m_cp;
   }
+
   return ! string.empty ();
 }
 

--- a/src/tl/tl/tlString.cc
+++ b/src/tl/tl/tlString.cc
@@ -1024,6 +1024,15 @@ Extractor::read_word (std::string &value, const char *non_term)
 }
 
 Extractor &
+Extractor::read_name (std::string &value, const char *non_term)
+{
+  if (! try_read_name (value, non_term)) {
+    error (tl::to_string (tr ("Expected a name string")));
+  }
+  return *this;
+}
+
+Extractor &
 Extractor::read_word_or_quoted (std::string &value, const char *non_term)
 {
   if (! try_read_word (value, non_term) && ! try_read_quoted (value)) {
@@ -1228,7 +1237,7 @@ Extractor::try_read (bool &value)
 }
 
 bool
-Extractor::try_read_word (std::string &string, const char *non_term)
+Extractor::try_read_name (std::string &string, const char *non_term)
 {
   if (! *skip ()) {
     return false;
@@ -1243,6 +1252,23 @@ Extractor::try_read_word (std::string &string, const char *non_term)
   } else {
     return false;
   }
+
+  while (*m_cp && (safe_isalnum (*m_cp) || strchr (non_term, *m_cp) != NULL)) {
+    string += *m_cp;
+    ++m_cp;
+  }
+
+  return ! string.empty ();
+}
+
+bool
+Extractor::try_read_word (std::string &string, const char *non_term)
+{
+  if (! *skip ()) {
+    return false;
+  }
+
+  string.clear ();
 
   while (*m_cp && (safe_isalnum (*m_cp) || strchr (non_term, *m_cp) != NULL)) {
     string += *m_cp;

--- a/src/tl/tl/tlString.h
+++ b/src/tl/tl/tlString.h
@@ -529,6 +529,13 @@ public:
   Extractor &read (std::string &value, const char *term = "");
 
   /**
+   *  @brief Read a name string
+   *
+   *  Name strings are like words, but for the first character digits are not allowed.
+   */
+  Extractor &read_name (std::string &value, const char *non_term = "_.$");
+
+  /**
    *  @brief Read a string consisting of "word" characters
    *
    *  Beside letters and digits the characters given in the "non_term" array are
@@ -609,6 +616,13 @@ public:
    *  or the input ends, the reader stops reading.
    */
   bool try_read (std::string &string, const char *term = "");
+
+  /**
+   *  @brief Try to read a name string
+   *
+   *  Name strings are like words, but for the first character digits are not allowed.
+   */
+  bool try_read_name (std::string &value, const char *non_term = "_.$");
 
   /**
    *  @brief Try to read a string consisting of "word" characters

--- a/src/tl/unit_tests/tlString.cc
+++ b/src/tl/unit_tests/tlString.cc
@@ -314,6 +314,9 @@ TEST(8)
   EXPECT_EQ (s, "a_word");
   EXPECT_EQ (x.test ("!"), true);
 
+  x = Extractor ("0_word!");
+  EXPECT_EQ (x.try_read_word (s), false);
+
   x = Extractor ("a_word!");
   EXPECT_EQ (x.try_read_word (s), true);
   EXPECT_EQ (s, "a_word");

--- a/src/tl/unit_tests/tlString.cc
+++ b/src/tl/unit_tests/tlString.cc
@@ -312,13 +312,26 @@ TEST(8)
   x = Extractor ("a_word!");
   x.read_word (s);
   EXPECT_EQ (s, "a_word");
+
+  x = Extractor ("a_word!");
+  s.clear ();
+  x.read_name (s);
+  EXPECT_EQ (s, "a_word");
   EXPECT_EQ (x.test ("!"), true);
 
   x = Extractor ("0_word!");
-  EXPECT_EQ (x.try_read_word (s), false);
+  EXPECT_EQ (x.try_read_word (s), true);
+
+  x = Extractor ("0_word!");
+  EXPECT_EQ (x.try_read_name (s), false);
 
   x = Extractor ("a_word!");
   EXPECT_EQ (x.try_read_word (s), true);
+  EXPECT_EQ (s, "a_word");
+  EXPECT_EQ (x.test ("!"), true);
+
+  x = Extractor ("a_word!");
+  EXPECT_EQ (x.try_read_name (s), true);
   EXPECT_EQ (s, "a_word");
   EXPECT_EQ (x.test ("!"), true);
 
@@ -328,7 +341,17 @@ TEST(8)
   EXPECT_EQ (x.at_end (), true);
 
   x = Extractor ("a_word!");
+  x.read_name (s, "_!");
+  EXPECT_EQ (s, "a_word!");
+  EXPECT_EQ (x.at_end (), true);
+
+  x = Extractor ("a_word!");
   EXPECT_EQ (x.try_read_word (s, "_!"), true);
+  EXPECT_EQ (s, "a_word!");
+  EXPECT_EQ (x.at_end (), true);
+
+  x = Extractor ("a_word!");
+  EXPECT_EQ (x.try_read_name (s, "_!"), true);
   EXPECT_EQ (s, "a_word!");
   EXPECT_EQ (x.at_end (), true);
 

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,7 @@
 # This script is sourced to define the main version parameters
 
 # The main version
-KLAYOUT_VERSION="0.26"
+KLAYOUT_VERSION="0.26.1"
 
 # The build date
 KLAYOUT_VERSION_DATE=$(date "+%Y-%m-%d")


### PR DESCRIPTION
The solution is to extend the api-version field.

"0.26.1" is KLayout API >= 0.26.1
"ruby" means: Ruby required
"python 2.6.0" means: Python required with at least 2.6.0
"0.26.1; ruby; python 2.6.0" means: all of this together

In addition, the version has been set to 0.26.1 now.