### PR TITLE
Fixed issue #1178 (technology-data xml results in SEGV)

### DIFF
--- a/src/plugins/tools/net_tracer/db_plugin/dbNetTracerPlugin.cc
+++ b/src/plugins/tools/net_tracer/db_plugin/dbNetTracerPlugin.cc
@@ -88,30 +88,27 @@ template <class Value>
 struct FallbackXMLWriteAdaptor
 {
   FallbackXMLWriteAdaptor (void (db::NetTracerConnectivity::*member) (const Value &), void (db::NetTracerConnectivity::*clear) ())
-    : mp_member (member), mp_clear (clear), mp_stack (0)
+    : mp_member (member), mp_clear (clear)
   {
     // .. nothing yet ..
   }
 
   void operator () (db::NetTracerTechnologyComponent &owner, tl::XMLReaderState &reader) const
   {
-    if (! mp_stack) {
-      mp_stack = const_cast<db::NetTracerConnectivity *> (get_default (owner));
-      if (! mp_stack) {
-        owner.push_back (db::NetTracerConnectivity ());
-        mp_stack = (owner.end () - 1).operator-> ();
-      }
-      (mp_stack->*mp_clear) ();
+    db::NetTracerConnectivity *stack = const_cast<db::NetTracerConnectivity *> (get_default (owner));
+    if (! stack) {
+      owner.push_back (db::NetTracerConnectivity ());
+      stack = (owner.end () - 1).operator-> ();
     }
+    (stack->*mp_clear) ();
 
     tl::XMLObjTag<Value> tag;
-    (mp_stack->*mp_member) (*reader.back (tag));
+    (stack->*mp_member) (*reader.back (tag));
   }
 
 private:
   void (db::NetTracerConnectivity::*mp_member) (const Value &);
   void (db::NetTracerConnectivity::*mp_clear) ();
-  mutable db::NetTracerConnectivity *mp_stack;
 };
 
 template <class Value, class Iter>


### PR DESCRIPTION
Problem was that the test case contained multiple technologies inside the config file and the cached values were not updated in the XML reader upon migrating to the new multi-stack capable scheme.