### PR TITLE
In the MacPorts environment, Ruby 2.7 is used.

### DIFF
--- a/macbuild/makeDMG4mac.py
+++ b/macbuild/makeDMG4mac.py
@@ -256,7 +256,7 @@ def CheckPkgDirectory():
         LatestOSMacPorts   = Platform == LatestOS
         LatestOSMacPorts  &= PackagePrefix == "LW"
         LatestOSMacPorts  &= QtIdentification == "qt5MP"
-        LatestOSMacPorts  &= RubyPythonID == "Rmp26Pmp38"
+        LatestOSMacPorts  &= RubyPythonID == "Rmp27Pmp38"
 
         LatestOSHomebrew   = Platform == LatestOS
         LatestOSHomebrew  &= PackagePrefix == "LW"


### PR DESCRIPTION
Some auxiliary files are missing from the DMG due to this Ruby version mismatch.