### PR TITLE
klayout_main: Don't abort on info messages

### DIFF
--- a/src/klayout_main/klayout_main/klayout.cc
+++ b/src/klayout_main/klayout_main/klayout.cc
@@ -171,7 +171,7 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext & /*ctx*/, const Q
     abort();
   case QtInfoMsg:
     fprintf(stderr, "Info: %s\n", msg.toLocal8Bit ().constData ());
-    abort();
+    break;
   }
 }
 #else


### PR DESCRIPTION
On Wayland+GNOME, a Qt info message is printed at startup, which as far as I can tell is no cause to abort:

```
Info: Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
```

Handle `QtInfoMsg` the same way as other non-fatal messages.