### PR TITLE
Fixed issue-1012 with some enhancements

### DIFF
--- a/src/buddies/src/bd/bdConverterMain.cc
+++ b/src/buddies/src/bd/bdConverterMain.cc
@@ -31,6 +31,33 @@
 namespace bd
 {
 
+static std::string::size_type find_file_sep (const std::string &s, std::string::size_type from)
+{
+  std::string::size_type p1 = s.find ("+", from);
+  std::string::size_type p2 = s.find (",", from);
+
+  if (p1 == std::string::npos) {
+    return p2;
+  } else if (p2 == std::string::npos) {
+    return p1;
+  } else {
+    return p1 < p2 ? p1 : p2;
+  }
+}
+
+static std::vector<std::string> split_file_list (const std::string &infile)
+{
+  std::vector<std::string> files;
+
+  size_t p = 0;
+  for (size_t pp = 0; (pp = find_file_sep (infile, p)) != std::string::npos; p = pp + 1) {
+    files.push_back (std::string (infile, p, pp - p));
+  }
+  files.push_back (std::string (infile, p));
+
+  return files;
+}
+
 int converter_main (int argc, char *argv[], const std::string &format)
 {
   bd::GenericWriterOptions generic_writer_options;
@@ -42,7 +69,7 @@ int converter_main (int argc, char *argv[], const std::string &format)
   generic_reader_options.add_options (cmd);
 
   cmd << tl::arg ("input",  &infile,  "The input file (any format, may be gzip compressed)",
-                  "You can use '+' to supply multiple files which will be read after each other into the same layout. "
+                  "You can use '+' or ',' to supply multiple files which will be read after each other into the same layout. "
                   "This provides some cheap, but risky way of merging files. Beware of cell name conflicts.")
       << tl::arg ("output", &outfile, tl::sprintf ("The output file (%s format)", format))
     ;
@@ -57,7 +84,7 @@ int converter_main (int argc, char *argv[], const std::string &format)
     db::LoadLayoutOptions load_options;
     generic_reader_options.configure (load_options);
 
-    std::vector<std::string> files = tl::split (infile, "+");
+    std::vector<std::string> files = split_file_list (infile);
 
     for (std::vector<std::string>::const_iterator f = files.begin (); f != files.end (); ++f) {
       tl::InputStream stream (*f);

--- a/src/buddies/src/bd/bdReaderOptions.cc
+++ b/src/buddies/src/bd/bdReaderOptions.cc
@@ -647,7 +647,7 @@ GenericReaderOptions::add_options (tl::CommandLineOptions &cmd)
                     "\n"
                     "The following values are accepted for this option:\n"
                     "\n"
-                    "* 0: produce LEF geometry unless a FOREIGN cell is specified\n"
+                    "* 0: produce LEF geometry unless a FOREIGN cell is specified (the default)\n"
                     "* 1: produce LEF geometry always and ignore FOREIGN\n"
                     "* 2: Never produce LEF geometry and assume FOREIGN always\n"
                     "\n"
@@ -679,8 +679,6 @@ GenericReaderOptions::add_options (tl::CommandLineOptions &cmd)
                     "Use a comma-separated list of file names here to specify which LEF files to read. "
                     "See also '--" + m_long_prefix + "lefdef-read-lef-with-def' for an option to implicitly read all LEF files in the same "
                     "place than the DEF file.\n"
-                    "\n"
-                    "Relative paths are resolved based on the location of the DEF file which is read."
                    )
       ;
 
@@ -807,6 +805,8 @@ GenericReaderOptions::configure (db::LoadLayoutOptions &load_options)
   load_options.set_option_by_name ("lefdef_config.separate_groups", m_lefdef_separate_groups);
   load_options.set_option_by_name ("lefdef_config.map_file", m_lefdef_map_file);
   load_options.set_option_by_name ("lefdef_config.macro_resolution_mode", m_lefdef_macro_resolution_mode);
+  load_options.set_option_by_name ("lefdef_config.macro_resolution_mode", m_lefdef_macro_resolution_mode);
+  load_options.set_option_by_name ("lefdef_config.paths_relative_to_cwd", true);
 
   m_lef_layouts.clear ();
   tl::Variant lef_layout_ptrs = tl::Variant::empty_list ();

--- a/src/plugins/streamers/lefdef/db_plugin/dbLEFDEFImporter.cc
+++ b/src/plugins/streamers/lefdef/db_plugin/dbLEFDEFImporter.cc
@@ -510,8 +510,9 @@ LEFDEFReaderOptions::LEFDEFReaderOptions ()
     m_special_routing_datatype (0),
     m_separate_groups (false),
     m_map_file (),
-    m_macro_resolution_mode (false),
-    m_read_lef_with_def (true)
+    m_macro_resolution_mode (0),
+    m_read_lef_with_def (true),
+    m_paths_relative_to_cwd (false)
 {
   //  .. nothing yet ..
 }
@@ -590,6 +591,7 @@ LEFDEFReaderOptions &LEFDEFReaderOptions::operator= (const LEFDEFReaderOptions &
     m_lef_files = d.m_lef_files;
     m_macro_layout_files = d.m_macro_layout_files;
     m_read_lef_with_def = d.m_read_lef_with_def;
+    m_paths_relative_to_cwd = d.m_paths_relative_to_cwd;
     set_macro_layouts (d.macro_layouts ());
   }
   return *this;
@@ -1204,6 +1206,18 @@ LEFDEFReaderState::open_layer (db::Layout &layout, const std::string &n, LayerPu
     }
 
     m_layers.insert (std::make_pair (std::make_pair (n, LayerDetailsKey (purpose, mask)), ll));
+
+    if (ll.empty ()) {
+      tl::warn << tl::to_string (tr ("No mapping for layer")) << " '" << n << "', purpose '" << purpose_to_name (purpose) << "'" << tl::noendl;
+      if (mask > 0) {
+        tl::warn << tl::to_string (tr (" Mask ")) << mask << tl::noendl;
+      }
+      if (via_size != db::DVector ()) {
+        tl::warn << tl::to_string (tr (" Via size ")) << via_size.to_string () << tl::noendl;
+      }
+      tl::warn << tl::to_string (tr (" - layer is ignored"));
+    }
+
     return ll;
 
   } else {

--- a/src/plugins/streamers/lefdef/db_plugin/dbLEFDEFImporter.h
+++ b/src/plugins/streamers/lefdef/db_plugin/dbLEFDEFImporter.h
@@ -113,6 +113,16 @@ public:
   db::FormatSpecificReaderOptions *clone () const;
   virtual const std::string &format_name () const;
 
+  bool paths_relative_to_cwd () const
+  {
+    return m_paths_relative_to_cwd;
+  }
+
+  void set_paths_relative_to_cwd (bool f)
+  {
+    m_paths_relative_to_cwd = f;
+  }
+
   bool read_all_layers () const
   {
     return m_read_all_layers;
@@ -1003,6 +1013,7 @@ private:
   std::vector<std::string> m_lef_files;
   tl::weak_collection<db::Layout> m_macro_layouts;
   std::vector<std::string> m_macro_layout_files;
+  bool m_paths_relative_to_cwd;
 };
 
 /**

--- a/src/plugins/streamers/lefdef/db_plugin/dbLEFDEFPlugin.cc
+++ b/src/plugins/streamers/lefdef/db_plugin/dbLEFDEFPlugin.cc
@@ -116,7 +116,7 @@ LEFDEFReader::read_lefdef (db::Layout &layout, const db::LoadLayoutOptions &opti
     effective_options = *lefdef_options;
   }
 
-  db::LEFDEFReaderState state (&effective_options, layout, tl::dirname (m_stream.absolute_path ()));
+  db::LEFDEFReaderState state (&effective_options, layout, effective_options.paths_relative_to_cwd () ? std::string () : tl::dirname (m_stream.absolute_path ()));
 
   layout.dbu (effective_options.dbu ());
 

--- a/src/plugins/streamers/lefdef/db_plugin/gsiDeclDbLEFDEF.cc
+++ b/src/plugins/streamers/lefdef/db_plugin/gsiDeclDbLEFDEF.cc
@@ -108,6 +108,10 @@ static void set_pin_property_name (db::LEFDEFReaderOptions *config, const tl::Va
 
 static
 gsi::Class<db::LEFDEFReaderOptions> decl_lefdef_config ("db", "LEFDEFReaderConfiguration",
+  gsi::method ("paths_relative_to_cwd=", &db::LEFDEFReaderOptions::set_paths_relative_to_cwd, gsi::arg ("f"),
+    "@brief Sets a value indicating whether to use paths relative to cwd (true) or DEF file (false) for map or LEF files\n"
+    "This write-only attribute has been introduced in version 0.27.9."
+  ) +
   gsi::method ("layer_map", (db::LayerMap &(db::LEFDEFReaderOptions::*) ()) &db::LEFDEFReaderOptions::layer_map,
     "@brief Gets the layer map to be used for the LEF/DEF reader\n"
     "@return A reference to the layer map\n"

--- a/src/tl/tl/tlLog.cc
+++ b/src/tl/tl/tlLog.cc
@@ -371,11 +371,13 @@ protected:
 
 private:
   bool m_colorized;
+  bool m_new_line;
 };
 
 WarningChannel::WarningChannel ()
 {
   m_colorized = can_colorize (stdout);
+  m_new_line = true;
 }
 
 WarningChannel::~WarningChannel ()
@@ -393,6 +395,7 @@ void
 WarningChannel::endl ()
 {
   fputs ("\n", stdout);
+  m_new_line = true;
 }
 
 void
@@ -410,7 +413,10 @@ WarningChannel::begin ()
   if (m_colorized) {
     fputs (ANSI_BLUE, stdout);
   }
-  fputs ("Warning: ", stdout);
+  if (m_new_line) {
+    fputs ("Warning: ", stdout);
+    m_new_line = false;
+  }
 }
 
 
@@ -436,11 +442,13 @@ protected:
 
 private:
   bool m_colorized;
+  bool m_new_line;
 };
 
 ErrorChannel::ErrorChannel ()
 {
   m_colorized = can_colorize (stderr);
+  m_new_line = true;
 }
 
 ErrorChannel::~ErrorChannel ()
@@ -458,6 +466,7 @@ void
 ErrorChannel::endl ()
 {
   fputs ("\n", stderr);
+  m_new_line = true;
 }
 
 void
@@ -475,7 +484,10 @@ ErrorChannel::begin ()
   if (m_colorized) {
     fputs (ANSI_RED, stderr);
   }
-  fputs ("ERROR: ", stderr);
+  if (m_new_line) {
+    fputs ("ERROR: ", stderr);
+    m_new_line = false;
+  }
 }
 
 // ------------------------------------------------


### PR DESCRIPTION
- warning if a layer is not mapped
- "," allowed as separator between files on buddy tools (in addition to '+')
- relative paths are resolved relative to . in buddy tools (more natural on Linux)
- Fixed tl::warn and tl::error so warnings/error messages can be continued with tl::noendl.