### PR TITLE
Add setting to disable Save Needed dialog box

### DIFF
--- a/src/lay/lay/MainConfigPage7.ui
+++ b/src/lay/lay/MainConfigPage7.ui
@@ -57,7 +57,7 @@
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>If this option is enabled, the program will detect changes in layout files and ask whether to reload them</string>
+         <string>If this option is enabled, the program will detect changes in layout files and ask whether to reload them.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -109,7 +109,45 @@
       <item row="1" column="2">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>(0 for &quot;no backups)</string>
+         <string>(0 for no backups)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Disable Save Needed Dialog</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="always_exit_without_saving">
+        <property name="text">
+         <string>Always exit without saving</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>If this option is enabled, the program will not ask to save changes before exiting.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/src/lay/lay/layConfig.h
+++ b/src/lay/lay/layConfig.h
@@ -62,6 +62,7 @@ static const std::string cfg_window_geometry ("window-geometry");
 static const std::string cfg_micron_digits ("digits-micron");
 static const std::string cfg_dbu_digits ("digits-dbu");
 static const std::string cfg_assistant_bookmarks ("assistant-bookmarks");
+static const std::string cfg_always_exit_without_saving ("always-exit-without-saving");
 
 }
 

--- a/src/lay/lay/layMainConfigPages.cc
+++ b/src/lay/lay/layMainConfigPages.cc
@@ -84,6 +84,7 @@ public:
     options.push_back (std::pair<std::string, std::string> (cfg_dbu_digits, "2"));
     options.push_back (std::pair<std::string, std::string> (cfg_reader_options_show_always, "false"));
     options.push_back (std::pair<std::string, std::string> (cfg_assistant_bookmarks, ""));
+    options.push_back (std::pair<std::string, std::string> (cfg_always_exit_without_saving, "false"));
   }
 
   virtual std::vector<std::pair <std::string, ConfigPage *> > config_pages (QWidget *parent) const 
@@ -198,6 +199,10 @@ MainConfigPage7::setup (lay::Dispatcher *root)
   int kb = 0;
   root->config_get (cfg_keep_backups, kb);
   mp_ui->keep_backups->setValue (kb);
+  
+  bool ex = false;
+  root->config_get (cfg_always_exit_without_saving, ex);
+  mp_ui->always_exit_without_saving->setChecked (ex);
 }
 
 void
@@ -206,6 +211,7 @@ MainConfigPage7::commit (lay::Dispatcher *root)
   try {
     root->config_set (cfg_layout_file_watcher_enabled, mp_ui->check_for_updates->isChecked ());
     root->config_set (cfg_keep_backups, mp_ui->keep_backups->value ());
+    root->config_set (cfg_always_exit_without_saving, mp_ui->always_exit_without_saving->isChecked ());
   } catch (...) { }
 }
 

--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -201,6 +201,8 @@ MainWindow::MainWindow (QApplication *app, const char *name, bool undo_enabled)
   init_menu ();
 
   mp_assistant = 0;
+      
+  m_always_exit_without_saving = false;
 
   mp_pr = new lay::ProgressReporter ();
   mp_pr->set_progress_bar (&m_text_progress);
@@ -1265,6 +1267,11 @@ MainWindow::configure (const std::string &name, const std::string &value)
     m_initial_technology = value;
     return true;
 
+  } else if (name == cfg_always_exit_without_saving) {
+
+    tl::from_string (cfg_always_exit_without_saving, m_always_exit_without_saving);
+    return true;
+
   } else {
     return false;
   }
@@ -1477,7 +1484,7 @@ MainWindow::can_close ()
   std::string df_list;
   int dirty_layouts = dirty_files (df_list);
 
-  if ( (dirty_layouts == 0) || cfg_always_exit_without_saving ) {
+  if ( m_always_exit_without_saving || (dirty_layouts == 0) ) {
     return true;
   } else {
 

--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -1477,7 +1477,7 @@ MainWindow::can_close ()
   std::string df_list;
   int dirty_layouts = dirty_files (df_list);
 
-  if (dirty_layouts == 0) {
+  if ( (dirty_layouts == 0) || cfg_always_exit_without_saving ) {
     return true;
   } else {
 

--- a/src/lay/lay/layMainWindow.h
+++ b/src/lay/lay/layMainWindow.h
@@ -684,7 +684,7 @@ private:
   lay::Navigator *mp_navigator;
   QDockWidget *mp_hp_dock_widget, *mp_lp_dock_widget, *mp_libs_dock_widget, *mp_eo_dock_widget, *mp_bm_dock_widget;
   ControlWidgetStack *mp_hp_stack, *mp_lp_stack, *mp_libs_stack, *mp_eo_stack, *mp_bm_stack;
-  bool m_hp_visible, m_lp_visible, m_libs_visible, m_eo_visible, m_bm_visible, m_navigator_visible, m_layer_toolbox_visible;
+  bool m_hp_visible, m_lp_visible, m_libs_visible, m_eo_visible, m_bm_visible, m_navigator_visible, m_layer_toolbox_visible, m_always_exit_without_saving;
   QDockWidget *mp_layer_toolbox_dock_widget;
   lay::LayerToolbox *mp_layer_toolbox;
   ViewWidgetStack *mp_view_stack;


### PR DESCRIPTION
This PR adds a setting to disable the _Save Needed_ dialog box.

#### Additionally
- a random quotation mark here is removed 
![image](https://user-images.githubusercontent.com/7860886/175288654-6de539de-5b1a-4f56-8e02-f8af03915197.png)
- a dot added to finish the sentence in _Watch Layout Files_

Closes #1102 