### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/klayout.pri
+++ b/src/klayout.pri
@@ -160,7 +160,7 @@ equals(HAVE_QT, "0") {
 } else {
 
   DEFINES += HAVE_QT
-  QT += core network xml sql
+  QT += core network xml sql widgets
 
   equals(HAVE_QT5, "1") {
     QT += designer printsupport

--- a/src/lay/lay/laySignalHandler.cc
+++ b/src/lay/lay/laySignalHandler.cc
@@ -450,7 +450,7 @@ void install_signal_handlers ()
   act.sa_sigaction = signal_handler;
   sigemptyset (&act.sa_mask);
   act.sa_flags = SA_SIGINFO;
-#if !defined(__APPLE__) && !defined(__OpenBSD__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
   act.sa_restorer = 0;
 #endif
 

--- a/src/tl/tl/tlFileUtils.cc
+++ b/src/tl/tl/tlFileUtils.cc
@@ -59,6 +59,13 @@
 
 #endif
 
+#if defined(__FreeBSD__)
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+#endif
+
 namespace tl
 {
 
@@ -815,6 +822,16 @@ get_inst_path_internal ()
     //  TODO: does this correctly translate paths? (MacOS uses UTF-8 encoding with D-like normalization)
     return tl::absolute_path (buffer);
   }
+
+#elif defined (__FreeBSD__)
+
+  char path[PATH_MAX];
+  size_t len = PATH_MAX;
+  const int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+  if (sysctl(&mib[0], 4, &path, &len, NULL, 0) == 0) {
+    return tl::absolute_path(path);
+  }
+  return "";
 
 #else
 

--- a/src/tl/tl/tlStream.cc
+++ b/src/tl/tl/tlStream.cc
@@ -32,6 +32,8 @@
 #include <zlib.h>
 #ifdef _WIN32 
 #  include <io.h>
+#else
+#  include <unistd.h>
 #endif
 
 #include "tlStream.h"


### PR DESCRIPTION
FreeBSD needs a few #ifdefs for the latest code to compile. While here, fix another build issue that seems to be due to klayout.pri not declaring that it needs qtWidgets.