### PR TITLE
Fixed #864 (Shapes#copy_shapes does not support undo/redo)

### DIFF
--- a/src/db/db/dbCell.cc
+++ b/src/db/db/dbCell.cc
@@ -333,21 +333,13 @@ void
 Cell::copy (unsigned int src, unsigned int dest)
 {
   if (src != dest) {
-    db::Shapes &dest_shapes = shapes (dest);
-    db::Cell::shape_iterator src_shape = begin (src, db::Shapes::shape_iterator::All);
-    while (! src_shape.at_end ()) {
-      dest_shapes.insert (*src_shape);
-      ++src_shape;
-    }
+    shapes (dest).insert (shapes (src));
   } else {
     //  When duplicating the layer, first create a copy to avoid problems with non-stable containers
     //  Hint: using the assignment and not the copy ctor does not copy the db::Manager association.
     db::Shapes shape_copy;
     shape_copy = shapes (src);
-    db::Shapes &dest_shapes = shapes (dest);
-    for (db::Cell::shape_iterator src_shape = shape_copy.begin (db::Shapes::shape_iterator::All); ! src_shape.at_end (); ++src_shape) {
-      dest_shapes.insert (*src_shape);
-    }
+    shapes (dest).insert (shape_copy);
   }
 }
 

--- a/src/db/db/dbShapes.cc
+++ b/src/db/db/dbShapes.cc
@@ -132,6 +132,36 @@ layer_op<Sh, StableTag>::erase (Shapes *shapes)
 }
 
 // ---------------------------------------------------------------------------------------
+//  FullLayerOp implementation
+
+void
+FullLayerOp::insert (Shapes *shapes)
+{
+  for (tl::vector<LayerBase *>::iterator l = shapes->get_layers ().end (); l != shapes->get_layers ().begin (); ) {
+    --l;
+    if (*l == mp_layer) {
+      return;
+    }
+  }
+  shapes->get_layers ().push_back (mp_layer);
+  shapes->invalidate_state ();
+  m_owns_layer = false;
+}
+
+void
+FullLayerOp::erase (Shapes *shapes)
+{
+  for (tl::vector<LayerBase *>::iterator l = shapes->get_layers ().begin (); l != shapes->get_layers ().end (); ++l) {
+    if (*l == mp_layer) {
+      shapes->get_layers ().erase (l);
+      shapes->invalidate_state ();
+      m_owns_layer = true;
+      break;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------------------
 //  Shapes implementation
 
 Shapes &
@@ -156,10 +186,16 @@ Shapes::layout () const
 }
 
 void
+Shapes::check_is_editable_for_undo_redo () const
+{
+  if (! is_editable ()) {
+    throw tl::Exception (tl::to_string (tr ("No undo/redo support on non-editable shape lists")));
+  }
+}
+
+void
 Shapes::insert (const Shapes &d)
 {
-  //  no undo support for this currently
-  tl_assert (! manager () || ! manager ()->transacting ());
   do_insert (d);
 }
 
@@ -175,10 +211,18 @@ Shapes::do_insert (const Shapes &d)
 
     //  both shape containers reside in the same repository space - simply copy
     if (m_layers.empty ()) {
+
       m_layers.reserve (d.m_layers.size ());
       for (tl::vector<LayerBase *>::const_iterator l = d.m_layers.begin (); l != d.m_layers.end (); ++l) {
-        m_layers.push_back ((*l)->clone (this, manager ()));
+        m_layers.push_back ((*l)->clone ());
+        if (manager () && manager ()->transacting ()) {
+          check_is_editable_for_undo_redo ();
+          manager ()->queue (this, new FullLayerOp (true, m_layers.back ()));
+        }
       }
+
+      invalidate_state ();
+
     } else {
       for (tl::vector<LayerBase *>::const_iterator l = d.m_layers.begin (); l != d.m_layers.end (); ++l) {
         (*l)->insert_into (this);
@@ -939,12 +983,19 @@ void
 Shapes::clear ()
 {
   if (!m_layers.empty ()) {
+
     for (tl::vector<LayerBase *>::const_iterator l = m_layers.begin (); l != m_layers.end (); ++l) {
-      (*l)->clear (this, manager ());
-      delete *l;
+      if (manager () && manager ()->transacting ()) {
+        check_is_editable_for_undo_redo ();
+        manager ()->queue (this, new FullLayerOp (false, (*l)));
+      } else {
+        delete *l;
+      }
     }
+
     invalidate_state ();  //  HINT: must come before the change is done!
     m_layers.clear ();
+
   }
 }
 
@@ -1104,6 +1155,7 @@ Shapes::replace_prop_id (const Sh *pos, db::properties_id_type prop_id)
       throw tl::Exception (tl::to_string (tr ("Function 'replace' is permitted only in editable mode")));
     }
     if (manager () && manager ()->transacting ()) {
+      check_is_editable_for_undo_redo ();
       db::layer_op<Sh, db::stable_layer_tag>::queue_or_append (manager (), this, false /*not insert*/, *pos);
     }
     invalidate_state ();  //  HINT: must come before the change is done!
@@ -1123,6 +1175,7 @@ Shapes::replace_prop_id_iter (typename db::object_tag<Sh>, const Iter &iter, db:
   }
 
   if (manager () && manager ()->transacting ()) {
+    check_is_editable_for_undo_redo ();
     db::layer_op<Sh, db::stable_layer_tag>::queue_or_append (manager (), this, false /*not insert*/, *iter);
   }
   db::object_with_properties <Sh> wp (*iter, prop_id);
@@ -1190,6 +1243,7 @@ Shapes::replace_member_with_props (typename db::object_tag<Sh> tag, const shape_
       //  simple replace case
 
       if (manager () && manager ()->transacting ()) {
+        check_is_editable_for_undo_redo ();
         db::layer_op<Sh, db::stable_layer_tag>::queue_or_append (manager (), this, false /*not insert*/, *ref.basic_ptr (tag));
       }
 
@@ -1214,6 +1268,7 @@ Shapes::replace_member_with_props (typename db::object_tag<Sh> tag, const shape_
     if (! ref.with_props ()) {
 
       if (manager () && manager ()->transacting ()) {
+        check_is_editable_for_undo_redo ();
         db::layer_op<Sh, db::stable_layer_tag>::queue_or_append (manager (), this, false /*not insert*/, *ref.basic_ptr (tag));
       }
 
@@ -1234,6 +1289,7 @@ Shapes::replace_member_with_props (typename db::object_tag<Sh> tag, const shape_
         get_layer<Sh, db::stable_layer_tag> ().replace (ref.basic_iter (tag), sh);
 
         if (manager () && manager ()->transacting ()) {
+          check_is_editable_for_undo_redo ();
           db::layer_op<Sh, db::stable_layer_tag>::queue_or_append (manager (), this, true /*insert*/, sh);
         }
 
@@ -1242,6 +1298,7 @@ Shapes::replace_member_with_props (typename db::object_tag<Sh> tag, const shape_
     } else {
 
       if (manager () && manager ()->transacting ()) {
+        check_is_editable_for_undo_redo ();
         db::layer_op<db::object_with_properties<Sh>, db::stable_layer_tag>::queue_or_append (manager (), this, false /*not insert*/, *ref.basic_ptr (typename db::object_with_properties<Sh>::tag ()));
       }
 

--- a/src/db/db/dbShapes.h
+++ b/src/db/db/dbShapes.h
@@ -487,6 +487,7 @@ public:
   virtual bool empty () const = 0;
   virtual void sort () = 0;
   virtual LayerBase *clone () const = 0;
+  virtual bool is_same_type (const LayerBase *other) const = 0;
   virtual void translate_into (Shapes *target, GenericRepository &rep, ArrayRepository &array_rep) const = 0;
   virtual void translate_into (Shapes *target, GenericRepository &rep, ArrayRepository &array_rep, pm_delegate_type &pm) const = 0;
   virtual void transform_into (Shapes *target, const Trans &trans, GenericRepository &rep, ArrayRepository &array_rep) const = 0;

--- a/src/db/db/dbShapes.h
+++ b/src/db/db/dbShapes.h
@@ -486,8 +486,7 @@ public:
   virtual size_t size () const = 0;
   virtual bool empty () const = 0;
   virtual void sort () = 0;
-  virtual void clear (Shapes *target, db::Manager *manager) = 0;
-  virtual LayerBase *clone (Shapes *target, db::Manager *manager) const = 0;
+  virtual LayerBase *clone () const = 0;
   virtual void translate_into (Shapes *target, GenericRepository &rep, ArrayRepository &array_rep) const = 0;
   virtual void translate_into (Shapes *target, GenericRepository &rep, ArrayRepository &array_rep, pm_delegate_type &pm) const = 0;
   virtual void transform_into (Shapes *target, const Trans &trans, GenericRepository &rep, ArrayRepository &array_rep) const = 0;
@@ -682,6 +681,8 @@ public:
 
     if (manager () && manager ()->transacting ()) {
 
+      check_is_editable_for_undo_redo ();
+
       tl::ident_map<db::properties_id_type> pm;
 
       //  for undo support iterate over the elements
@@ -721,6 +722,8 @@ public:
 
     if (manager () && manager ()->transacting ()) {
 
+      check_is_editable_for_undo_redo ();
+
       //  for undo support iterate over the elements
       for (ShapeIterator s = d.begin (ShapeIterator::All); ! s.at_end (); ++s) {
         insert (*s, trans, pm);
@@ -759,6 +762,8 @@ public:
     tl_assert (&d != this);
 
     if (manager () && manager ()->transacting ()) {
+
+      check_is_editable_for_undo_redo ();
 
       //  for undo support iterate over the elements
       for (ShapeIterator s = d.begin (ShapeIterator::All); ! s.at_end (); ++s) {
@@ -806,6 +811,7 @@ public:
   shape_type insert (const Sh &sh)
   {
     if (manager () && manager ()->transacting ()) {
+      check_is_editable_for_undo_redo ();
       if (is_editable ()) {
         db::layer_op<Sh, db::stable_layer_tag>::queue_or_append (manager (), this, true /*insert*/, sh);
       } else {
@@ -849,6 +855,7 @@ public:
 
       //  insert the array as a whole in non-editable mode
       if (manager () && manager ()->transacting ()) {
+        check_is_editable_for_undo_redo ();
         db::layer_op<db::array<Obj, Trans>, db::unstable_layer_tag>::queue_or_append (manager (), this, true /*insert*/, arr);
       }
       invalidate_state ();  //  HINT: must come before the change is done!
@@ -886,6 +893,7 @@ public:
 
       //  insert the array as a whole in non-editable mode
       if (manager () && manager ()->transacting ()) {
+        check_is_editable_for_undo_redo ();
         db::layer_op< db::object_with_properties< db::array<Obj, Trans> >, db::unstable_layer_tag>::queue_or_append (manager (), this, true /*insert*/, arr);
       }
       invalidate_state ();  //  HINT: must come before the change is done!
@@ -906,6 +914,7 @@ public:
   {
     typedef typename std::iterator_traits <Iter>::value_type value_type;
     if (manager () && manager ()->transacting ()) {
+      check_is_editable_for_undo_redo ();
       if (is_editable ()) {
         db::layer_op<value_type, db::stable_layer_tag>::queue_or_append (manager (), this, true /*insert*/, from, to);
       } else {
@@ -1001,6 +1010,7 @@ public:
       throw tl::Exception (tl::to_string (tr ("Function 'erase' is permitted only in editable mode")));
     }
     if (manager () && manager ()->transacting ()) {
+      check_is_editable_for_undo_redo ();
       db::layer_op<typename Tag::object_type, StableTag>::queue_or_append (manager (), this, false /*not insert*/, *pos);
     }
     invalidate_state ();  //  HINT: must come before the change is done!
@@ -1064,6 +1074,7 @@ public:
       throw tl::Exception (tl::to_string (tr ("Function 'erase' is permitted only in editable mode")));
     }
     if (manager () && manager ()->transacting ()) {
+      check_is_editable_for_undo_redo ();
       db::layer_op<typename Tag::object_type, StableTag>::queue_or_append (manager (), this, false /*not insert*/, from, to);
     }
     invalidate_state ();  //  HINT: must come before the change is done!
@@ -1090,6 +1101,7 @@ public:
       throw tl::Exception (tl::to_string (tr ("Function 'erase' is permitted only in editable mode")));
     }
     if (manager () && manager ()->transacting ()) {
+      check_is_editable_for_undo_redo ();
       db::layer_op<typename Tag::object_type, StableTag>::queue_or_append (manager (), this, false /*not insert*/, first, last, true /*dummy*/);
     }
     invalidate_state ();  //  HINT: must come before the change is done!
@@ -1480,12 +1492,20 @@ public:
 
 private:
   friend class ShapeIterator;
+  friend class FullLayerOp;
 
   tl::vector<LayerBase *> m_layers;
   db::Cell *mp_cell;  //  HINT: contains "dirty" in bit 0 and "editable" in bit 1
 
   void invalidate_state ();
   void do_insert (const Shapes &d);
+  void check_is_editable_for_undo_redo () const;
+
+  //  gets the layers array
+  tl::vector<LayerBase *> &get_layers ()
+  {
+    return m_layers;
+  }
 
   //  extract dirty flag from mp_cell
   bool is_dirty () const 
@@ -1604,6 +1624,7 @@ private:
     for (typename Array::iterator a = arr.begin (); ! a.at_end (); ++a) {
       res_wp_type obj_wp (*a * arr.object (), arr.properties_id ());
       if (manager () && manager ()->transacting ()) {
+        check_is_editable_for_undo_redo ();
         db::layer_op<res_wp_type, db::stable_layer_tag>::queue_or_append (manager (), this, true /*insert*/, obj_wp);
       }
       l.insert (obj_wp);
@@ -1618,6 +1639,7 @@ private:
     db::layer<ResType, db::stable_layer_tag> &l = get_layer<ResType, db::stable_layer_tag> ();
     for (typename Array::iterator a = arr.begin (); ! a.at_end (); ++a) {
       if (manager () && manager ()->transacting ()) {
+        check_is_editable_for_undo_redo ();
         db::layer_op<ResType, db::stable_layer_tag>::queue_or_append (manager (), this, true /*insert*/, *a * arr.object ());
       }
       l.insert (*a * arr.object ());
@@ -1738,6 +1760,51 @@ public:
 private:
   bool m_insert;
   std::vector<Sh> m_shapes;
+
+  void insert (Shapes *shapes);
+  void erase (Shapes *shapes);
+};
+
+class FullLayerOp
+  : public LayerOpBase
+{
+public:
+  FullLayerOp (bool insert, LayerBase *layer)
+    : m_insert (insert), mp_layer (layer), m_owns_layer (! insert)
+  {
+    //  .. nothing yet ..
+  }
+
+  ~FullLayerOp ()
+  {
+    if (m_owns_layer) {
+      delete mp_layer;
+      mp_layer = 0;
+    }
+  }
+
+  virtual void undo (Shapes *shapes)
+  {
+    if (m_insert) {
+      erase (shapes);
+    } else {
+      insert (shapes);
+    }
+  }
+
+  virtual void redo (Shapes *shapes)
+  {
+    if (m_insert) {
+      insert (shapes);
+    } else {
+      erase (shapes);
+    }
+  }
+
+private:
+  bool m_insert;
+  LayerBase *mp_layer;
+  bool m_owns_layer;
 
   void insert (Shapes *shapes);
   void erase (Shapes *shapes);

--- a/src/db/db/dbShapes2.cc
+++ b/src/db/db/dbShapes2.cc
@@ -753,23 +753,10 @@ inline unsigned int iterator_type_mask (db::object_tag< db::object_with_properti
 }
 
 template <class Sh, class StableTag>
-void 
-layer_class<Sh, StableTag>::clear (Shapes *target, db::Manager *manager)
-{
-  if (manager && manager->transacting ()) {
-    manager->queue (target, new db::layer_op<Sh, StableTag> (false /*not insert*/, m_layer.begin (), m_layer.end ()));
-  }
-  m_layer.clear ();
-}
-
-template <class Sh, class StableTag>
 LayerBase *
-layer_class<Sh, StableTag>::clone (Shapes *target, db::Manager *manager) const 
+layer_class<Sh, StableTag>::clone () const
 {
   layer_class<Sh, StableTag> *r = new layer_class<Sh, StableTag> ();
-  if (manager && manager->transacting ()) {
-    manager->queue (target, new db::layer_op<Sh, StableTag> (true /*insert*/, m_layer.begin (), m_layer.end ()));
-  }
   r->m_layer = m_layer;
   return r;
 }
@@ -877,7 +864,6 @@ layer_class<Sh, StableTag>::deref_and_transform_into (Shapes *target, const Tran
 {
   deref_and_transform_into_shapes deref_op (target);
   for (typename layer_type::iterator s = m_layer.begin (); s != m_layer.end (); ++s) {
-
     deref_op (*s, trans, pm);
   }
 }

--- a/src/db/db/dbShapes2.h
+++ b/src/db/db/dbShapes2.h
@@ -141,6 +141,11 @@ public:
     m_layer.sort ();
   }
 
+  virtual bool is_same_type (const LayerBase *other) const
+  {
+    return dynamic_cast<const layer_class<Sh, StableTag> *> (other);
+  }
+
   virtual LayerBase *clone () const;
   virtual void translate_into (Shapes *target, GenericRepository &rep, ArrayRepository &array_rep) const;
   virtual void translate_into (Shapes *target, GenericRepository &rep, ArrayRepository &array_rep, pm_delegate_type &pm) const;

--- a/src/db/db/dbShapes2.h
+++ b/src/db/db/dbShapes2.h
@@ -141,8 +141,7 @@ public:
     m_layer.sort ();
   }
 
-  virtual void clear (Shapes *target, db::Manager *manager);
-  virtual LayerBase *clone (Shapes *target, db::Manager *manager) const;
+  virtual LayerBase *clone () const;
   virtual void translate_into (Shapes *target, GenericRepository &rep, ArrayRepository &array_rep) const;
   virtual void translate_into (Shapes *target, GenericRepository &rep, ArrayRepository &array_rep, pm_delegate_type &pm) const;
   virtual void transform_into (Shapes *target, const Trans &trans, GenericRepository &rep, ArrayRepository &array_rep) const;

--- a/src/db/db/dbShapes3.cc
+++ b/src/db/db/dbShapes3.cc
@@ -344,6 +344,7 @@ Shapes::erase_shape_by_tag_ws (Tag /*tag*/, StableTag /*stable_tag*/, const shap
     db::layer<typename Tag::object_type, StableTag> &l = get_layer<typename Tag::object_type, StableTag> ();
     typename db::layer<typename Tag::object_type, StableTag>::iterator i = iterator_from_shape (l, shape);
     if (manager () && manager ()->transacting ()) {
+      check_is_editable_for_undo_redo ();
       db::layer_op<typename Tag::object_type, StableTag>::queue_or_append (manager (), this, false /*not insert*/, *i);
     }
     invalidate_state ();  //  HINT: must come before the change is done!
@@ -356,6 +357,7 @@ Shapes::erase_shape_by_tag_ws (Tag /*tag*/, StableTag /*stable_tag*/, const shap
     db::layer<swp_type, StableTag> &l = get_layer<swp_type, StableTag> ();
     typename db::layer<swp_type, StableTag>::iterator i = iterator_from_shape (l, shape);
     if (manager () && manager ()->transacting ()) {
+      check_is_editable_for_undo_redo ();
       db::layer_op<swp_type, StableTag>::queue_or_append (manager (), this, false /*not insert*/, *i);
     }
     invalidate_state ();  //  HINT: must come before the change is done!

--- a/src/db/db/gsiDeclDbShapes.cc
+++ b/src/db/db/gsiDeclDbShapes.cc
@@ -246,12 +246,7 @@ static void insert_iter_with_trans (db::Shapes *sh, const db::RecursiveShapeIter
 
 static void insert_shapes (db::Shapes *sh, const db::Shapes &s)
 {
-  //  NOTE: if the source (r) is from the same layout than the shapes live in, we better
-  //  lock the layout against updates while inserting
-  db::LayoutLocker locker (sh->layout ());
-  for (db::Shapes::shape_iterator i = s.begin (db::ShapeIterator::All); !i.at_end(); ++i) {
-    sh->insert (*i);
-  }
+  sh->insert (s);
 }
 
 static void insert_shapes_with_flags (db::Shapes *sh, const db::Shapes &s, unsigned int flags)

--- a/src/db/unit_tests/dbLayoutTests.cc
+++ b/src/db/unit_tests/dbLayoutTests.cc
@@ -557,9 +557,13 @@ TEST(5)
   EXPECT_EQ (l2s (l), "begin_lib 0.001\nbegin_cell {LIBCELL}\nbox 1 0 {0 0} {100 200}\nend_cell\nend_lib\n");
 
   //  switch to another LIBCELL, this time using layer 2/0
-  m.transaction ("switch_to_b");
-  l.set_technology_name ("B");
-  m.commit ();
+  if (l.is_editable ()) {
+    m.transaction ("switch_to_b");
+    l.set_technology_name ("B");
+    m.commit ();
+  } else {
+    l.set_technology_name ("B");
+  }
 
   EXPECT_EQ (l.technology_name (), "B");
   cell = &l.cell (l.cell_by_name ("LIBCELL").second);
@@ -609,9 +613,13 @@ TEST(6)
   info.pcell_parameters ["npoints"] = tl::Variant (8);
   info.pcell_parameters ["layer"] = tl::Variant (db::LayerProperties (1, 0));
 
-  m.transaction ("import");
+  if (l.is_editable ()) {
+    m.transaction ("import");
+  }
   cell = l.recover_proxy (info);
-  m.commit ();
+  if (l.is_editable ()) {
+    m.commit ();
+  }
   EXPECT_EQ (cell->get_qualified_name (), "Basic.CIRCLE");
   EXPECT_EQ (cell->get_basic_name (), "CIRCLE");
   EXPECT_EQ (cell->get_display_name (), "Basic.CIRCLE(l=1/0,r=10,n=8)");
@@ -622,10 +630,14 @@ TEST(6)
   l.get_context_info (cell->cell_index (), info2);
   info2.pcell_parameters ["actual_radius"] = tl::Variant (5.0);
 
-  m.transaction ("modify");
+  if (l.is_editable ()) {
+    m.transaction ("modify");
+  }
   db::cell_index_type ci = cell->cell_index ();
   l.recover_proxy_as (ci, info2);
-  m.commit ();
+  if (l.is_editable ()) {
+    m.commit ();
+  }
   cell = &l.cell (ci);
   EXPECT_EQ (cell->get_qualified_name (), "Basic.CIRCLE");
   EXPECT_EQ (cell->get_basic_name (), "CIRCLE");

--- a/testdata/ruby/dbLayout.rb
+++ b/testdata/ruby/dbLayout.rb
@@ -901,103 +901,98 @@ class DBLayout_TestClass < TestBase
     assert_equal(dump_layer(lll, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (1200,0;2200,1100); (1200,0;2200,1100); (-1200,0;-100,1000); (-1200,0;-100,1000)")
     assert_equal(dump_layer(lll, 1, "c0"), "(0,100;1000,1200); (100,0;1100,1100)")
 
-    # TODO: undo tests crashes in non-editable mode! Should be checked properly.
-    if lll.is_editable?
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, false)
+    assert_equal(m.transaction_for_undo, "9")
 
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, false)
-      assert_equal(m.transaction_for_undo, "9")
+    m.undo
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_undo, "8")
 
-      m.undo
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_undo, "8")
+    assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (1200,0;2200,1100); (1200,0;2200,1100); (-1200,0;-100,1000); (-1200,0;-100,1000)")
+    assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (100,0;1100,1100)")
 
-      assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (1200,0;2200,1100); (1200,0;2200,1100); (-1200,0;-100,1000); (-1200,0;-100,1000)")
-      assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (100,0;1100,1100)")
+    m.undo
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_undo, "7")
 
-      m.undo
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_undo, "7")
+    assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (1200,0;2200,1100); (-1200,0;-100,1000)")
+    assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (100,0;1100,1100)")
 
-      assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (1200,0;2200,1100); (-1200,0;-100,1000)")
-      assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (100,0;1100,1100)")
+    m.undo
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_undo, "6")
 
-      m.undo
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_undo, "6")
+    assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (1200,0;2200,1100); (-1200,0;-100,1000)")
+    assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100)")
 
-      assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (1200,0;2200,1100); (-1200,0;-100,1000)")
-      assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100)")
+    m.undo
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_undo, "5")
 
-      m.undo
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_undo, "5")
+    assert_equal(dump_layer(l, 0, "c0"), "(1200,0;2200,1100); (-1200,0;-100,1000)")
+    assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100)")
 
-      assert_equal(dump_layer(l, 0, "c0"), "(1200,0;2200,1100); (-1200,0;-100,1000)")
-      assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100)")
+    m.undo
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_undo, "4")
 
-      m.undo
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_undo, "4")
+    assert_equal(dump_layer(l, 0, "c0"), "")
+    assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
 
-      assert_equal(dump_layer(l, 0, "c0"), "")
-      assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
+    m.undo
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_undo, "3")
 
-      m.undo
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_undo, "3")
+    assert_equal(dump_layer(l, 1, "c0"), "")
+    assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
 
-      assert_equal(dump_layer(l, 1, "c0"), "")
-      assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
+    m.undo
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_undo, "2")
 
-      m.undo
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_undo, "2")
+    assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
+    assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
 
-      assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
-      assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
+    m.undo
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_undo, "1")
 
-      m.undo
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_undo, "1")
+    assert_equal(dump_layer(l, 0, "c0"), "")
+    assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
 
-      assert_equal(dump_layer(l, 0, "c0"), "")
-      assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
+    m.undo
+    assert_equal(m.has_undo?, false)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_redo, "1")
 
-      m.undo
-      assert_equal(m.has_undo?, false)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_redo, "1")
+    assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
+    assert_equal(dump_layer(l, 1, "c0"), "")
 
-      assert_equal(dump_layer(l, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
-      assert_equal(dump_layer(l, 1, "c0"), "")
+    m.redo
+    assert_equal(m.has_undo?, true)
+    assert_equal(m.has_redo?, true)
+    assert_equal(m.transaction_for_redo, "2")
 
-      m.redo
-      assert_equal(m.has_undo?, true)
-      assert_equal(m.has_redo?, true)
-      assert_equal(m.transaction_for_redo, "2")
+    assert_equal(dump_layer(l, 0, "c0"), "")
+    assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
 
-      assert_equal(dump_layer(l, 0, "c0"), "")
-      assert_equal(dump_layer(l, 1, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (100,0;1100,1100); (1200,0;2200,1100); (-1200,0;-100,1000)")
+    assert_equal(dump_layer(ll, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (1200,0;2200,1100); (1200,0;2200,1100); (-1200,0;-100,1000); (-1200,0;-100,1000)")
+    assert_equal(dump_layer(ll, 1, "c0"), "(0,100;1000,1200); (100,0;1100,1100)")
 
-      assert_equal(dump_layer(ll, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (1200,0;2200,1100); (1200,0;2200,1100); (-1200,0;-100,1000); (-1200,0;-100,1000)")
-      assert_equal(dump_layer(ll, 1, "c0"), "(0,100;1000,1200); (100,0;1100,1100)")
+    l.destroy
+    m.destroy
 
-      l.destroy
-      m.destroy
-
-      assert_equal(dump_layer(lll, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (1200,0;2200,1100); (1200,0;2200,1100); (-1200,0;-100,1000); (-1200,0;-100,1000)")
-      assert_equal(dump_layer(lll, 1, "c0"), "(0,100;1000,1200); (100,0;1100,1100)")
-
-    end
+    assert_equal(dump_layer(lll, 0, "c0"), "(0,100;1000,1200); (0,100;1000,1200); (1200,0;2200,1100); (1200,0;2200,1100); (-1200,0;-100,1000); (-1200,0;-100,1000)")
+    assert_equal(dump_layer(lll, 1, "c0"), "(0,100;1000,1200); (100,0;1100,1100)")
 
   end
 


### PR DESCRIPTION
While doing so changed the following things too:
- Instance and Shapes methods raise an exception if not
  in editable mode and with undo/redo
- Faster and leaner undo/redo on Shapes#clear