### PR TITLE
Implemented #426 (feature request: group techs)

### DIFF
--- a/src/db/db/dbTechnology.cc
+++ b/src/db/db/dbTechnology.cc
@@ -253,13 +253,13 @@ Technologies::technology_by_name (const std::string &name)
 //  Technology implementation
 
 Technology::Technology ()
-  : m_name (), m_description (), m_dbu (0.001), m_persisted (true), m_readonly (false)
+  : m_name (), m_description (), m_group (), m_dbu (0.001), m_persisted (true), m_readonly (false)
 {
   init ();
 }
 
-Technology::Technology (const std::string &name, const std::string &description)
-  : m_name (name), m_description (description), m_dbu (0.001), m_persisted (true), m_readonly (false)
+Technology::Technology (const std::string &name, const std::string &description, const std::string &group)
+  : m_name (name), m_description (description), m_group (group), m_dbu (0.001), m_persisted (true), m_readonly (false)
 {
   init ();
 }
@@ -284,7 +284,7 @@ Technology::~Technology ()
 
 Technology::Technology (const Technology &d)
   : tl::Object (),
-    m_name (d.m_name), m_description (d.m_description), m_grain_name (d.m_grain_name), m_dbu (d.m_dbu),
+    m_name (d.m_name), m_description (d.m_description), m_group (d.m_group), m_grain_name (d.m_grain_name), m_dbu (d.m_dbu),
     m_explicit_base_path (d.m_explicit_base_path), m_default_base_path (d.m_default_base_path),
     m_load_layout_options (d.m_load_layout_options),
     m_save_layout_options (d.m_save_layout_options),
@@ -302,6 +302,7 @@ Technology &Technology::operator= (const Technology &d)
 
     m_name = d.m_name;
     m_description = d.m_description;
+    m_group = d.m_group;
     m_grain_name = d.m_grain_name;
     m_dbu = d.m_dbu;
     m_default_base_path = d.m_default_base_path;
@@ -330,12 +331,29 @@ Technology &Technology::operator= (const Technology &d)
   return *this;
 }
 
+std::string
+Technology::get_display_string () const
+{
+  std::string d = name ();
+  if (! d.empty () && ! description ().empty ()) {
+    d += " - ";
+  }
+  d += description ();
+  if (! group ().empty ()) {
+    d += " [";
+    d += group ();
+    d += "]";
+  }
+  return d;
+}
+
 tl::XMLElementList 
 Technology::xml_elements () 
 {
   tl::XMLElementList elements = 
          tl::make_member (&Technology::name, &Technology::set_name, "name") + 
          tl::make_member (&Technology::description, &Technology::set_description, "description") + 
+         tl::make_member (&Technology::group, &Technology::set_group, "group") +
          tl::make_member (&Technology::dbu, &Technology::set_dbu, "dbu") +
          tl::make_member (&Technology::explicit_base_path, &Technology::set_explicit_base_path, "base-path") +
          tl::make_member (&Technology::default_base_path, &Technology::set_default_base_path, "original-base-path") +

--- a/src/db/db/dbTechnology.h
+++ b/src/db/db/dbTechnology.h
@@ -265,7 +265,7 @@ public:
   /**
    *  @brief The constructor 
    */
-  Technology (const std::string &name, const std::string &description);
+  Technology (const std::string &name, const std::string &description, const std::string &group = std::string ());
 
   /**
    *  @brief The copy constructor 
@@ -413,6 +413,33 @@ public:
       technology_changed ();
     }
   }
+
+  /**
+   *  @brief Gets the technology group
+   */
+  const std::string &group () const
+  {
+    return m_group;
+  }
+
+  /**
+   *  @brief Sets the technology group
+   */
+  void set_group (const std::string &d)
+  {
+    if (m_group != d) {
+      m_group = d;
+      technology_changed ();
+    }
+  }
+
+  /**
+   *  @brief Gets the display string
+   *
+   *  The display string is used to indicate the technology through a
+   *  descriptive string
+   */
+  std::string get_display_string () const;
 
   /**
    *  @brief Gets the default database unit
@@ -613,7 +640,7 @@ public:
   tl::event<Technology *> technology_changed_with_sender_event;
 
 private:
-  std::string m_name, m_description;
+  std::string m_name, m_description, m_group;
   std::string m_grain_name;
   double m_dbu;
   std::string m_explicit_base_path, m_default_base_path;

--- a/src/db/db/gsiDeclDbTechnologies.cc
+++ b/src/db/db/gsiDeclDbTechnologies.cc
@@ -191,6 +191,20 @@ gsi::Class<db::Technology> technology_decl ("db", "Technology",
   gsi::method ("description=", &db::Technology::set_description, gsi::arg ("description"),
     "@brief Sets the description\n"
   ) +
+  gsi::method ("group", &db::Technology::group,
+    "@brief Gets the technology group\n"
+    "\n"
+    "The technology group is used to group certain technologies together in the technology selection menu. "
+    "Technologies with the same group are put under a submenu with that group title.\n"
+    "\n"
+    "The 'group' attribute has been introduced in version 0.26.2.\n"
+  ) +
+  gsi::method ("group=", &db::Technology::set_group, gsi::arg ("group"),
+    "@brief Sets the technology group\n"
+    "See \\group for details about this attribute.\n"
+    "\n"
+    "The 'group' attribute has been introduced in version 0.26.2.\n"
+  ) +
   gsi::method ("dbu", &db::Technology::dbu,
     "@brief Gets the default database unit\n"
     "\n"

--- a/src/lay/lay/TechBaseEditorPage.ui
+++ b/src/lay/lay/TechBaseEditorPage.ui
@@ -14,37 +14,24 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="3">
-    <widget class="QToolButton" name="browse_pb">
-     <property name="text">
-      <string>...</string>
+   <item row="11" column="0" colspan="4">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="desc_le"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Name</string>
+   <item row="6" column="0" colspan="4">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="name_le">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="3">
-    <widget class="QLabel" name="label_3">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>The base path is used to locate auxiliary files if those are specified with a relative path. If none is specified, the default path is used. The default path is the one from which a technology was imported.</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+      <string>Base path</string>
      </property>
     </widget>
    </item>
@@ -55,23 +42,38 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="4">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Name</string>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
+    </widget>
+   </item>
+   <item row="7" column="0" rowspan="2">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Database
+unit</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2" colspan="2">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>5</height>
+       <width>40</width>
+       <height>20</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item row="9" column="1" colspan="3">
+   <item row="10" column="1" colspan="3">
     <widget class="QGroupBox" name="lyp_grp">
      <property name="title">
       <string>Load layer properties file</string>
@@ -125,14 +127,10 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Base path</string>
-     </property>
-    </widget>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="desc_le"/>
    </item>
-   <item row="9" column="0">
+   <item row="10" column="0">
     <widget class="QLabel" name="label_10">
      <property name="text">
       <string>Layer
@@ -143,28 +141,10 @@ properties</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" rowspan="2">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Database
-unit</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="4">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="4">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="name_le">
+     <property name="enabled">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -175,14 +155,28 @@ unit</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1" colspan="3">
-    <widget class="QLabel" name="label_8">
+   <item row="4" column="3">
+    <widget class="QToolButton" name="browse_pb">
      <property name="text">
-      <string>The default database unit is used as database unit for freshly created layouts</string>
+      <string>...</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1" colspan="3">
+   <item row="3" column="0" colspan="4">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1" rowspan="2" colspan="3">
+    <widget class="QListWidget" name="libs_lw">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="3">
     <widget class="QFrame" name="frame">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
@@ -223,39 +217,30 @@ unit</string>
      </layout>
     </widget>
    </item>
-   <item row="1" column="2" colspan="2">
-    <spacer>
+   <item row="8" column="1" colspan="3">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>The default database unit is used as database unit for freshly created layouts</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="4">
+    <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
-       <height>20</height>
+       <width>20</width>
+       <height>5</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QLineEdit" name="base_path_le"/>
-   </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="libs_lbl">
-     <property name="text">
-      <string>Technology
-specific
-libraries</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="4">
-    <widget class="Line" name="line_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0">
+   <item row="13" column="0">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -268,10 +253,42 @@ libraries</string>
      </property>
     </spacer>
    </item>
-   <item row="11" column="1" rowspan="2" colspan="3">
-    <widget class="QListWidget" name="libs_lw">
-     <property name="selectionMode">
-      <enum>QAbstractItemView::NoSelection</enum>
+   <item row="5" column="1" colspan="3">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>The base path is used to locate auxiliary files if those are specified with a relative path. If none is specified, the default path is used. The default path is the one from which a technology was imported.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QLineEdit" name="base_path_le"/>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="libs_lbl">
+     <property name="text">
+      <string>Technology
+specific
+libraries</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="group_le"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>Group</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2" colspan="2">
+    <widget class="QLabel" name="label_12">
+     <property name="text">
+      <string>(Used for creating tech groups)</string>
      </property>
     </widget>
    </item>

--- a/src/lay/lay/layTechSetupDialog.cc
+++ b/src/lay/lay/layTechSetupDialog.cc
@@ -80,6 +80,11 @@ title_for_technology (const db::Technology *t)
       d += t->description ();
     }
   }
+  if (! t->group ().empty ()) {
+    d += " [";
+    d += t->group ();
+    d += "]";
+  }
   return d;
 }
 
@@ -106,6 +111,7 @@ TechBaseEditorPage::setup ()
 {
   mp_ui->name_le->setText (tl::to_qstring (tech ()->name ()));
   mp_ui->desc_le->setText (tl::to_qstring (tech ()->description ()));
+  mp_ui->group_le->setText (tl::to_qstring (tech ()->group ()));
   mp_ui->dbu_le->setText (tl::to_qstring (tl::to_string (tech ()->dbu ())));
   mp_ui->desc_le->setEnabled (! tech ()->name ().empty ());
   mp_ui->base_path_le->setText (tl::to_qstring (tech ()->explicit_base_path ()));
@@ -155,6 +161,7 @@ void
 TechBaseEditorPage::commit ()
 {
   tech ()->set_description (tl::to_string (mp_ui->desc_le->text ()));
+  tech ()->set_group (tl::to_string (mp_ui->group_le->text ()));
   tech ()->set_explicit_base_path (tl::to_string (mp_ui->base_path_le->text ()));
 
   double d = 0.001;
@@ -741,11 +748,7 @@ BEGIN_PROTECTED
     tl_assert (t != 0);
   }
 
-  std::string d = t->name ();
-  if (! d.empty () && ! t->description ().empty ()) {
-    d += " - ";
-  }
-  d += t->description ();
+  std::string d = t->get_display_string ();
 
   bool ok = false;
   QString tn = QInputDialog::getText (this, QObject::tr ("Add Technology"), 

--- a/src/laybasic/laybasic/layDialogs.cc
+++ b/src/laybasic/laybasic/layDialogs.cc
@@ -135,13 +135,7 @@ NewLayoutPropertiesDialog::exec_dialog (std::string &technology, std::string &ce
   unsigned int technology_index = 0;
   for (db::Technologies::const_iterator t = db::Technologies::instance ()->begin (); t != db::Technologies::instance ()->end (); ++t, ++technology_index) {
 
-    std::string d = t->name ();
-    if (! d.empty () && ! t->description ().empty ()) {
-      d += " - ";
-    }
-    d += t->description ();
-
-    mp_ui->tech_cbx->addItem (tl::to_qstring (d));
+    mp_ui->tech_cbx->addItem (tl::to_qstring (t->get_display_string ()));
     if (t->name () == technology) {
       mp_ui->tech_cbx->setCurrentIndex (technology_index);
     }

--- a/src/laybasic/laybasic/layLayoutPropertiesForm.cc
+++ b/src/laybasic/laybasic/layLayoutPropertiesForm.cc
@@ -192,13 +192,7 @@ BEGIN_PROTECTED
   unsigned int technology_index = 0;
   for (db::Technologies::const_iterator t = db::Technologies::instance ()->begin (); t != db::Technologies::instance ()->end (); ++t, ++technology_index) {
 
-    std::string d = t->name ();
-    if (! d.empty () && ! t->description ().empty ()) {
-      d += " - ";
-    }
-    d += t->description ();
-
-    tech_cbx->addItem (tl::to_qstring (d));
+    tech_cbx->addItem (tl::to_qstring (t->get_display_string ()));
     if (t->name () == m_handles [index]->tech_name ()) {
       tech_cbx->setCurrentIndex (technology_index);
     }


### PR DESCRIPTION
The tech group is a new XML tag "<group>...</group>".
This tag is editable in the tech "general" page as "Group".
If non-empty, a submenu will be created in the tech selector
menu for all techs with the same group.