### PR TITLE
Add -lexecinfo for BSD

### DIFF
--- a/src/lay/lay/lay.pro
+++ b/src/lay/lay/lay.pro
@@ -179,6 +179,10 @@ win32 {
   LIBS += -lpsapi -ldbghelp
 }
 
+*bsd* {
+  LIBS += -lexecinfo
+}
+
 # Note: this accounts for UI-generated headers placed into the output folders in
 # shadow builds:
 INCLUDEPATH += $$DESTDIR/laybasic/laybasic

--- a/src/tl/tl.pro
+++ b/src/tl/tl.pro
@@ -1,6 +1,9 @@
 
 TEMPLATE = subdirs
 SUBDIRS = tl unit_tests
+*bsd* {
+    LIBS += -lexecinfo
+}
 
 unit_tests.depends += tl
 


### PR DESCRIPTION
FreeBSD and NetBSD require -lexecinfo for the backtrace() functions.