### PR TITLE
Support python 3.11 changes.

### DIFF
--- a/src/pya/pya/pyaUtils.cc
+++ b/src/pya/pya/pyaUtils.cc
@@ -62,7 +62,11 @@ void check_error ()
     if (exc_traceback) {
       PyTracebackObject *traceback = (PyTracebackObject*) exc_traceback.get ();
       for (PyTracebackObject *t = traceback; t; t = t->tb_next) {
+#if PY_VERSION_HEX >= 0x030B0000
+        backtrace.push_back (tl::BacktraceElement (python2c<std::string> (PyFrame_GetCode(t->tb_frame)->co_filename), t->tb_lineno));
+#else
         backtrace.push_back (tl::BacktraceElement (python2c<std::string> (t->tb_frame->f_code->co_filename), t->tb_lineno));
+#endif
       }
       std::reverse (backtrace.begin (), backtrace.end ());
     }


### PR DESCRIPTION
This PR adds support for required changes having python >= 3.11

---
* [Builds](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/build/4568893/) on {py3.6, py3.10} x {ppc64le, aarch64, x86_64}.
* Pass tests within OpenLane workflow (mostly invoking DRC).

Guided from here: https://docs.python.org/3.11/whatsnew/3.11.html#pyframeobject-3-11-hiding

Thanks,
~Cristian.
