### PR TITLE
Fixed #989 (cannot convert <defunct> cell to static cell)

### DIFF
--- a/src/db/db/dbColdProxy.cc
+++ b/src/db/db/dbColdProxy.cc
@@ -81,9 +81,9 @@ std::string
 ColdProxy::get_basic_name () const
 {
   if (! mp_context_info->pcell_name.empty ()) {
-    return "<defunct>" + mp_context_info->pcell_name;
+    return mp_context_info->pcell_name;
   } else if (! mp_context_info->cell_name.empty ()) {
-    return "<defunct>" + mp_context_info->cell_name;
+    return mp_context_info->cell_name;
   } else {
     return Cell::get_basic_name ();
   }

--- a/src/db/db/dbLayout.cc
+++ b/src/db/db/dbLayout.cc
@@ -2295,7 +2295,7 @@ Layout::convert_cell_to_static (db::cell_index_type ci)
   tl_assert (is_valid_cell_index (ci));
   db::cell_index_type ret_ci = ci;
 
-  if (dynamic_cast<const LibraryProxy *> (m_cell_ptrs [ci]) || dynamic_cast<const PCellVariant *> (m_cell_ptrs [ci])) {
+  if (m_cell_ptrs [ci] && m_cell_ptrs [ci]->is_proxy ()) {
 
     invalidate_hier ();
 

--- a/src/db/db/gsiDeclDbCell.cc
+++ b/src/db/db/gsiDeclDbCell.cc
@@ -1510,11 +1510,22 @@ static db::Cell *dup_cell (const db::Cell *cell)
   return new_cell;
 }
 
+static const char *cell_name (const db::Cell *cell)
+{
+  if (cell->layout ()) {
+    return cell->layout ()->cell_name (cell->cell_index ());
+  } else {
+    return "<none>";
+  }
+}
+
 static db::Point default_origin;
 
 Class<db::Cell> decl_Cell ("db", "Cell",
-  gsi::method ("name", &db::Cell::get_basic_name,
+  gsi::method_ext ("name", &cell_name,
     "@brief Gets the cell's name\n"
+    "\n"
+    "This may be an internal name for proxy cells. See \\basic_name for the formal name (PCell name or library cell name).\n"
     "\n"
     "This method has been introduced in version 0.22.\n"
   ) +

--- a/src/db/unit_tests/dbLayoutTests.cc
+++ b/src/db/unit_tests/dbLayoutTests.cc
@@ -544,7 +544,7 @@ TEST(5)
   cell = l.recover_proxy (info);
   EXPECT_EQ (dynamic_cast<db::ColdProxy *> (cell) != 0, true);
   EXPECT_EQ (cell->get_qualified_name (), "<defunct>LIB.LIBCELL");
-  EXPECT_EQ (cell->get_basic_name (), "<defunct>LIBCELL");
+  EXPECT_EQ (cell->get_basic_name (), "LIBCELL");
   EXPECT_EQ (cell->get_display_name (), "<defunct>LIB.LIBCELL");
 
   EXPECT_EQ (l2s (l), "begin_lib 0.001\nbegin_cell {LIBCELL}\nend_cell\nend_lib\n");
@@ -562,7 +562,7 @@ TEST(5)
   cell = &l.cell (l.cell_by_name ("LIBCELL").second);
   EXPECT_EQ (dynamic_cast<db::ColdProxy *> (cell) != 0, true);
   EXPECT_EQ (cell->get_qualified_name (), "<defunct>LIB.LIBCELL");
-  EXPECT_EQ (cell->get_basic_name (), "<defunct>LIBCELL");
+  EXPECT_EQ (cell->get_basic_name (), "LIBCELL");
   EXPECT_EQ (cell->get_display_name (), "<defunct>LIB.LIBCELL");
 
   //  NOTE: the box on 1/0 retained
@@ -590,7 +590,7 @@ TEST(5)
     cell = &l.cell (l.cell_by_name ("LIBCELL").second);
     EXPECT_EQ (dynamic_cast<db::ColdProxy *> (cell) != 0, true);
     EXPECT_EQ (cell->get_qualified_name (), "<defunct>LIB.LIBCELL");
-    EXPECT_EQ (cell->get_basic_name (), "<defunct>LIBCELL");
+    EXPECT_EQ (cell->get_basic_name (), "LIBCELL");
     EXPECT_EQ (cell->get_display_name (), "<defunct>LIB.LIBCELL");
     EXPECT_EQ (l2s (l), "begin_lib 0.001\nbegin_cell {LIBCELL}\nbox 1 0 {0 0} {100 200}\nend_cell\nend_lib\n");
 


### PR DESCRIPTION
Fixed some more glitches while doing so:
* cell.name (gsi) was giving "basic_name", now it's changed to the
  internal name to be consistent with "name=". The "functional name"
  is still available as "basic_name".
* The basic name was rendering "<defunct>..." for defunct cells
  and has been changed to the functional name. Otherwise this
  is not accessible.