### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/src/tl/tl/tlTimer.cc
+++ b/src/tl/tl/tlTimer.cc
@@ -28,7 +28,7 @@
 #if defined(_MSC_VER) || defined(_WIN32)
 #  include <Windows.h>
 #  include <Psapi.h>
-#elif defined(__MACH__)
+#elif defined(__MACH__) && defined(__APPLE__)
 #  include <mach/clock.h>
 #  include <mach/mach.h>
 #  include <sys/times.h>
@@ -54,7 +54,7 @@ const uint64_t ft_to_epoch_offset = uint64_t (11644473600) * uint64_t (10000000)
 void current_utc_time (struct timespec *ts)
 {
 
-#if defined(__MACH__)
+#if defined(__MACH__) && defined(__APPLE__)
 
   clock_serv_t cclock;
   mach_timespec_t mts;
@@ -86,7 +86,7 @@ void current_utc_time (struct timespec *ts)
 
 static int64_t ms_time ()
 {
-#if defined(__MACH__)
+#if defined(__MACH__) && defined(__APPLE__)
 
   clock_serv_t cclock;
   mach_timespec_t mts;


### PR DESCRIPTION
Hurd uses a different version of Mach that does not have `mach/clock.h`.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```