### PR TITLE
Issue 691 (technology management)

### DIFF
--- a/src/db/db/db.pro
+++ b/src/db/db/db.pro
@@ -19,6 +19,7 @@ SOURCES = \
   dbClipboard.cc \
   dbClipboardData.cc \
   dbClip.cc \
+  dbColdProxy.cc \
   dbCommonReader.cc \
   dbEdge.cc \
   dbEdgePair.cc \
@@ -214,6 +215,7 @@ HEADERS = \
   dbClipboardData.h \
   dbClipboard.h \
   dbClip.h \
+  dbColdProxy.h \
   dbCommonReader.h \
   dbEdge.h \
   dbEdgePair.h \

--- a/src/db/db/dbColdProxy.cc
+++ b/src/db/db/dbColdProxy.cc
@@ -77,9 +77,9 @@ std::string
 ColdProxy::get_basic_name () const
 {
   if (! mp_context_info->pcell_name.empty ()) {
-    return "<defunc>" + mp_context_info->pcell_name;
+    return "<defunct>" + mp_context_info->pcell_name;
   } else if (! mp_context_info->cell_name.empty ()) {
-    return "<defunc>" + mp_context_info->cell_name;
+    return "<defunct>" + mp_context_info->cell_name;
   } else {
     return Cell::get_basic_name ();
   }

--- a/src/db/db/dbColdProxy.cc
+++ b/src/db/db/dbColdProxy.cc
@@ -1,0 +1,128 @@
+
+/*
+
+  KLayout Layout Viewer
+  Copyright (C) 2006-2020 Matthias Koefferlein
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+
+#include "dbColdProxy.h"
+#include "dbLibraryManager.h"
+#include "dbLibrary.h"
+#include "dbLayout.h"
+#include "dbLayoutUtils.h"
+
+#include "tlThreads.h"
+
+namespace db
+{
+
+static tl::Mutex s_map_mutex;
+static std::map<std::string, tl::weak_collection<ColdProxy> > s_proxies_per_library_name;
+
+const tl::weak_collection<ColdProxy> &
+ColdProxy::cold_proxies_per_lib_name (const std::string &libname)
+{
+  tl::MutexLocker locker (&s_map_mutex);
+
+  std::map<std::string, tl::weak_collection<ColdProxy> >::const_iterator i = s_proxies_per_library_name.find (libname);
+  if (i != s_proxies_per_library_name.end ()) {
+    return i->second;
+  } else {
+    static tl::weak_collection<ColdProxy> s_empty;
+    return s_empty;
+  }
+}
+
+ColdProxy::ColdProxy (db::cell_index_type ci, db::Layout &layout, const ProxyContextInfo &info)
+  : Cell (ci, layout), mp_context_info (new ProxyContextInfo (info))
+{
+  if (! info.lib_name.empty ()) {
+    tl::MutexLocker locker (&s_map_mutex);
+    s_proxies_per_library_name [info.lib_name].push_back (this);
+  }
+}
+
+ColdProxy::~ColdProxy ()
+{
+  delete mp_context_info;
+  mp_context_info = 0;
+}
+
+Cell *
+ColdProxy::clone (Layout &layout) const
+{
+  Cell *cell = new ColdProxy (db::Cell::cell_index (), layout, *mp_context_info);
+  //  copy the cell content
+  *cell = *this;
+  return cell;
+}
+
+std::string 
+ColdProxy::get_basic_name () const
+{
+  if (! mp_context_info->pcell_name.empty ()) {
+    return "<defunc>" + mp_context_info->pcell_name;
+  } else if (! mp_context_info->cell_name.empty ()) {
+    return "<defunc>" + mp_context_info->cell_name;
+  } else {
+    return Cell::get_basic_name ();
+  }
+}
+
+std::string 
+ColdProxy::get_display_name () const
+{
+  if (! mp_context_info->lib_name.empty ()) {
+    std::string stem = "<defunct>" + mp_context_info->lib_name + ".";
+    if (! mp_context_info->pcell_name.empty ()) {
+      return stem + mp_context_info->pcell_name;
+    } else if (! mp_context_info->cell_name.empty ()) {
+      return stem + mp_context_info->cell_name;
+    } else {
+      return stem + "<unknown>";
+    }
+  } else {
+    return Cell::get_display_name ();
+  }
+}
+
+std::string
+ColdProxy::get_qualified_name () const
+{
+  if (! mp_context_info->lib_name.empty ()) {
+    std::string stem = "<defunct>" + mp_context_info->lib_name + ".";
+    if (! mp_context_info->pcell_name.empty ()) {
+      if (mp_context_info->pcell_parameters.empty ()) {
+        return stem + mp_context_info->pcell_name;
+      } else {
+        //  TODO: list parameters? Might be long.
+        return stem + mp_context_info->pcell_name + "(...)";
+      }
+    } else if (! mp_context_info->cell_name.empty ()) {
+      return stem + mp_context_info->cell_name;
+    } else {
+      return stem + "<unknown>";
+    }
+  } else {
+    return Cell::get_qualified_name ();
+  }
+}
+
+}
+

--- a/src/db/db/dbColdProxy.h
+++ b/src/db/db/dbColdProxy.h
@@ -1,0 +1,111 @@
+
+/*
+
+  KLayout Layout Viewer
+  Copyright (C) 2006-2020 Matthias Koefferlein
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+
+#ifndef HDR_dbColdProxy
+#define HDR_dbColdProxy
+
+#include "dbCommon.h"
+
+#include "dbTypes.h"
+#include "dbCell.h"
+
+#include "tlObject.h"
+
+namespace db
+{
+
+struct ProxyContextInfo;
+
+/**
+ *  @brief A cell specialization: a cold proxy representing a library or PCell which has gone out of scope
+ *
+ *  If a PCell or library cell gets disconnected - for example, because the technology has changed or during
+ *  development of PCell code - this proxy replaces the original one. It stores the connection information, so
+ *  it can be regenerated when it becomes valid again.
+ */
+class DB_PUBLIC ColdProxy 
+  : public Cell, public tl::Object
+{
+public:
+  /** 
+   *  @brief The constructor
+   *
+   *  Creates a cold proxy represented by the ProxyContextInfo data.
+   */
+  ColdProxy (db::cell_index_type ci, db::Layout &layout, const ProxyContextInfo &info);
+
+  /**
+   *  @brief The destructor
+   */
+  ~ColdProxy ();
+
+  /**
+   *  @brief Cloning 
+   */
+  virtual Cell *clone (Layout &layout) const;
+
+  /**
+   *  @brief Get the library id 
+   */
+  const ProxyContextInfo &context_info () const
+  {
+    return *mp_context_info;
+  }
+
+  /**
+   *  @brief Indicates that this cell is a proxy cell
+   */
+  virtual bool is_proxy () const 
+  { 
+    return true; 
+  }
+
+  /**
+   *  @brief Gets a list of cold proxies for a given library name
+   */
+  static const tl::weak_collection<ColdProxy> &cold_proxies_per_lib_name (const std::string &libname);
+
+  /**
+   *  @brief Gets the basic name
+   */
+  virtual std::string get_basic_name () const;
+
+  /**
+   *  @brief Gets the display name
+   */
+  virtual std::string get_display_name () const;
+
+  /**
+   *  @brief Gets the qualified name
+   */
+  virtual std::string get_qualified_name () const;
+
+private:
+  ProxyContextInfo *mp_context_info;
+};
+
+}
+
+#endif
+
+

--- a/src/db/db/dbLayout.cc
+++ b/src/db/db/dbLayout.cc
@@ -2472,6 +2472,13 @@ bool
 Layout::get_context_info (cell_index_type cell_index, ProxyContextInfo &info) const
 {
   const db::Cell *cptr = &cell (cell_index);
+
+  const db::ColdProxy *cold_proxy = dynamic_cast <const db::ColdProxy *> (cptr);
+  if (cold_proxy) {
+    info = cold_proxy->context_info ();
+    return true;
+  }
+
   const db::Layout *ly = this;
 
   const db::LibraryProxy *lib_proxy;

--- a/src/db/db/dbLayout.cc
+++ b/src/db/db/dbLayout.cc
@@ -481,7 +481,7 @@ Layout::set_technology_name (const std::string &tech)
 
   }
 
-  if (mapping.empty ()) {
+  if (! mapping.empty ()) {
 
     bool needs_cleanup = false;
 
@@ -495,7 +495,8 @@ Layout::set_technology_name (const std::string &tech)
       db::LibraryProxy *lib_proxy = dynamic_cast<db::LibraryProxy *> (&*c);
       if (lib_proxy && (m = mapping.find (lib_proxy->lib_id ())) != mapping.end ()) {
 
-        db::Cell *lib_cell = &cell (lib_proxy->library_cell_index ());
+        db::Library *lib = db::LibraryManager::instance ().lib (lib_proxy->lib_id ());
+        db::Cell *lib_cell = &lib->layout ().cell (lib_proxy->library_cell_index ());
         db::PCellVariant *lib_pcell = dynamic_cast <db::PCellVariant *> (lib_cell);
         if (lib_pcell) {
           pcells_to_map.push_back (std::make_pair (lib_proxy, lib_pcell));

--- a/src/db/db/dbLayout.h
+++ b/src/db/db/dbLayout.h
@@ -458,6 +458,20 @@ public:
 };
 
 /**
+ *  @brief A binary object representing context information for regenerating library proxies and PCells
+ */
+struct DB_PUBLIC ProxyContextInfo
+{
+  std::string lib_name;
+  std::string cell_name;
+  std::string pcell_name;
+  std::map<std::string, tl::Variant> pcell_parameters;
+
+  static ProxyContextInfo deserialize (std::vector<std::string>::const_iterator from, std::vector<std::string>::const_iterator to);
+  void serialize (std::vector<std::string> &strings);
+};
+
+/**
  *  @brief The layout object
  *
  *  The layout object basically wraps the cell graphs and
@@ -863,8 +877,9 @@ public:
    *  @param parameters The PCell parameters
    *  @param cell_index The cell index which is to be replaced by the PCell variant proxy
    *  @param layer_mapping The optional layer mapping object that maps the PCell layers to the layout's layers
+   *  @param retain_layout Set to true for not using update() on the PCell but to retain existing layout (conservative approach)
    */
-  void get_pcell_variant_as (pcell_id_type pcell_id, const std::vector<tl::Variant> &parameters, cell_index_type cell_index, ImportLayerMapping *layer_mapping = 0);
+  void get_pcell_variant_as (pcell_id_type pcell_id, const std::vector<tl::Variant> &parameters, cell_index_type cell_index, ImportLayerMapping *layer_mapping = 0, bool retain_layout = false);
 
   /** 
    *  @brief Get the PCell variant cell of a existing cell with new parameters
@@ -1010,9 +1025,21 @@ public:
   /**
    *  @brief Get the proxy cell (index) for a given library an cell index (inside that library)
    *
-   *  This method replaces the cell with the given target cell index by a library. 
+   *  @param retain_layout Set to true for not using update() on the PCell but to retain existing layout (conservative approach)
+   *
+   *  This method replaces the cell with the given target cell index by a library.
    */
-  void get_lib_proxy_as (Library *lib, cell_index_type cell_index, cell_index_type target_cell_index, ImportLayerMapping *layer_mapping = 0);
+  void get_lib_proxy_as (Library *lib, cell_index_type cell_index, cell_index_type target_cell_index, ImportLayerMapping *layer_mapping = 0, bool retain_layout = false);
+
+  /**
+   *  @brief Creates a cold proxy representing the given context information
+   */
+  cell_index_type create_cold_proxy (const db::ProxyContextInfo &info);
+
+  /**
+   *  @brief Subsitutes the given cell by a cold proxy representing the given context information
+   */
+  void create_cold_proxy_as (const db::ProxyContextInfo &info, cell_index_type cell_index);
 
   /**
    *  @brief Get the context information for a given cell (for writing into a file)
@@ -1025,6 +1052,11 @@ public:
   bool get_context_info (cell_index_type cell_index, std::vector <std::string> &context_info) const;
 
   /**
+   *  @brief Gets the context information as a binary object
+   */
+  bool get_context_info (cell_index_type cell_index, ProxyContextInfo &context_info) const;
+
+  /**
    *  @brief Recover a proxy cell from the given context info.
    *
    *  Creates a proxy cell from the context information given by two iterators into a string list.
@@ -1034,6 +1066,11 @@ public:
    *  @param to The end iterator for the strings from which to recover the cell
    */
   db::Cell *recover_proxy (std::vector <std::string>::const_iterator from, std::vector <std::string>::const_iterator to);
+
+  /**
+   *  @brief Recover a proxy cell from the given binary context info object.
+   */
+  db::Cell *recover_proxy (const ProxyContextInfo &context_info);
 
   /**
    *  @brief Recover a proxy cell from the given context info.
@@ -1049,6 +1086,27 @@ public:
    *  @return true, if the proxy cell could be created
    */
   bool recover_proxy_as (cell_index_type cell_index, std::vector <std::string>::const_iterator from, std::vector <std::string>::const_iterator to, ImportLayerMapping *layer_mapping = 0);
+
+  /**
+   *  @brief Recover a proxy cell from the given binary context info object
+   *
+   *  See the string-based version of "recover_proxy_as" for details.
+   */
+  bool recover_proxy_as (cell_index_type cell_index, const ProxyContextInfo &context_info, ImportLayerMapping *layer_mapping = 0);
+
+  /**
+   *  @brief Restores proxies as far as possible
+   *
+   *  This feature can be used after a library update to make sure that proxies are updated.
+   *  Library updates may enabled lost connections which are help in cold proxies. This method will recover
+   *  these connections.
+   */
+  void restore_proxies(ImportLayerMapping *layer_mapping = 0);
+
+  /**
+   *  @brief Replaces the given cell index with the new cell
+   */
+  void replace_cell (cell_index_type target_cell_index, db::Cell *new_cell, bool retain_layout);
 
   /**
    *  @brief Delete a cell plus the subcells not used otherwise
@@ -1853,6 +1911,11 @@ private:
    *  @brief Implementation of prune_cells and some prune_subcells variants
    */
   void do_prune_cells_or_subcells (const std::set<cell_index_type> &ids, int levels, bool subcells);
+
+  /**
+   *  @brief Recovers a proxy without considering the library from context_info
+   */
+  db::Cell *recover_proxy_no_lib (const ProxyContextInfo &context_info);
 };
 
 /**

--- a/src/db/db/dbLayout.h
+++ b/src/db/db/dbLayout.h
@@ -594,6 +594,13 @@ public:
   void set_technology_name (const std::string &tech);
 
   /**
+   *  @brief Changes the technology name
+   *  This method will only change the technology name, but does not re-assess the library links.
+   *  It's provided mainly to support undo/redo and testing.
+   */
+  void set_technology_name_without_update (const std::string &tech);
+
+  /**
    *  @brief Accessor to the array repository
    */
   ArrayRepository &array_repository ()
@@ -1815,6 +1822,11 @@ public:
    *  If no object with that name exists, an empty string is returned
    */
   const std::string &meta_info_value (const std::string &name) const;
+
+  /**
+   *  @brief This event is triggered when the technology changes
+   */
+  tl::Event technology_changed_event;
 
 protected:
   /**

--- a/src/db/db/dbLayout.h
+++ b/src/db/db/dbLayout.h
@@ -67,6 +67,7 @@ class Region;
 class Edges;
 class EdgePairs;
 class Texts;
+class Technology;
 class CellMapping;
 class LayerMapping;
 
@@ -555,9 +556,28 @@ public:
   }
 
   /**
-   *  @brief Clear the layout
+   *  @brief Clears the layout
    */
   void clear ();
+
+  /**
+   *  @brief Gets the technology name the layout is associated with
+   */
+  const std::string &technology_name () const
+  {
+    return m_tech_name;
+  }
+
+  /**
+   *  @brief Gets the technology object the layout is associated with or null if no valid technology is associated
+   */
+  const db::Technology *technology () const;
+
+  /**
+   *  @brief Changes the technology, the layout is associated with
+   *  Changing the layout may re-assess all the library references as libraries can be technology specific
+   */
+  void set_technology_name (const std::string &tech);
 
   /**
    *  @brief Accessor to the array repository
@@ -1779,6 +1799,7 @@ private:
   bool m_do_cleanup;
   bool m_editable;
   meta_info m_meta_info;
+  std::string m_tech_name;
   tl::Mutex m_lock;
 
   /**

--- a/src/db/db/dbLayoutContextHandler.cc
+++ b/src/db/db/dbLayoutContextHandler.cc
@@ -80,7 +80,7 @@ tl::Variant LayoutContextHandler::eval_double_bracket (const std::string &s) con
 
         std::string tail = cp + 1;
 
-        db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (libname);
+        db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (libname, mp_layout->technology_name ());
         if (! lib) {
           throw tl::Exception (tl::to_string (tr ("Not a valid library name: ")) + libname);
         }

--- a/src/db/db/dbLibrary.cc
+++ b/src/db/db/dbLibrary.cc
@@ -192,6 +192,7 @@ Library::remap_to (db::Library *other)
       if (! pn.first) {
 
         //  substitute by static layout cell
+        //  @@@ TODO: keep reference so we don't loose the connection immediately.
         std::string name = r->first->cell_name (ci);
         db::Cell *old_cell = r->first->take_cell (ci);
         r->first->insert_cell (ci, name, new db::Cell (*old_cell));
@@ -204,6 +205,7 @@ Library::remap_to (db::Library *other)
         if (! old_pcell_decl || ! new_pcell_decl) {
 
           //  substitute by static layout cell
+          //  @@@ TODO: keep reference so we don't loose the connection immediately.
           std::string name = r->first->cell_name (ci);
           db::Cell *old_cell = r->first->take_cell (ci);
           r->first->insert_cell (ci, name, new db::Cell (*old_cell));
@@ -233,6 +235,7 @@ Library::remap_to (db::Library *other)
       if (! cn.first) {
 
         //  unlink this proxy: substitute by static layout cell
+        //  @@@ TODO: keep reference so we don't loose the connection immediately.
         std::string name = r->first->cell_name (ci);
         db::Cell *old_cell = r->first->take_cell (ci);
         r->first->insert_cell (ci, name, new db::Cell (*old_cell));

--- a/src/db/db/dbLibrary.cc
+++ b/src/db/db/dbLibrary.cc
@@ -191,12 +191,10 @@ Library::remap_to (db::Library *other)
 
       if (! pn.first) {
 
-        //  substitute by static layout cell
-        //  @@@ TODO: keep reference so we don't loose the connection immediately.
-        std::string name = r->first->cell_name (ci);
-        db::Cell *old_cell = r->first->take_cell (ci);
-        r->first->insert_cell (ci, name, new db::Cell (*old_cell));
-        delete old_cell;
+        //  substitute by a cold proxy
+        db::ProxyContextInfo info;
+        r->first->get_context_info (ci, info);
+        r->first->create_cold_proxy_as (info, ci);
 
       } else {
 
@@ -204,12 +202,10 @@ Library::remap_to (db::Library *other)
         const db::PCellDeclaration *new_pcell_decl = other->layout ().pcell_declaration (pn.second);
         if (! old_pcell_decl || ! new_pcell_decl) {
 
-          //  substitute by static layout cell
-          //  @@@ TODO: keep reference so we don't loose the connection immediately.
-          std::string name = r->first->cell_name (ci);
-          db::Cell *old_cell = r->first->take_cell (ci);
-          r->first->insert_cell (ci, name, new db::Cell (*old_cell));
-          delete old_cell;
+          //  substitute by a cold proxy
+          db::ProxyContextInfo info;
+          r->first->get_context_info (ci, info);
+          r->first->create_cold_proxy_as (info, ci);
 
         } else {
 
@@ -234,12 +230,10 @@ Library::remap_to (db::Library *other)
 
       if (! cn.first) {
 
-        //  unlink this proxy: substitute by static layout cell
-        //  @@@ TODO: keep reference so we don't loose the connection immediately.
-        std::string name = r->first->cell_name (ci);
-        db::Cell *old_cell = r->first->take_cell (ci);
-        r->first->insert_cell (ci, name, new db::Cell (*old_cell));
-        delete old_cell;
+        //  substitute by a cold proxy
+        db::ProxyContextInfo info;
+        r->first->get_context_info (ci, info);
+        r->first->create_cold_proxy_as (info, ci);
 
       } else {
 

--- a/src/db/db/dbLibraryManager.cc
+++ b/src/db/db/dbLibraryManager.cc
@@ -69,19 +69,25 @@ LibraryManager::~LibraryManager ()
 std::pair<bool, lib_id_type> 
 LibraryManager::lib_by_name (const std::string &name, const std::set<std::string> &for_technologies) const
 {
-  iterator l = m_lib_by_name.find (name);
-  while (l != m_lib_by_name.end () && l->first == name) {
-    const db::Library *lptr = lib (l->second);
-    bool found = lptr->for_technologies ();
-    for (std::set<std::string>::const_iterator t = for_technologies.begin (); t != for_technologies.end () && found; ++t) {
-      if (! lptr->is_for_technology (*t)) {
-        found = false;
+  iterator l;
+
+  if (! for_technologies.empty ()) {
+
+    l = m_lib_by_name.find (name);
+    while (l != m_lib_by_name.end () && l->first == name) {
+      const db::Library *lptr = lib (l->second);
+      bool found = lptr->for_technologies ();
+      for (std::set<std::string>::const_iterator t = for_technologies.begin (); t != for_technologies.end () && found; ++t) {
+        if (! lptr->is_for_technology (*t)) {
+          found = false;
+        }
       }
+      if (found) {
+        return std::make_pair (true, l->second);
+      }
+      ++l;
     }
-    if (found) {
-      return std::make_pair (true, l->second);
-    }
-    ++l;
+
   }
 
   //  fallback: technology-unspecific libs

--- a/src/db/db/dbLibraryManager.cc
+++ b/src/db/db/dbLibraryManager.cc
@@ -70,14 +70,23 @@ LibraryManager::lib_by_name (const std::string &name, const std::set<std::string
 {
   iterator l = m_lib_by_name.find (name);
   while (l != m_lib_by_name.end () && l->first == name) {
-    bool found = true;
-    for (std::set<std::string>::const_iterator t = for_technologies.begin (); t != for_technologies.end (); ++t) {
-      if (! lib (l->second)->is_for_technology (*t)) {
+    const db::Library *lptr = lib (l->second);
+    bool found = lptr->for_technologies ();
+    for (std::set<std::string>::const_iterator t = for_technologies.begin (); t != for_technologies.end () && found; ++t) {
+      if (! lptr->is_for_technology (*t)) {
         found = false;
-        break;
       }
     }
     if (found) {
+      return std::make_pair (true, l->second);
+    }
+    ++l;
+  }
+
+  //  fallback: technology-unspecific libs
+  l = m_lib_by_name.find (name);
+  while (l != m_lib_by_name.end () && l->first == name) {
+    if (! lib (l->second)->for_technologies ()) {
       return std::make_pair (true, l->second);
     }
     ++l;

--- a/src/db/db/dbLibraryManager.h
+++ b/src/db/db/dbLibraryManager.h
@@ -33,6 +33,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <set>
 
 namespace db
 {
@@ -50,7 +51,7 @@ class Library;
 class DB_PUBLIC LibraryManager
 {
 public:
-  typedef std::map <std::string, lib_id_type> lib_name_map;
+  typedef std::multimap <std::string, lib_id_type> lib_name_map;
   typedef lib_name_map::const_iterator iterator;
 
   /** 
@@ -90,11 +91,41 @@ public:
   }
 
   /**
-   *  @brief Get the library by name
+   *  @brief Get the library by name which is valid for all given technologies
+   *
+   *  This method looks up a library which is valid for all technologies listed in "for_technologies". It may be
+   *  responsible for more than that too.
    *
    *  @return A pair, the boolean is true, if the name is valid. The second member is the library id.
    */
-  std::pair<bool, lib_id_type> lib_by_name (const std::string &name) const;
+  std::pair<bool, lib_id_type> lib_by_name (const std::string &name, const std::set<std::string> &for_technologies) const;
+
+  /**
+   *  @brief Get the library by name which is valid for the given technology
+   *
+   *  This method looks up a library which is valid for the given technology. It may be
+   *  responsible for more than that too.
+   *
+   *  @return A pair, the boolean is true, if the name is valid. The second member is the library id.
+   */
+  std::pair<bool, lib_id_type> lib_by_name (const std::string &name, const std::string &for_technology) const
+  {
+    std::set<std::string> techs;
+    if (! for_technology.empty ()) {
+      techs.insert (for_technology);
+    }
+    return lib_by_name (name, techs);
+  }
+
+  /**
+   *  @brief Get the library by name for any technology
+   *
+   *  @return A pair, the boolean is true, if the name is valid. The second member is the library id.
+   */
+  std::pair<bool, lib_id_type> lib_by_name (const std::string &name) const
+  {
+    return lib_by_name (name, std::set<std::string> ());
+  }
 
   /**
    *  @brief Get the library by name
@@ -104,6 +135,36 @@ public:
   Library *lib_ptr_by_name (const std::string &name) const
   {
     std::pair<bool, lib_id_type> ll = lib_by_name (name);
+    if (ll.first) {
+      return lib (ll.second);
+    } else {
+      return 0;
+    }
+  }
+
+  /**
+   *  @brief Get the library by name and technology
+   *
+   *  @return The pointer to the library or 0, if there is no library with that name.
+   */
+  Library *lib_ptr_by_name (const std::string &name, const std::string &for_technology) const
+  {
+    std::pair<bool, lib_id_type> ll = lib_by_name (name, for_technology);
+    if (ll.first) {
+      return lib (ll.second);
+    } else {
+      return 0;
+    }
+  }
+
+  /**
+   *  @brief Get the library by name and technology
+   *
+   *  @return The pointer to the library or 0, if there is no library with that name.
+   */
+  Library *lib_ptr_by_name (const std::string &name, const std::set<std::string> &for_technologies) const
+  {
+    std::pair<bool, lib_id_type> ll = lib_by_name (name, for_technologies);
     if (ll.first) {
       return lib (ll.second);
     } else {

--- a/src/db/db/dbLibraryProxy.cc
+++ b/src/db/db/dbLibraryProxy.cc
@@ -99,8 +99,6 @@ LibraryProxy::remap (lib_id_type lib_id, cell_index_type lib_cell_index)
   m_lib_id = lib_id;
   m_library_cell_index = lib_cell_index;
 
-  //  It's important to register at the new library, but the old library is about to the deleted, so we don't unregister.
-  //  That does not disturb the old library iterating over the layouts.
   db::Library *lib = db::LibraryManager::instance ().lib (m_lib_id);
   if (lib) {
     lib->register_proxy (this, layout ());

--- a/src/db/db/dbManager.cc
+++ b/src/db/db/dbManager.cc
@@ -156,15 +156,13 @@ Manager::cancel ()
     m_opened = false;
 
     if (m_current->first.begin () != m_current->first.end ()) {
-
       ++m_current;
       undo ();
-
-    } else {
-      //  empty transactions .. just delete
-      erase_transactions (m_current, m_transactions.end ());
-      m_current = m_transactions.end ();
     }
+
+    //  wipe following history as we don't want the cancelled operation to be redoable
+    erase_transactions (m_current, m_transactions.end ());
+    m_current = m_transactions.end ();
 
   }
 }

--- a/src/db/db/dbPCellDeclaration.h
+++ b/src/db/db/dbPCellDeclaration.h
@@ -29,6 +29,7 @@
 #include "gsiObject.h"
 #include "dbLayout.h"
 #include "tlVariant.h"
+#include "tlObject.h"
 
 namespace db
 {
@@ -327,7 +328,8 @@ public:
  *  @brief A declaration for a PCell
  */
 class DB_PUBLIC PCellDeclaration
-  : public gsi::ObjectBase
+  : public gsi::ObjectBase,
+    public tl::Object
 {
 public:
   /**

--- a/src/db/db/gsiDeclDbLayout.cc
+++ b/src/db/db/gsiDeclDbLayout.cc
@@ -39,6 +39,7 @@
 #include "dbLayoutUtils.h"
 #include "dbLayerMapping.h"
 #include "dbCellMapping.h"
+#include "dbTechnology.h"
 #include "tlStream.h"
 
 namespace gsi
@@ -750,7 +751,7 @@ static db::Cell *create_cell2 (db::Layout *layout, const std::string &name, cons
 
 static db::Cell *create_cell3 (db::Layout *layout, const std::string &name, const std::string &libname)
 {
-  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (libname);
+  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (libname, layout->technology_name ());
   if (! lib) {
     return 0;
   }
@@ -765,7 +766,7 @@ static db::Cell *create_cell3 (db::Layout *layout, const std::string &name, cons
 
 static db::Cell *create_cell4 (db::Layout *layout, const std::string &name, const std::string &libname, const std::map<std::string, tl::Variant> &params)
 {
-  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (libname);
+  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (libname, layout->technology_name ());
   if (! lib) {
     return 0;
   }
@@ -987,6 +988,21 @@ Class<db::Layout> decl_Layout ("db", "Layout",
     "See \\LayoutMetaInfo for details about layouts and meta information.\n"
     "\n"
     "This method has been introduced in version 0.25."
+  ) +
+  gsi::method ("technology_name", &db::Layout::technology_name,
+    "@brief Gets the name of the technology this layout is associated with\n"
+    "This method has been introduced in version 0.27. Before that, the technology has been kept in the 'technology' meta data element."
+  ) +
+  gsi::method ("technology", &db::Layout::technology,
+    "@brief Gets the \\Technology object of the technology this layout is associated with or nil if the layout is not associated with a technology\n"
+    "This method has been introduced in version 0.27. Before that, the technology has been kept in the 'technology' meta data element."
+  ) +
+  gsi::method ("technology_name=", &db::Layout::set_technology_name, gsi::arg ("name"),
+    "@brief Sets the name of the technology this layout is associated with\n"
+    "Changing the technology name will re-assess all library references because libraries can be technology specified. "
+    "Cell layouts may be substituted during this re-assessment.\n"
+    "\n"
+    "This method has been introduced in version 0.27."
   ) +
   gsi::method ("is_editable?", &db::Layout::is_editable,
     "@brief Returns a value indicating whether the layout is editable.\n"

--- a/src/db/unit_tests/dbLibrariesTests.cc
+++ b/src/db/unit_tests/dbLibrariesTests.cc
@@ -617,3 +617,43 @@ TEST(3)
   }
 }
 
+TEST(4)
+{
+  LIBT_A *lib_a1 = new LIBT_A ();
+  lib_a1->add_technology ("X");
+  db::LibraryManager::instance ().register_lib (lib_a1);
+
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").second, lib_a1->get_id ());
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Z").first, false);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, false);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").second, lib_a1->get_id ());
+
+  LIBT_A *lib_a2 = new LIBT_A ();
+  lib_a2->add_technology ("Y");
+  db::LibraryManager::instance ().register_lib (lib_a2);
+
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").second, lib_a2->get_id ());
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Z").first, false);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, false);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").second, lib_a1->get_id ());
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Y").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Y").second, lib_a2->get_id ());
+
+  LIBT_A *lib_a3 = new LIBT_A ();
+  lib_a3->add_technology ("X");
+  db::LibraryManager::instance ().register_lib (lib_a3);
+
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").second, lib_a3->get_id ());
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Z").first, false);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, false);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").second, lib_a3->get_id ());
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Y").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Y").second, lib_a2->get_id ());
+}
+

--- a/src/db/unit_tests/dbLibrariesTests.cc
+++ b/src/db/unit_tests/dbLibrariesTests.cc
@@ -626,7 +626,8 @@ TEST(4)
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").first, true);
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").second, lib_a1->get_id ());
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Z").first, false);
-  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, false);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").second, lib_a1->get_id ());
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").first, true);
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").second, lib_a1->get_id ());
 
@@ -637,7 +638,8 @@ TEST(4)
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").first, true);
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").second, lib_a2->get_id ());
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Z").first, false);
-  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, false);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").second, lib_a2->get_id ());
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").first, true);
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").second, lib_a1->get_id ());
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Y").first, true);
@@ -650,7 +652,23 @@ TEST(4)
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").first, true);
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").second, lib_a3->get_id ());
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Z").first, false);
-  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, false);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").second, lib_a3->get_id ());
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").second, lib_a3->get_id ());
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Y").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Y").second, lib_a2->get_id ());
+
+
+  LIBT_A *lib_a4 = new LIBT_A ();
+  db::LibraryManager::instance ().register_lib (lib_a4);
+
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A").second, lib_a3->get_id ());
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Z").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Z").second, lib_a4->get_id ());
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").first, true);
+  EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "").second, lib_a3->get_id ());
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").first, true);
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "X").second, lib_a3->get_id ());
   EXPECT_EQ (db::LibraryManager::instance ().lib_by_name ("A", "Y").first, true);

--- a/src/edt/edt/edtEditorOptionsPages.cc
+++ b/src/edt/edt/edtEditorOptionsPages.cc
@@ -440,14 +440,13 @@ EditorOptionsInst::update_cell_edits ()
   }
 
   db::Layout *layout = 0;
-  lay::LayoutView *view = lay::LayoutView::current ();
 
   //  find the layout the cell has to be looked up: that is either the layout of the current instance or
   //  the library selected
   if (mp_ui->lib_cbx->current_library ()) {
     layout = &mp_ui->lib_cbx->current_library ()->layout ();
-  } else if (view && view->cellview (m_cv_index).is_valid ()) {
-    layout = &view->cellview (m_cv_index)->layout ();
+  } else if (view ()->cellview (m_cv_index).is_valid ()) {
+    layout = &view ()->cellview (m_cv_index)->layout ();
   }
 
   if (! layout) {
@@ -485,7 +484,7 @@ EditorOptionsInst::browse_cell ()
 {
 BEGIN_PROTECTED
 
-  if (m_cv_index >= 0 && lay::LayoutView::current () && lay::LayoutView::current ()->cellview (m_cv_index).is_valid ()) {
+  if (m_cv_index >= 0 && view ()->cellview (m_cv_index).is_valid ()) {
 
     //  find the layout the cell has to be looked up: that is either the layout of the current instance or 
     //  the library selected
@@ -495,7 +494,7 @@ BEGIN_PROTECTED
       lib = mp_ui->lib_cbx->current_library ();
       layout = &lib->layout ();
     } else {
-      layout = &lay::LayoutView::current ()->cellview (m_cv_index)->layout ();
+      layout = &view ()->cellview (m_cv_index)->layout ();
     }
 
     bool all_cells = (mp_ui->lib_cbx->current_library () != 0 ? false : true);
@@ -605,12 +604,10 @@ EditorOptionsInst::setup (lay::Dispatcher *root)
     std::string techname;
 
     mp_ui->lib_cbx->update_list ();
-    if (m_cv_index >= 0 && lay::LayoutView::current () && lay::LayoutView::current ()->cellview (m_cv_index).is_valid ()) {
-      techname = lay::LayoutView::current ()->cellview (m_cv_index)->tech_name ();
-      mp_ui->lib_cbx->set_technology_filter (techname, true);
-    } else {
-      mp_ui->lib_cbx->set_technology_filter (std::string (), false);
+    if (m_cv_index >= 0 && view ()->cellview (m_cv_index).is_valid ()) {
+      techname = view ()->cellview (m_cv_index)->tech_name ();
     }
+    mp_ui->lib_cbx->set_technology_filter (techname, ! techname.empty ());
 
     //  cell name
     std::string s;
@@ -707,11 +704,11 @@ EditorOptionsInstPCellParam::apply (lay::Dispatcher *root)
   std::string param;
   db::Layout *layout = 0;
 
-  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, view ()->active_cellview_ref ()->tech_name ());
+  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, view ()->active_cellview ().is_valid () ? view ()->active_cellview ()->tech_name () : std::string ());
   if (lib) {
     layout = &lib->layout ();
-  } else if (m_cv_index >= 0 && lay::LayoutView::current () && lay::LayoutView::current ()->cellview (m_cv_index).is_valid ()) {
-    layout = &lay::LayoutView::current ()->cellview (m_cv_index)->layout ();
+  } else if (m_cv_index >= 0 && view ()->cellview (m_cv_index).is_valid ()) {
+    layout = &view ()->cellview (m_cv_index)->layout ();
   }
 
   bool ok = true;
@@ -760,7 +757,7 @@ EditorOptionsInstPCellParam::setup (lay::Dispatcher *root)
     needs_update = true;
   }
 
-  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, view ()->active_cellview_ref ()->tech_name ());
+  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, view ()->active_cellview ().is_valid () ? view ()->active_cellview ()->tech_name () : std::string ());
 
   //  pcell parameters
   std::string param;
@@ -840,7 +837,7 @@ EditorOptionsInstPCellParam::update_pcell_parameters (const std::vector <tl::Var
 
   //  find the layout the cell has to be looked up: that is either the layout of the current instance or
   //  the library selected
-  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, view ()->active_cellview_ref ()->tech_name ());
+  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, view ()->active_cellview ().is_valid () ? view ()->active_cellview ()->tech_name () : std::string ());
   if (lib) {
     layout = &lib->layout ();
   } else {

--- a/src/edt/edt/edtEditorOptionsPages.h
+++ b/src/edt/edt/edtEditorOptionsPages.h
@@ -51,6 +51,7 @@ namespace lay
 {
   class PluginDeclaration;
   class Dispatcher;
+  class LayoutView;
   class Plugin;
 }
 
@@ -68,7 +69,7 @@ class EditorOptionsGeneric
 Q_OBJECT
 
 public:
-  EditorOptionsGeneric (lay::Dispatcher *dispatcher);
+  EditorOptionsGeneric (lay::LayoutView *view, lay::Dispatcher *dispatcher);
   ~EditorOptionsGeneric ();
 
   virtual std::string title () const;
@@ -91,7 +92,7 @@ class EditorOptionsText
   : public lay::EditorOptionsPage
 {
 public:
-  EditorOptionsText (lay::Dispatcher *dispatcher);
+  EditorOptionsText (lay::LayoutView *view, lay::Dispatcher *dispatcher);
   ~EditorOptionsText ();
 
   virtual std::string title () const;
@@ -112,7 +113,7 @@ class EditorOptionsPath
 Q_OBJECT 
 
 public:
-  EditorOptionsPath (lay::Dispatcher *dispatcher);
+  EditorOptionsPath (lay::LayoutView *view, lay::Dispatcher *dispatcher);
   ~EditorOptionsPath ();
 
   virtual std::string title () const;
@@ -136,7 +137,7 @@ class EditorOptionsInst
 Q_OBJECT 
 
 public:
-  EditorOptionsInst (lay::Dispatcher *root);
+  EditorOptionsInst (lay::LayoutView *view, lay::Dispatcher *root);
   ~EditorOptionsInst ();
 
   virtual std::string title () const;
@@ -154,6 +155,9 @@ private:
   Ui::EditorOptionsInst *mp_ui;
   edt::PCellParametersPage *mp_pcell_parameters;
   int m_cv_index;
+
+  virtual void technology_changed (const std::string &);
+  virtual void active_cellview_changed ();
 };
 
 /**
@@ -165,7 +169,7 @@ class EditorOptionsInstPCellParam
 Q_OBJECT
 
 public:
-  EditorOptionsInstPCellParam (lay::Dispatcher *root);
+  EditorOptionsInstPCellParam (lay::LayoutView *view, lay::Dispatcher *root);
   ~EditorOptionsInstPCellParam ();
 
   virtual std::string title () const;
@@ -184,6 +188,7 @@ private:
   std::string m_lib_name, m_cell_name;
 
   void update_pcell_parameters (const std::vector <tl::Variant> &parameters);
+  virtual void technology_changed (const std::string &);
 };
 
 }

--- a/src/edt/edt/edtPCellParametersPage.cc
+++ b/src/edt/edt/edtPCellParametersPage.cc
@@ -153,7 +153,7 @@ PCellParametersPage::PCellParametersPage (QWidget *parent, bool dense)
 void
 PCellParametersPage::init ()
 {
-  mp_pcell_decl = 0;
+  mp_pcell_decl.reset (0);
   mp_layout = 0;
   mp_view = 0;
   m_cv_index = 0;
@@ -185,7 +185,7 @@ PCellParametersPage::init ()
 void
 PCellParametersPage::setup (const db::Layout *layout, lay::LayoutView *view, int cv_index, const db::PCellDeclaration *pcell_decl, const db::pcell_parameters_type &parameters)
 {
-  mp_pcell_decl = pcell_decl;
+  mp_pcell_decl.reset (const_cast<db::PCellDeclaration *> (pcell_decl));  //  no const weak_ptr ...
   mp_layout = layout;
   mp_view = view;
   m_cv_index = cv_index;
@@ -457,130 +457,135 @@ std::vector<tl::Variant>
 PCellParametersPage::get_parameters (bool *ok)
 {
   std::vector<tl::Variant> parameters;
-  bool edit_error = true;
 
-  int r = 0;
-  const std::vector<db::PCellParameterDeclaration> &pcp = mp_pcell_decl->parameter_declarations ();
-  for (std::vector<db::PCellParameterDeclaration>::const_iterator p = pcp.begin (); p != pcp.end (); ++p, ++r) {
+  try {
 
-    if (p->is_hidden () || p->get_type () == db::PCellParameterDeclaration::t_shape) {
+    if (! mp_pcell_decl) {
+      throw tl::Exception (tl::to_string (tr ("PCell no longer valid.")));
+    }
 
-      if (r < (int) m_parameters.size ()) {
-        parameters.push_back (m_parameters [r]);
-      } else {
-        parameters.push_back (p->get_default ());
-      }
+    bool edit_error = true;
 
-    } else {
+    int r = 0;
+    const std::vector<db::PCellParameterDeclaration> &pcp = mp_pcell_decl->parameter_declarations ();
+    for (std::vector<db::PCellParameterDeclaration>::const_iterator p = pcp.begin (); p != pcp.end (); ++p, ++r) {
 
-      parameters.push_back (tl::Variant ());
+      if (p->is_hidden () || p->get_type () == db::PCellParameterDeclaration::t_shape) {
 
-      if (p->get_choices ().empty ()) {
-
-        switch (p->get_type ()) {
-          
-        case db::PCellParameterDeclaration::t_int:
-          {
-            QLineEdit *le = dynamic_cast<QLineEdit *> (m_widgets [r]);
-            if (le) {
-
-              try {
-
-                int v = 0;
-                tl::from_string (tl::to_string (le->text ()), v);
-
-                parameters.back () = tl::Variant (v);
-                lay::indicate_error (le, 0);
-
-              } catch (tl::Exception &ex) {
-
-                lay::indicate_error (le, &ex);
-                edit_error = false;
-
-              }
-
-            }
-          }
-          break;
-
-        case db::PCellParameterDeclaration::t_double:
-          {
-            QLineEdit *le = dynamic_cast<QLineEdit *> (m_widgets [r]);
-            if (le) {
-
-              try {
-
-                double v = 0;
-                tl::from_string (tl::to_string (le->text ()), v);
-
-                parameters.back () = tl::Variant (v);
-                lay::indicate_error (le, 0);
-
-              } catch (tl::Exception &ex) {
-
-                lay::indicate_error (le, &ex);
-                edit_error = false;
-
-              }
-
-            }
-          }
-          break;
-
-        case db::PCellParameterDeclaration::t_string:
-          {
-            QLineEdit *le = dynamic_cast<QLineEdit *> (m_widgets [r]);
-            if (le) {
-              parameters.back () = tl::Variant (tl::to_string (le->text ()));
-            }
-          }
-          break;
-
-        case db::PCellParameterDeclaration::t_list:
-          {
-            QLineEdit *le = dynamic_cast<QLineEdit *> (m_widgets [r]);
-            if (le) {
-              std::vector<std::string> values = tl::split (tl::to_string (le->text ()), ",");
-              parameters.back () = tl::Variant (values.begin (), values.end ());
-            }
-          }
-          break;
-
-        case db::PCellParameterDeclaration::t_layer:
-          {
-            lay::LayerSelectionComboBox *ly = dynamic_cast<lay::LayerSelectionComboBox *> (m_widgets [r]);
-            if (ly) {
-              parameters.back () = tl::Variant (ly->current_layer_props ());
-            }
-          }
-          break;
-        case db::PCellParameterDeclaration::t_boolean:
-          {
-            QCheckBox *cbx = dynamic_cast<QCheckBox *> (m_widgets [r]);
-            if (cbx) {
-              parameters.back () = tl::Variant (cbx->isChecked ());
-            }
-          }
-          break;
-
-        default:
-          break;
+        if (r < (int) m_parameters.size ()) {
+          parameters.push_back (m_parameters [r]);
+        } else {
+          parameters.push_back (p->get_default ());
         }
 
       } else {
 
-        QComboBox *cb = dynamic_cast<QComboBox*> (m_widgets [r]);
-        if (cb && cb->currentIndex () >= 0 && cb->currentIndex () < int (p->get_choices ().size ())) {
-          parameters.back () = p->get_choices () [cb->currentIndex ()];
+        parameters.push_back (tl::Variant ());
+
+        if (p->get_choices ().empty ()) {
+
+          switch (p->get_type ()) {
+
+          case db::PCellParameterDeclaration::t_int:
+            {
+              QLineEdit *le = dynamic_cast<QLineEdit *> (m_widgets [r]);
+              if (le) {
+
+                try {
+
+                  int v = 0;
+                  tl::from_string (tl::to_string (le->text ()), v);
+
+                  parameters.back () = tl::Variant (v);
+                  lay::indicate_error (le, 0);
+
+                } catch (tl::Exception &ex) {
+
+                  lay::indicate_error (le, &ex);
+                  edit_error = false;
+
+                }
+
+              }
+            }
+            break;
+
+          case db::PCellParameterDeclaration::t_double:
+            {
+              QLineEdit *le = dynamic_cast<QLineEdit *> (m_widgets [r]);
+              if (le) {
+
+                try {
+
+                  double v = 0;
+                  tl::from_string (tl::to_string (le->text ()), v);
+
+                  parameters.back () = tl::Variant (v);
+                  lay::indicate_error (le, 0);
+
+                } catch (tl::Exception &ex) {
+
+                  lay::indicate_error (le, &ex);
+                  edit_error = false;
+
+                }
+
+              }
+            }
+            break;
+
+          case db::PCellParameterDeclaration::t_string:
+            {
+              QLineEdit *le = dynamic_cast<QLineEdit *> (m_widgets [r]);
+              if (le) {
+                parameters.back () = tl::Variant (tl::to_string (le->text ()));
+              }
+            }
+            break;
+
+          case db::PCellParameterDeclaration::t_list:
+            {
+              QLineEdit *le = dynamic_cast<QLineEdit *> (m_widgets [r]);
+              if (le) {
+                std::vector<std::string> values = tl::split (tl::to_string (le->text ()), ",");
+                parameters.back () = tl::Variant (values.begin (), values.end ());
+              }
+            }
+            break;
+
+          case db::PCellParameterDeclaration::t_layer:
+            {
+              lay::LayerSelectionComboBox *ly = dynamic_cast<lay::LayerSelectionComboBox *> (m_widgets [r]);
+              if (ly) {
+                parameters.back () = tl::Variant (ly->current_layer_props ());
+              }
+            }
+            break;
+          case db::PCellParameterDeclaration::t_boolean:
+            {
+              QCheckBox *cbx = dynamic_cast<QCheckBox *> (m_widgets [r]);
+              if (cbx) {
+                parameters.back () = tl::Variant (cbx->isChecked ());
+              }
+            }
+            break;
+
+          default:
+            break;
+          }
+
+        } else {
+
+          QComboBox *cb = dynamic_cast<QComboBox*> (m_widgets [r]);
+          if (cb && cb->currentIndex () >= 0 && cb->currentIndex () < int (p->get_choices ().size ())) {
+            parameters.back () = p->get_choices () [cb->currentIndex ()];
+          }
+
         }
 
       }
 
     }
-
-  }
-
-  try {
 
     if (! edit_error) {
       throw tl::Exception (tl::to_string (tr ("There are errors. See the highlighted edit fields for details.")));
@@ -628,6 +633,10 @@ PCellParametersPage::get_parameters (bool *ok)
 void 
 PCellParametersPage::set_parameters (const std::vector<tl::Variant> &parameters)
 {
+  if (! mp_pcell_decl) {
+    return;
+  }
+
   //  write the changed value back
   size_t r = 0;
   const std::vector<db::PCellParameterDeclaration> &pcp = mp_pcell_decl->parameter_declarations ();

--- a/src/edt/edt/edtPCellParametersPage.h
+++ b/src/edt/edt/edtPCellParametersPage.h
@@ -104,7 +104,7 @@ public:
    */
   const db::PCellDeclaration *pcell_decl () const
   {
-    return mp_pcell_decl;
+    return mp_pcell_decl.get ();
   }
 
   /**
@@ -122,7 +122,7 @@ private:
   QScrollArea *mp_parameters_area;
   QLabel *mp_error_label;
   QLabel *mp_error_icon;
-  const db::PCellDeclaration *mp_pcell_decl;
+  tl::weak_ptr<db::PCellDeclaration> mp_pcell_decl;
   std::vector<QWidget *> m_widgets;
   const db::Layout *mp_layout;
   lay::LayoutView *mp_view;

--- a/src/edt/edt/edtPlugin.cc
+++ b/src/edt/edt/edtPlugin.cc
@@ -75,7 +75,7 @@ void get_text_editor_options_pages (std::vector<lay::EditorOptionsPage *> &ret, 
 
   ret.push_back (new RecentConfigurationPage (view, dispatcher, "edit-recent-text-param",
                         &text_cfg_descriptors[0], &text_cfg_descriptors[sizeof (text_cfg_descriptors) / sizeof (text_cfg_descriptors[0])]));
-  ret.push_back (new edt::EditorOptionsText (dispatcher));
+  ret.push_back (new edt::EditorOptionsText (view, dispatcher));
 }
 
 static 
@@ -101,7 +101,7 @@ void get_path_editor_options_pages (std::vector<lay::EditorOptionsPage *> &ret, 
   
   ret.push_back (new RecentConfigurationPage (view, dispatcher, "edit-recent-path-param",
                         &path_cfg_descriptors[0], &path_cfg_descriptors[sizeof (path_cfg_descriptors) / sizeof (path_cfg_descriptors[0])]));
-  ret.push_back (new EditorOptionsPath (dispatcher));
+  ret.push_back (new EditorOptionsPath (view, dispatcher));
 }
 
 static 
@@ -145,8 +145,8 @@ void get_inst_editor_options_pages (std::vector<lay::EditorOptionsPage *> &ret, 
 
   ret.push_back (new RecentConfigurationPage (view, dispatcher, "edit-recent-inst-param",
                         &inst_cfg_descriptors[0], &inst_cfg_descriptors[sizeof (inst_cfg_descriptors) / sizeof (inst_cfg_descriptors[0])]));
-  ret.push_back (new EditorOptionsInstPCellParam (dispatcher));
-  ret.push_back (new EditorOptionsInst (dispatcher));
+  ret.push_back (new EditorOptionsInstPCellParam (view, dispatcher));
+  ret.push_back (new EditorOptionsInst (view, dispatcher));
 }
 
 template <class Svc>
@@ -327,10 +327,10 @@ public:
     return false;
   }
 
-  virtual void get_editor_options_pages (std::vector<lay::EditorOptionsPage *> &pages, lay::LayoutView * /*view*/, lay::Dispatcher *dispatcher) const
+  virtual void get_editor_options_pages (std::vector<lay::EditorOptionsPage *> &pages, lay::LayoutView *view, lay::Dispatcher *dispatcher) const
   {
     //  NOTE: we do not set plugin_declaration which makes the page unspecific
-    EditorOptionsGeneric *generic_opt = new EditorOptionsGeneric (dispatcher);
+    EditorOptionsGeneric *generic_opt = new EditorOptionsGeneric (view, dispatcher);
     pages.push_back (generic_opt);
   }
 

--- a/src/edt/edt/edtRecentConfigurationPage.cc
+++ b/src/edt/edt/edtRecentConfigurationPage.cc
@@ -219,7 +219,11 @@ RecentConfigurationPage::render_to (QTreeWidgetItem *item, int column, const std
       const db::Library *lib = 0;
       for (std::list<ConfigurationDescriptor>::const_iterator c = m_cfg.begin (); c != m_cfg.end (); ++c, ++libname_column) {
         if (c->rendering == RecentConfigurationPage::CellLibraryName) {
-          lib = db::LibraryManager::instance ().lib_ptr_by_name (values [libname_column], view ()->active_cellview_ref ()->tech_name ());
+          if (view ()->active_cellview ().is_valid ()) {
+            lib = db::LibraryManager::instance ().lib_ptr_by_name (values [libname_column], view ()->active_cellview ()->tech_name ());
+          } else {
+            lib = db::LibraryManager::instance ().lib_ptr_by_name (values [libname_column]);
+          }
           break;
         }
       }

--- a/src/edt/edt/edtRecentConfigurationPage.h
+++ b/src/edt/edt/edtRecentConfigurationPage.h
@@ -46,8 +46,7 @@ class EditorOptionsPages;
  *  @brief The base class for a object properties page
  */
 class RecentConfigurationPage
-  : public lay::EditorOptionsPage,
-    public tl::Object
+  : public lay::EditorOptionsPage
 {
 Q_OBJECT
 
@@ -79,7 +78,7 @@ public:
 
   template <class Iter>
   RecentConfigurationPage (lay::LayoutView *view, lay::Dispatcher *dispatcher, const std::string &recent_cfg_name, Iter begin_cfg, Iter end_cfg)
-    : EditorOptionsPage (dispatcher), mp_view (view), m_recent_cfg_name (recent_cfg_name), m_cfg (begin_cfg, end_cfg)
+    : EditorOptionsPage (view, dispatcher), m_recent_cfg_name (recent_cfg_name), m_cfg (begin_cfg, end_cfg)
   {
     init ();
   }
@@ -96,7 +95,6 @@ private slots:
   void item_clicked (QTreeWidgetItem *item);
 
 private:
-  lay::LayoutView *mp_view;
   std::string m_recent_cfg_name;
   std::list<ConfigurationDescriptor> m_cfg;
   QTreeWidget *mp_tree_widget;
@@ -107,6 +105,7 @@ private:
   void set_stored_values (const std::list<std::vector<std::string> > &values) const;
   void render_to (QTreeWidgetItem *item, int column, const std::vector<std::string> &values, RecentConfigurationPage::ConfigurationRendering rendering);
   void layers_changed (int);
+  virtual void technology_changed (const std::string &);
 };
 
 }

--- a/src/edt/edt/edtServiceImpl.cc
+++ b/src/edt/edt/edtServiceImpl.cc
@@ -1854,7 +1854,12 @@ InstService::switch_cell_or_pcell (bool switch_parameters)
   }
 
   const lay::CellView &cv = view ()->cellview (m_cv_index);
-  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, cv->tech_name ());
+  db::Library *lib = 0;
+  if (cv.is_valid ()) {
+    lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, cv->tech_name ());
+  } else {
+    lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name);
+  }
 
   //  find the layout the cell has to be looked up: that is either the layout of the current instance or
   //  the library selected

--- a/src/edt/edt/edtServiceImpl.cc
+++ b/src/edt/edt/edtServiceImpl.cc
@@ -1414,7 +1414,7 @@ InstService::make_cell (const lay::CellView &cv)
 
   lay::LayerState layer_state = view ()->layer_snapshot ();
 
-  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name);
+  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, cv->tech_name ());
 
   //  find the layout the cell has to be looked up: that is either the layout of the current instance or 
   //  the library selected
@@ -1853,8 +1853,8 @@ InstService::switch_cell_or_pcell (bool switch_parameters)
 
   }
 
-  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name);
   const lay::CellView &cv = view ()->cellview (m_cv_index);
+  db::Library *lib = db::LibraryManager::instance ().lib_ptr_by_name (m_lib_name, cv->tech_name ());
 
   //  find the layout the cell has to be looked up: that is either the layout of the current instance or
   //  the library selected

--- a/src/lay/lay/layLibraryController.h
+++ b/src/lay/lay/layLibraryController.h
@@ -119,9 +119,17 @@ private slots:
   void sync_with_external_sources ();
 
 private:
+  struct LibInfo
+  {
+    LibInfo () : name (), time (), tech () { }
+    std::string name;
+    QDateTime time;
+    std::set<std::string> tech;
+  };
+
   tl::FileSystemWatcher *m_file_watcher;
   tl::DeferredMethod<LibraryController> dm_sync_files;
-  std::map<std::string, std::pair<std::string, QDateTime> > m_lib_files;
+  std::map<std::string, LibInfo> m_lib_files;
 
   void sync_files ();
 };

--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -2506,7 +2506,7 @@ void
 MainWindow::cm_new_layout ()
 {
   std::string technology = m_initial_technology;
-  static std::string s_new_cell_cell_name;
+  static std::string s_new_cell_cell_name ("TOP");
   static double s_new_cell_window_size = 2.0;
 
   double dbu = 0.0;

--- a/src/lay/lay/layTechnologyController.cc
+++ b/src/lay/lay/layTechnologyController.cc
@@ -285,15 +285,33 @@ bool
 TechnologyController::menu_activated (const std::string &symbol) const
 {
   if (symbol == "technology_selector:apply_technology") {
+
     if (lay::LayoutView::current () && lay::LayoutView::current ()->active_cellview ().is_valid ()) {
-      //  Cancels the current modes - changing the technology may make libraries unavailable
-      //  for example.
+
       if (mp_mw) {
+
+        //  Cancels the current modes - changing the technology may make libraries unavailable
+        //  for example.
         mp_mw->cancel ();
+
+        //  apply technology with undo
+        mp_mw->manager ().transaction (tl::sprintf (tl::to_string (tr ("Apply technology '%s'")), m_current_technology));
+        try {
+          lay::LayoutView::current ()->active_cellview ()->apply_technology (m_current_technology);
+          mp_mw->manager ().commit ();
+        } catch (...) {
+          mp_mw->manager ().cancel ();
+          throw;
+        }
+
+      } else {
+        lay::LayoutView::current ()->active_cellview ()->apply_technology (m_current_technology);
       }
-      lay::LayoutView::current ()->active_cellview ()->apply_technology (m_current_technology);
+
     }
+
     return true;
+
   } else {
     return lay::PluginDeclaration::menu_activated (symbol);
   }

--- a/src/laybasic/laybasic/layCellView.cc
+++ b/src/laybasic/laybasic/layCellView.cc
@@ -59,6 +59,8 @@ LayoutHandle::LayoutHandle (db::Layout *layout, const std::string &filename)
     m_dirty (false),
     m_save_options_valid (false)
 {
+  layout->technology_changed_event.add (this, &LayoutHandle::on_technology_changed);
+
   //  layouts in the managed layouts space participate in spare proxy cleanup
   layout->do_cleanup (true);
 
@@ -106,6 +108,12 @@ LayoutHandle::~LayoutHandle ()
   }
 
   file_watcher ().remove_file (filename ());
+}
+
+void
+LayoutHandle::on_technology_changed ()
+{
+  technology_changed_event ();
 }
 
 void 
@@ -232,7 +240,6 @@ LayoutHandle::set_tech_name (const std::string &tn)
 {
   if (mp_layout && tn != tech_name ()) {
     mp_layout->set_technology_name (tn);
-    technology_changed_event ();
   }
 }
 

--- a/src/laybasic/laybasic/layCellView.h
+++ b/src/laybasic/laybasic/layCellView.h
@@ -115,10 +115,7 @@ public:
    *
    *  An empty name indicates the default technology should be used.
    */
-  const std::string &tech_name () const
-  {
-    return m_tech_name;
-  }
+  const std::string &tech_name () const;
 
   /**
    *  @brief Applies the given technology
@@ -300,7 +297,6 @@ private:
   int m_ref_count;
   std::string m_name;
   std::string m_filename;
-  std::string m_tech_name;
   bool m_dirty;
   db::SaveLayoutOptions m_save_options;
   bool m_save_options_valid;

--- a/src/laybasic/laybasic/layCellView.h
+++ b/src/laybasic/laybasic/layCellView.h
@@ -302,6 +302,8 @@ private:
   bool m_save_options_valid;
   db::LoadLayoutOptions m_load_options;
 
+  void on_technology_changed ();
+
   static std::map <std::string, LayoutHandle *> ms_dict;
   static tl::FileSystemWatcher *mp_file_watcher;
 };

--- a/src/laybasic/laybasic/layEditorOptionsPage.cc
+++ b/src/laybasic/laybasic/layEditorOptionsPage.cc
@@ -24,6 +24,7 @@
 #include "tlInternational.h"
 #include "layEditorOptionsPage.h"
 #include "layEditorOptionsPages.h"
+#include "layLayoutView.h"
 
 namespace lay
 {
@@ -31,15 +32,39 @@ namespace lay
 // ------------------------------------------------------------------
 //  EditorOptionsPage implementation
 
-EditorOptionsPage::EditorOptionsPage (lay::Dispatcher *dispatcher)
-  : QWidget (0), mp_owner (0), m_active (true), mp_plugin_declaration (0), mp_dispatcher (dispatcher)
+EditorOptionsPage::EditorOptionsPage (lay::LayoutView *view, lay::Dispatcher *dispatcher)
+  : QWidget (0), mp_owner (0), m_active (true), mp_plugin_declaration (0), mp_dispatcher (dispatcher), mp_view (view)
 {
-  //  nothing yet ..
+  attach_events ();
 }
 
 EditorOptionsPage::~EditorOptionsPage ()
 {
   set_owner (0);
+}
+
+void
+EditorOptionsPage::attach_events ()
+{
+  detach_from_all_events ();
+  view ()->active_cellview_changed_event.add (this, &EditorOptionsPage::on_active_cellview_changed);
+  int cv_index = view ()->active_cellview_index ();
+  if (cv_index >= 0) {
+    view ()->cellview (cv_index)->technology_changed_event.add (this, &EditorOptionsPage::on_technology_changed);
+  }
+}
+
+void
+EditorOptionsPage::on_active_cellview_changed ()
+{
+  active_cellview_changed ();
+  attach_events ();
+}
+
+void
+EditorOptionsPage::on_technology_changed ()
+{
+  technology_changed (view ()->active_cellview_ref ()->tech_name ());
 }
 
 void

--- a/src/laybasic/laybasic/layEditorOptionsPage.h
+++ b/src/laybasic/laybasic/layEditorOptionsPage.h
@@ -25,6 +25,8 @@
 
 #include "laybasicCommon.h"
 
+#include "tlObject.h"
+
 #include <QWidget>
 
 namespace lay
@@ -32,19 +34,21 @@ namespace lay
 
 class PluginDeclaration;
 class Dispatcher;
+class LayoutView;
 class Plugin;
+class CellView;
 class EditorOptionsPages;
 
 /**
  *  @brief The base class for a object properties page
  */
 class LAYBASIC_PUBLIC EditorOptionsPage
-  : public QWidget
+  : public QWidget, public tl::Object
 {
 Q_OBJECT
 
 public:
-  EditorOptionsPage (lay::Dispatcher *dispatcher);
+  EditorOptionsPage (lay::LayoutView *view, lay::Dispatcher *dispatcher);
   virtual ~EditorOptionsPage ();
 
   virtual std::string title () const = 0;
@@ -72,11 +76,24 @@ protected:
     return mp_dispatcher;
   }
 
+  lay::LayoutView *view () const
+  {
+    return mp_view;
+  }
+
+  virtual void active_cellview_changed () { }
+  virtual void technology_changed (const std::string & /*tech*/) { }
+
 private:
   EditorOptionsPages *mp_owner;
   bool m_active;
   const lay::PluginDeclaration *mp_plugin_declaration;
   lay::Dispatcher *mp_dispatcher;
+  lay::LayoutView *mp_view;
+
+  void on_active_cellview_changed ();
+  void on_technology_changed ();
+  void attach_events ();
 };
 
 }

--- a/src/laybasic/laybasic/layWidgets.h
+++ b/src/laybasic/laybasic/layWidgets.h
@@ -26,6 +26,8 @@
 
 #include "laybasicCommon.h"
 
+#include "tlObject.h"
+
 #include <QPushButton>
 #include <QComboBox>
 #include <QLabel>
@@ -170,7 +172,7 @@ private:
  *  This combo box allows selecting a (physical) layer from a layout
  */
 class LAYBASIC_PUBLIC LayerSelectionComboBox
-  : public QComboBox
+  : public QComboBox, public tl::Object
 {
 Q_OBJECT
 
@@ -249,6 +251,7 @@ protected slots:
 private:
   LayerSelectionComboBoxPrivateData *mp_private;
 
+  void on_layer_list_changed (int);
   void update_layer_list ();
 };
 

--- a/src/plugins/streamers/gds2/db_plugin/dbGDS2ReaderBase.cc
+++ b/src/plugins/streamers/gds2/db_plugin/dbGDS2ReaderBase.cc
@@ -358,17 +358,21 @@ GDS2ReaderBase::do_read (db::Layout &layout)
 
       db::cell_index_type cell_index = make_cell (layout, m_cellname);
 
-      db::Cell *cell = &layout.cell (cell_index);
-
+      bool ignore_cell = false;
       std::map <tl::string, std::vector <std::string> >::const_iterator ctx = m_context_info.find (m_cellname);
       if (ctx != m_context_info.end ()) {
         GDS2ReaderLayerMapping layer_mapping (this, &layout, m_create_layers);
         if (layout.recover_proxy_as (cell_index, ctx->second.begin (), ctx->second.end (), &layer_mapping)) {
           //  ignore everything in that cell since it is created by the import:
-          cell = 0;
+          ignore_cell = true;
         }
       }
       
+      db::Cell *cell = 0;
+      if (! ignore_cell) {
+        cell = &layout.cell (cell_index);
+      }
+
       long attr = 0;
       db::PropertiesRepository::properties_set cell_properties;
 

--- a/src/plugins/streamers/lefdef/db_plugin/dbLEFDEFImporter.cc
+++ b/src/plugins/streamers/lefdef/db_plugin/dbLEFDEFImporter.cc
@@ -43,11 +43,7 @@ std::string correct_path (const std::string &fn, const db::Layout &layout, const
 
     //  if a technology is given and the file can be found in the technology's base path, take it
     //  from there.
-    std::string tn = layout.meta_info_value ("technology");
-    const db::Technology *tech = 0;
-    if (! tn.empty ()) {
-      tech = db::Technologies::instance ()->technology_by_name (tn);
-    }
+    const db::Technology *tech = layout.technology ();
 
     if (tech && ! tech->base_path ().empty ()) {
       std::string new_fn = tl::combine_path (tech->base_path (), fn);

--- a/src/plugins/streamers/magic/db_plugin/dbMAGReader.cc
+++ b/src/plugins/streamers/magic/db_plugin/dbMAGReader.cc
@@ -74,11 +74,7 @@ MAGReader::read (db::Layout &layout, const db::LoadLayoutOptions &options)
 {
   prepare_layers ();
 
-  mp_klayout_tech = 0;
-  std::string klayout_tech_name = layout.meta_info_value ("technology");
-  if (! klayout_tech_name.empty () && db::Technologies::instance ()->has_technology (klayout_tech_name)) {
-    mp_klayout_tech = db::Technologies::instance ()->technology_by_name (klayout_tech_name);
-  }
+  mp_klayout_tech = layout.technology ();
 
   const db::MAGReaderOptions &specific_options = options.get_options<db::MAGReaderOptions> ();
   m_lambda = specific_options.lambda;

--- a/src/plugins/streamers/magic/db_plugin/dbMAGReader.h
+++ b/src/plugins/streamers/magic/db_plugin/dbMAGReader.h
@@ -145,7 +145,7 @@ private:
   std::map<std::string, std::string> m_use_lib_paths;
   db::VCplxTrans m_dbu_trans_inv;
   std::string m_tech;
-  db::Technology *mp_klayout_tech;
+  const db::Technology *mp_klayout_tech;
 
   void do_read (db::Layout &layout, db::cell_index_type to_cell, tl::TextInputStream &stream);
   void do_read_part (db::Layout &layout, db::cell_index_type cell_index, tl::TextInputStream &stream);

--- a/src/plugins/streamers/magic/db_plugin/dbMAGWriter.cc
+++ b/src/plugins/streamers/magic/db_plugin/dbMAGWriter.cc
@@ -122,7 +122,7 @@ MAGWriter::write_dummmy_top (const std::set<db::cell_index_type> &cell_set, cons
 
   std::string tech = m_options.tech;
   if (tech.empty ()) {
-    tech = layout.meta_info_value ("technology");
+    tech = layout.technology_name ();
   }
   if (! tech.empty ()) {
     os << "tech " << make_string (tl::to_lower_case (tech)) << "\n";
@@ -177,7 +177,7 @@ MAGWriter::do_write_cell (db::cell_index_type ci, const std::vector <std::pair <
 
   std::string tech = m_options.tech;
   if (tech.empty ()) {
-    tech = layout.meta_info_value ("technology");
+    tech = layout.technology_name ();
   }
   if (! tech.empty ()) {
     os << "tech " << make_string (tl::to_lower_case (tech)) << "\n";


### PR DESCRIPTION
This is much more than just the fix, it's a much more consistent technology management:
- Visibility of libraries now is confined to current technology
- Switching the technology with update the cells
- "cold proxies" allow keeping defunct references (even over GDS/OASIS streams) and allows restoring them when possible
- Technology is a property of the layout now
- Some bugs in the PCell properties dialog have been fixed (e.g. layer combo boxes were not updated when layers got added)
- Undo/redo for "apply technology"