### PR TITLE
Add klayout.metainfo.xml metadata file

### DIFF
--- a/etc/klayout.metainfo.xml
+++ b/etc/klayout.metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>de.klayout.KLayout</id>
+  
+  <name>KLayout</name>
+  <summary>KLayout, viewer and editor for mask layouts</summary>
+  
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  
+  <description>
+    <p>
+      Mask layout viewer and editor for the chip design engineer.
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">klayout.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://www.klayout.de/intro-image.png</image>
+    </screenshot>
+  </screenshots>
+
+  <developer_name>Matthias Köfferlein</developer_name>
+  <provides>
+      <binary>klayout</binary>
+  </provides>
+</component>


### PR DESCRIPTION
This PR adds a minimal AppStream metadata file (see [documentation here](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html)) which helps with displaying the application in software centers. Whether you want to do use it is up to you. I am providing it because I want to package KLayout as a flatpak and it is recommended to offer this file upstream.