### PR TITLE
Commenting out GC.start as it slows down the DRC run significantly.

### DIFF
--- a/src/drc/drc/built-in-macros/_drc_engine.rb
+++ b/src/drc/drc/built-in-macros/_drc_engine.rb
@@ -2125,7 +2125,7 @@ CODE
       t = RBA::Timer::new
       t.start
       self._process_events
-      GC.start # force a garbage collection before the operation to free unused memory
+      ## GC.start # force a garbage collection before the operation to free unused memory
       res = yield
       t.stop
 
@@ -2521,7 +2521,7 @@ CODE
         end
 
         # force garbage collection
-        GC.start
+        ## GC.start
 
       end
 
@@ -2540,7 +2540,7 @@ CODE
         @drc_progress = nil
       end
 
-      GC.start
+      ## GC.start
 
     end
 


### PR DESCRIPTION
Dear Mattias,

After a few tests on GF180MCU DRC rule deck developed on small GDS files. After profiling GC.start takes a lot of time to run. After removing GC.start affected run time significantly.

Runtime analysis before removing GC.start
```
2022-11-22 20:18:23 +0200: Memory Usage (897388K) : DRC Total Run time 81.656426 seconds
  %   cumulative   self              self     total
 time   seconds   seconds    calls  ms/call  ms/call  name
 75.07    59.38     59.38     4214    14.09    14.09  GC.start
 10.39    67.60      8.22       14   586.84   586.84  RBA::Edges#width_check
  1.45    68.74      1.14      175     6.53     6.53  RBA::Region#not_interacting
  1.21    69.70      0.96       70    13.68    13.68  RBA::Edges#&
  1.06    70.53      0.84       48    17.44    17.44  RBA::Region#complex_op
  0.79    71.16      0.62      195     3.20     3.20  RBA::Region#-
  0.66    71.68      0.52      159     3.29     3.29  RBA::Region#|
  0.64    72.19      0.50       88     5.73     5.73  RBA::Edges#interacting
  0.58    72.65      0.46      146     3.14     3.14  RBA::Region#&
  0.45    73.00      0.36       66     5.41     5.41  RBA::Region#not_inside
  0.43    73.34      0.34       81     4.19     4.19  RBA::Region#not_outside
  0.42    73.68      0.33    27555     0.01     0.05  DRC::DRCEngine#src_line
  0.39    73.99      0.31      153     2.03     2.03  RBA::Region#interacting
  0.39    74.30      0.31      283     1.09     1.09  RBA::Region#inside
  0.39    74.60      0.31     4212     0.07    18.32  DRC::DRCEngine#run_timed
  0.35    74.88      0.28       55     5.05     5.05  RBA::Region#sized
  0.33    75.14      0.26       79     3.26     3.26  RBA::Region#enclosing_check
  0.32    75.39      0.25    56698     0.00     0.01  Kernel#!~
  0.26    75.60      0.21       14    14.86    14.86  RBA::EdgePairs#edges
  0.24    75.78      0.19      106     1.76     1.76  RBA::Region#merged
  0.23    75.96      0.18       41     4.39     4.39  RBA::Edges#with_length
  0.22    76.14      0.17       26     6.66     6.66  RBA::Edges#enclosing_check
  0.21    76.30      0.17       46     3.65     3.65  RBA::Region#space_check
  0.21    76.47      0.16      243     0.67     0.67  RBA::Region#edges
  0.17    76.61      0.14       11    12.56    12.56  RBA::Edges#enclosed_check
  0.17    76.74      0.13       68     1.93     1.93  RBA::Edges#-
  0.16    76.86      0.13      149     0.86     0.86  RBA::Region#outside
  0.15    76.98      0.12    24312     0.00     3.81  DRC::DRCEngine#_context
  0.14    77.09      0.11    56698     0.00     0.00  String#=~
  0.14    77.20      0.11      620     0.18     0.18  Kernel#`
  0.13    77.31      0.10    36806     0.00     0.01  DRC::DRCLayer#data
  0.12    77.41      0.10     8426     0.01     0.02  DRC::DRCEngine#_process_events
  0.12    77.50      0.09     4739     0.02     0.16  Array#each
  0.10    77.58      0.08     5996     0.01    12.89  DRC::DRCEngine#_tcmd
  0.08    77.65      0.07     4212     0.02     0.02  Kernel#caller
  0.08    77.71      0.06       94     0.67     0.67  RBA::Region#separation_check
  0.08    77.77      0.06       15     4.14     4.14  RBA::Edges#separation_check
  0.08    77.83      0.06     4214     0.01     0.05  DRC::DRCEngine#info
  0.07    77.89      0.05     9028     0.01     0.01  Class#new
  0.07    77.94      0.05     4214     0.01     0.01  RBA::Logger.log
  0.05    77.98      0.04    16852     0.00     0.00  RBA::Application.instance
  0.05    78.02      0.04    29048     0.00     0.00  Kernel#is_a?
  0.05    78.05      0.04       19     1.90     1.90  RBA::Region#covering
  0.04    78.09      0.03     1229     0.03     0.04  DRC::DRCEngine#_prep_value
  0.04    78.12      0.03        6     5.33     5.33  RBA::Region#with_bbox_min
  0.04    78.15      0.03      620     0.05     0.26  DRC::DRCExecutable#execute
  0.04    78.18      0.03       15     1.97     1.97  RBA::Region#corners
  0.04    78.21      0.03       28     1.04     1.04  RBA::Edges#centers
  0.03    78.23      0.03       35     0.74     0.74  RBA::Edges#extended
  0.03    78.26      0.03     1796     0.01     0.04  DRC::DRCLayer#requires_edges_or_region
  0.03    78.28      0.03        3     8.34     8.34  RBA::Edges#with_angle
  0.03    78.31      0.02     4212     0.01     0.17  Enumerable#find
  0.03    78.33      0.02      690     0.03     0.09  DRC::DRCEngine#_output
  0.03    78.35      0.02     4213     0.00     0.00  RBA::Timer#stop
  0.02    78.37      0.02     1105     0.02     0.04  DRC::DRCLayer#requires_same_type
  0.02    78.39      0.02       12     1.49     1.49  RBA::Edges#not_interacting
  0.02    78.41      0.02        1    17.68    17.68  RBA::Edges#in
  0.02    78.42      0.02      690     0.02     0.02  RBA::ReportDatabase#create_category
  0.02    78.44      0.02       41     0.41     0.41  RBA::Region#width_check
  0.02    78.46      0.01     4213     0.00     0.00  File.basename
  0.02    78.47      0.01      620     0.02     0.34  Logger#add
  0.02    78.49      0.01     1380     0.01     7.42  DRC::DRCEngine#_vcmd
  0.02    78.50      0.01      482     0.03    17.91  DRC::DRCLayer#interacting
  0.02    78.51      0.01     8426     0.00     0.00  RBA::Application#process_events
  0.02    78.53      0.01      526     0.02    17.57  DRC::DRCLayer#-
  0.02    78.54      0.01      620     0.02     0.02  Time#to_s
  0.02    78.55      0.01       10     1.27     1.27  RBA::Edges#not_in
  0.02    78.56      0.01      345     0.04     0.04  RBA::EdgePairs#polygons
  0.02    78.58      0.01      807     0.02     0.04  DRC::DRCLayer#requires_edges_texts_or_region
  0.02    78.59      0.01      534     0.02     6.58  DRC::DRCLayer#separation
  0.02    78.60      0.01      566     0.02    16.84  DRC::DRCLayer#inside
  0.01    78.61      0.01     4212     0.00     0.00  RBA::Timer#start
  0.01    78.62      0.01     1380     0.01    14.76  DRC::DRCLayer#output
  0.01    78.64      0.01     1014     0.01     9.75  DRC::DRCLayer#polygons
  0.01    78.65      0.01      432     0.03    21.90  DRC::DRCLayer#&
  0.01    78.66      0.01      521     0.02     7.43  DRC::DRCLayer#enclosing
  0.01    78.67      0.01     2546     0.00     0.00  RBA::Region#enable_progress
  0.01    78.68      0.01      374     0.03    20.74  DRC::DRCLayer#not_interacting
  0.01    78.69      0.01     1046     0.01     7.37  DRC::DRCEngine#_cmd
  0.01    78.70      0.01      690     0.01     0.01  RBA::RdbCategory#scan_collection
  0.01    78.71      0.01     1240     0.01     0.03  Logger::LogDevice#write
  0.01    78.72      0.01     1554     0.01     0.02  DRC::DRCLayer#forget
  0.01    78.72      0.01      861     0.01     0.05  DRC::DRCEngine#_make_value
  0.01    78.73      0.01      106     0.07     0.07  RBA::Region#with_angle
  0.01    78.74      0.01      514     0.01    15.69  DRC::DRCLayer#edges
  0.01    78.75      0.01     4212     0.00     0.00  RBA::Timer#initialize
  0.01    78.76      0.01      324     0.02    11.22  DRC::DRCLayer#with_angle
  0.01    78.76      0.01      362     0.02    17.74  DRC::DRCLayer#|
  0.01    78.77      0.01      620     0.01     0.01  IO#write
  0.01    78.78      0.01       23     0.30     0.30  RBA::EdgePairs#first_edges
  0.01    78.78      0.01       22     0.30     0.30  RBA::Edges#|
  0.01    78.79      0.01     2546     0.00     0.00  RBA::Region#disable_progress
  0.01    78.79      0.01      941     0.01     0.01  DRC::DRCEngine#_check_numeric
  0.01    78.80      0.01     4657     0.00     0.00  Kernel#class
  0.01    78.81      0.01        1     5.88     5.88  RBA::Layout#read
  0.01    78.81      0.01     4214     0.00     0.00  String#*
  0.01    78.82      0.01     3516     0.00     0.00  DRC::DRCLayer#initialize
  0.01    78.82      0.01      106     0.05     0.05  RBA::Region#grid_check
  0.01    78.83      0.01       11     0.50     0.50  RBA::EdgePairs#with_length_both
  0.01    78.83      0.01      298     0.02    15.31  DRC::DRCLayer#outside
  0.01    78.84      0.01      913     0.01     0.01  DRC::DRCLayer#check_is_layer
  0.01    78.84      0.01      216     0.02    83.88  DRC::DRCLayer#width
  0.01    78.85      0.00       12     0.41     0.41  RBA::Region#extents
  0.01    78.85      0.00       22     0.22     0.22  RBA::EdgePairs#second_edges
  0.01    78.86      0.00      620     0.01     0.03  Monitor#synchronize
  0.01    78.86      0.00      212     0.02    16.79  DRC::DRCLayer#ongrid
  0.01    78.87      0.00      620     0.01     0.27  Logger#format_message
  0.01    78.87      0.00        4     0.99     0.99  RBA::Edges#space_check
  0.00    78.88      0.00      620     0.01     0.35  Logger#info
  0.00    78.88      0.00      620     0.01     0.03  MonitorMixin#mon_synchronize
  0.00    78.88      0.00      200     0.02     8.86  DRC::DRCLayer#space
  0.00    78.89      0.00      166     0.02    13.04  DRC::DRCLayer#sized
  0.00    78.89      0.00      379     0.01     0.02  DRC::DRCLayer#requires_region
  0.00    78.89      0.00      678     0.01     0.01  RBA::Region#_destroy
  0.00    78.90      0.00      390     0.01     0.02  DRC::DRCLayer#requires_edge_pairs
  0.00    78.90      0.00      622     0.01     0.01  Time.now
  0.00    78.91      0.00      690     0.00     0.00  RBA::CplxTrans#initialize
  0.00    78.91      0.00      221     0.02     5.04  DRC::DRCLayer#extended
  0.00    78.91      0.00       70     0.05     0.05  RBA::Region#overlapping
  0.00    78.91      0.00      524     0.01    17.61  DRC::DRCLayer#not
  0.00    78.92      0.00     1892     0.00     0.00  DRC::DRCEngine#dbu
  0.00    78.92      0.00      212     0.01    14.23  DRC::DRCLayer#merged
  0.00    78.92      0.00      140     0.02    14.58  DRC::DRCLayer#overlapping
  0.00    78.93      0.00      162     0.02    18.42  DRC::DRCLayer#not_outside
  0.00    78.93      0.00      420     0.01    21.87  DRC::DRCLayer#and
  0.00    78.93      0.00      690     0.00     0.00  RBA::RdbCategory#description=
  0.00    78.94      0.00       96     0.03    31.27  DRC::DRCLayer#drc
  0.00    78.94      0.00      132     0.02    19.44  DRC::DRCLayer#not_inside
  0.00    78.94      0.00        1     2.26     2.26  TracePoint#enable
  0.00    78.94      0.00       30     0.08     0.08  RBA::Region#with_area
  0.00    78.94      0.00      362     0.01    17.76  DRC::DRCLayer#or
  0.00    78.95      0.00      212     0.01    12.38  DRC::DRCSource#polygons
  0.00    78.95      0.00      463     0.00     0.03  Array#collect
  0.00    78.95      0.00      454     0.00     0.00  RBA::Edges#enable_progress
  0.00    78.95      0.00      163     0.01     8.11  DRC::DRCLayer#with_length
  0.00    78.95      0.00       19     0.10     0.10  RBA::Region#holes
  0.00    78.96      0.00      620     0.00     0.00  String#[]
  0.00    78.96      0.00      415     0.00     0.00  RBA::EdgePairs#enable_progress
  0.00    78.96      0.00     1142     0.00     0.00  Float#floor
  0.00    78.96      0.00      283     0.01     0.01  DRC::DRCEngine#euclidian
  0.00    78.96      0.00      107     0.02     0.05  DRC::DRCEngine#_input
  0.00    78.96      0.00      107     0.01     0.03  DRC::DRCSource#parse_input_layers
  0.00    78.97      0.00      212     0.01    12.41  DRC::DRCEngine#polygons
  0.00    78.97      0.00      108     0.01     0.01  RBA::Region#initialize
  0.00    78.97      0.00     1145     0.00     0.00  Integer#to_i
  0.00    78.97      0.00      341     0.00     0.00  RBA::Region::Metrics#==
  0.00    78.97      0.00      621     0.00     0.00  String#+
  0.00    78.97      0.00      622     0.00     0.00  Time#initialize
  0.00    78.97      0.00      620     0.00     0.00  String#strip
  0.00    78.97      0.00      528     0.00     0.00  DRC::DRCLayer#minmax_count
  0.00    78.98      0.00      161     0.01     0.02  Array#select
  0.00    78.98      0.00      620     0.00     0.00  Process.pid
  0.00    78.98      0.00      454     0.00     0.00  RBA::Edges#disable_progress
  0.00    78.98      0.00       44     0.02    12.85  DRC::DRCLayer#enclosed
  0.00    78.98      0.00      690     0.00     0.00  String#to_s
  0.00    78.98      0.00      106     0.01     0.01  RBA::Layout#find_layer
  0.00    78.98      0.00       60     0.02    14.04  DRC::DRCLayer#with_area
  0.00    78.98      0.00       47     0.02     0.12  DRC::DRCOpNodeCheck#do_create_node
  0.00    78.98      0.00       81     0.01     0.09  DRC::DRCOpNode#create_node
  0.00    78.99      0.00      622     0.00     0.00  Integer#to_s
  0.00    78.99      0.00      415     0.00     0.00  RBA::EdgePairs#disable_progress
  0.00    78.99      0.00      620     0.00     0.00  Kernel#block_given?
  0.00    78.99      0.00       66     0.01     0.07  DRC::DRCEngine#_cop_enclosed
  0.00    78.99      0.00      620     0.00     0.00  Logger#format_severity
  0.00    78.99      0.00       38     0.02    17.45  DRC::DRCLayer#covering
  0.00    78.99      0.00      620     0.00     0.00  Integer#round
  0.00    78.99      0.00       45     0.02    10.71  DRC::DRCLayer#corners
  0.00    78.99      0.00       56     0.01    14.77  DRC::DRCLayer#centers
  0.00    78.99      0.00       30     0.03     0.03  DRC::DRCEngine#_prep_value_area
  0.00    78.99      0.00       42     0.02    12.57  DRC::DRCLayer#without_length
  0.00    78.99      0.00      106     0.01     0.02  DRC::DRCLayer#count
  0.00    79.00      0.00       69     0.01     0.02  DRC::DRCLayer#requires_edges
  0.00    79.00      0.00        1     0.62     0.62  RBA::Region#insert
  0.00    79.00      0.00      126     0.00     0.00  RBA::Region::OppositeFilter#!=
  0.00    79.00      0.00      485     0.00     0.00  Float#um
  0.00    79.00      0.00       88     0.01     0.03  DRC::DRCEngine#_make_value_with_nil
  0.00    79.00      0.00       52     0.01     0.02  DRC::DRCLayer#requires_edges_or_edge_pairs
  0.00    79.00      0.00      335     0.00     0.00  DRC::DRCMetrics#initialize
  0.00    79.00      0.00      214     0.00     0.01  DRC::DRCEngine#layout
  0.00    79.00      0.00       32     0.02     0.04  DRC::DRCEngine#_make_node
  0.00    79.00      0.00       46     0.01    13.98  DRC::DRCLayer#first_edges
  0.00    79.00      0.00       33     0.02     0.02  RBA::CompoundRegionOperationNode.new_enclosed_check
  0.00    79.00      0.00       44     0.01    13.92  DRC::DRCLayer#second_edges
  0.00    79.00      0.00       47     0.01     0.02  DRC::DRCOpNodeCheck#initialize
  0.00    79.00      0.00       28     0.02     7.01  DRC::DRCLayer#isolated
  0.00    79.00      0.00       24     0.02    14.93  DRC::DRCLayer#not_in
  0.00    79.00      0.00       38     0.01    15.03  DRC::DRCLayer#holes
  0.00    79.00      0.00       44     0.01     0.15  DRC::DRCEngine#enclosed
  0.00    79.00      0.00       85     0.01     0.01  RBA::Edges#_destroy
  0.00    79.00      0.00       72     0.01     0.01  Float#==
  0.00    79.01      0.00       20     0.02     5.94  DRC::DRCLayer#overlap
  0.00    79.01      0.00       26     0.02     0.02  RBA::RecursiveShapeIterator#initialize
  0.00    79.01      0.00        7     0.06     0.06  RBA::Region#isolated_check
  0.00    79.01      0.00       14     0.03    17.01  DRC::DRCLayer#not_covering
  0.00    79.01      0.00       58     0.01     0.03  DRC::DRCEngine#_make_area_value_with_nil
  0.00    79.01      0.00       70     0.01     0.01  Kernel#dup
  0.00    79.01      0.00       28     0.01     0.04  DRC::DRCComparable#<=
  0.00    79.01      0.00       18     0.02     9.06  DRC::DRCLayer#size
  0.00    79.01      0.00       24     0.01    15.18  DRC::DRCLayer#extents
  0.00    79.01      0.00       48     0.01     0.01  DRC::DRCOpNodeWithCompare#initialize
  0.00    79.01      0.00      272     0.00     0.00  Array#push
  0.00    79.01      0.00       11     0.03     0.03  DRC::DRCEngine#both
  0.00    79.01      0.00      128     0.00     0.00  RBA::CompoundRegionOperationNode#result_type
  0.00    79.01      0.00       16     0.02     0.10  DRC::DRCEngine#_cop_separation
  0.00    79.01      0.00       70     0.00     0.01  Kernel#initialize_dup
  0.00    79.01      0.00       52     0.01     0.01  Integer#um
  0.00    79.01      0.00       17     0.02     0.02  RBA::CompoundRegionOperationNode.new_width_check
  0.00    79.01      0.00       25     0.01     0.03  DRC::DRCComparable#<
  0.00    79.01      0.00       15     0.02     0.05  DRC::DRCEngine#_cop_width
  0.00    79.01      0.00       59     0.00     0.02  DRC::DRCComparable#_self_or_original
  0.00    79.01      0.00       30     0.01     0.07  DRC::DRCEngine#width
  0.00    79.01      0.00       32     0.01     0.01  RBA::CompoundRegionOperationNode.new_secondary
  0.00    79.01      0.00      126     0.00     0.00  RBA::Region::RectFilter#!=
  0.00    79.01      0.00       50     0.01     0.01  DRC::DRCEngine#projection
  0.00    79.01      0.00       27     0.01     0.01  RBA::Layout#cell
  0.00    79.01      0.00       14     0.02    12.83  DRC::DRCLayer#with_holes
  0.00    79.01      0.00      107     0.00     0.00  RBA::Cell#cell_index
  0.00    79.01      0.00       12     0.02    13.57  DRC::DRCLayer#inside_part
  0.00    79.01      0.00      127     0.00     0.00  RBA::CompoundRegionOperationNode::ResultType#==
  0.00    79.01      0.00      163     0.00     0.00  Kernel#object_id
  0.00    79.01      0.00       35     0.01     0.28  Enumerable#each_with_index
  0.00    79.01      0.00        7     0.03     0.03  RBA::Region#with_holes
  0.00    79.01      0.00       81     0.00     0.00  DRC::DRCOpNode#initialize
  0.00    79.01      0.00      109     0.00     0.00  Range#begin
  0.00    79.01      0.00        7     0.02     0.02  RBA::CompoundRegionOperationNode.new_separation_check
  0.00    79.01      0.00       14     0.01     0.17  DRC::DRCEngine#separation
  0.00    79.02      0.00      106     0.00     0.00  RBA::Region#count
  0.00    79.02      0.00       12     0.01    18.96  DRC::DRCLayer#with_bbox_min
  0.00    79.02      0.00      122     0.00     0.00  Integer#abs
  0.00    79.02      0.00        8     0.02    13.17  DRC::DRCLayer#not_overlapping
  0.00    79.02      0.00      108     0.00     0.00  Range#end
  0.00    79.02      0.00        8     0.02    19.24  DRC::DRCLayer#in
  0.00    79.02      0.00        7     0.02     0.02  RBA::Region#not_covering
  0.00    79.02      0.00       64     0.00     0.00  DRC::DRCComparable#_check_bounds
  0.00    79.02      0.00       28     0.00     0.01  DRC::DRCComparable#set_lt
  0.00    79.02      0.00        2     0.07     0.40  DRC::DRCEngine#report
  0.00    79.02      0.00        4     0.03     0.03  RBA::Region#overlap_check
  0.00    79.02      0.00       96     0.00     0.00  Float#to_f
  0.00    79.02      0.00       19     0.01     0.01  DRC::DRCComparable#set_le
  0.00    79.02      0.00        6     0.02     0.09  DRC::DRCEngine#_cop_enclosing
  0.00    79.02      0.00       47     0.00     0.00  Symbol#to_s
  0.00    79.02      0.00       48     0.00     0.00  RBA::CompoundRegionOperationNode#distance
  0.00    79.02      0.00        6     0.02     0.02  RBA::Region#size
  0.00    79.02      0.00       11     0.01     0.06  Float#<=
  0.00    79.02      0.00        1     0.10     0.10  RBA::ReportDatabase#initialize
  0.00    79.02      0.00        3     0.03     0.80  DRC::DRCLayer#insert
  0.00    79.02      0.00       74     0.00     0.00  Integer#to_f
  0.00    79.02      0.00       56     0.00     0.00  Kernel#respond_to?
  0.00    79.02      0.00        6     0.01    16.31  DRC::DRCLayer#non_rectangles
  0.00    79.02      0.00       17     0.01     0.01  RBA::CompoundRegionOperationNode.new_edge_pair_to_first_edges
  0.00    79.02      0.00       13     0.01     0.01  RBA::EdgePairs#_destroy
  0.00    79.02      0.00        6     0.01     0.01  RBA::Edges#inside_part
  0.00    79.02      0.00       16     0.01     0.01  RBA::CompoundRegionOperationNode.new_edges
  0.00    79.02      0.00        2     0.04    33.25  DRC::DRCSource#extent
  0.00    79.02      0.00        4     0.02     0.02  RBA::Region#not_overlapping
  0.00    79.02      0.00        3     0.03     0.06  DRC::DRCComparable#!=
  0.00    79.02      0.00       79     0.00     0.00  BasicObject#==
  0.00    79.02      0.00       26     0.00     0.00  RBA::ICplxTrans#initialize
  0.00    79.02      0.00        3     0.03    12.32  DRC::DRCLayer#without_angle
  0.00    79.02      0.00       70     0.00     0.00  Kernel#initialize_copy
  0.00    79.02      0.00       13     0.01     0.01  RBA::CompoundRegionOperationNode.new_geometrical_boolean
  0.00    79.02      0.00        1     0.07     0.07  RBA::ReportDatabase#create_cell
  0.00    79.02      0.00        4     0.02     3.05  DRC::DRCEngine#source
  0.00    79.02      0.00       13     0.01     0.01  DRC::DRCComparable#set_ge
  0.00    79.02      0.00        4     0.02     0.02  RBA::CompoundRegionOperationNode.new_enclosing_check
  0.00    79.02      0.00       12     0.01     0.01  String#%
  0.00    79.02      0.00       11     0.01     0.02  DRC::DRCComparable#coerce
  0.00    79.02      0.00       11     0.01     0.01  DRC::DRCEngine#joined
  0.00    79.02      0.00        3     0.02     0.09  DRC::DRCEngine#_cop_overlap
  0.00    79.02      0.00       12     0.00     0.02  DRC::DRCEngine#_make_numeric_value_with_nil
  0.00    79.02      0.00        4     0.01     0.21  DRC::DRCEngine#enclosing
  0.00    79.02      0.00       26     0.00     0.00  RBA::RecursiveShapeIterator#global_dtrans=
  0.00    79.02      0.00        2     0.03    32.27  DRC::DRCSource#input
  0.00    79.02      0.00        3     0.02     0.02  RBA::Region#non_rectangles
  0.00    79.02      0.00       26     0.00     0.00  RBA::RecursiveShapeIterator#shape_flags=
  0.00    79.02      0.00       29     0.00     0.00  RBA::Layout#dbu
  0.00    79.02      0.00        1     0.05     0.22  DRC::DRCOpNodeEdgeLengthFilter#do_create_node
  0.00    79.02      0.00        3     0.02     0.02  RBA::Region#in
  0.00    79.02      0.00        2     0.02     0.07  DRC::DRCComparable#==
  0.00    79.02      0.00        1     0.05    28.14  DRC::DRCEngine#_finish
  0.00    79.02      0.00       33     0.00     0.00  DRC::DRCOpNode#do_create_node
  0.00    79.02      0.00        2     0.02    33.33  DRC::DRCEngine#extent
  0.00    79.02      0.00        1     0.04    13.36  DRC::DRCEngine#_cleanup
  0.00    79.02      0.00        3     0.01     0.01  RBA::CompoundRegionOperationNode.new_join
  0.00    79.02      0.00        7     0.01     0.01  Integer#==
  0.00    79.02      0.00        2     0.02     0.02  RBA::Region#not_in
  0.00    79.02      0.00        2     0.02    11.93  DRC::DRCLayer#area
  0.00    79.02      0.00        2     0.02     0.02  RBA::LayoutView.current
  0.00    79.02      0.00        2     0.02     0.20  DRC::DRCEngine#overlap
  0.00    79.02      0.00        2     0.02     0.02  RBA::CompoundRegionOperationNode.new_overlap_check
  0.00    79.02      0.00        4     0.01     0.01  DRC::DRCComparable#set_gt
  0.00    79.02      0.00        2     0.01     0.11  DRC::DRCEngine#length
  0.00    79.02      0.00        1     0.02    28.17  DRC::DRCExecutable#cleanup
  0.00    79.02      0.00        1     0.02     0.07  Logger#initialize
  0.00    79.02      0.00        2     0.01     5.95  DRC::DRCEngine#_tdcmd
  0.00    79.02      0.00        3     0.01     0.02  DRC::DRCEngine#transparent
  0.00    79.02      0.00        2     0.01     0.03  DRC::DRCSource#finish
  0.00    79.02      0.00       11     0.00     0.00  DRC::DRCJoinFlag#initialize
  0.00    79.02      0.00        1     0.02     0.06  DRC::DRCComparable#>
  0.00    79.02      0.00        1     0.02     0.04  DRC::DRCEngine#make_source
  0.00    79.02      0.00        1     0.02     0.03  DRC::DRCEngine#primary
  0.00    79.02      0.00        2     0.01     0.01  DRC::DRCEngine#square
  0.00    79.02      0.00        1     0.02     0.02  RBA::CompoundRegionOperationNode.new_edge_length_filter
  0.00    79.02      0.00        1     0.01     0.01  RBA::Layout#initialize
  0.00    79.02      0.00        1     0.01     0.02  DRC::DRCEngine#threads
  0.00    79.02      0.00        1     0.01     0.01  RBA::Region#area
  0.00    79.02      0.00        2     0.01     0.06  DRC::DRCEngine#_flush
  0.00    79.02      0.00        1     0.01     0.01  RBA::Layout#delete_layer
  0.00    79.02      0.00        1     0.01     0.01  RBA::LayerInfo#initialize
  0.00    79.02      0.00        1     0.01     0.01  RBA::DBox#transformed
  0.00    79.02      0.00        6     0.00     0.00  DRC::DRCEngine#is_tiled?
  0.00    79.02      0.00        1     0.01     0.01  RBA::Cell#name
  0.00    79.02      0.00        1     0.01     0.02  Time#-
  0.00    79.02      0.00        1     0.01     0.02  DRC::DRCEngine#use_dbu
  0.00    79.02      0.00        1     0.01     0.08  DRC::DRCEngine#_cop_length
  0.00    79.02      0.00        1     0.01     0.01  RBA::Layout#insert_layer
  0.00    79.02      0.00       12     0.00     0.00  BasicObject#initialize
  0.00    79.02      0.00        1     0.01     0.01  DRC::DRCEngine#verbose
  0.00    79.02      0.00        1     0.01     0.02  DRC::DRCEngine#polygon_layer
  0.00    79.02      0.00        2     0.00     0.00  RBA::DBox#*
  0.00    79.02      0.00        1     0.01     0.04  Logger::LogDevice#initialize
  0.00    79.02      0.00        1     0.01     0.01  RBA::Cell#bbox
  0.00    79.02      0.00        1     0.01     0.02  DRC::DRCOpNodeEdgeLengthFilter#initialize
  0.00    79.02      0.00        1     0.01     0.04  DRC::DRCOpNode#length
  0.00    79.02      0.00        1     0.01     0.05  DRC::DRCEngine#_make_area_value
  0.00    79.02      0.00        1     0.01     0.01  MonitorMixin#mon_initialize
  0.00    79.02      0.00        1     0.01     0.01  Logger::LogDevice#set_dev
  0.00    79.02      0.00        1     0.01     0.06  Hash#each
  0.00    79.02      0.00        1     0.01     0.01  RBA::CompoundRegionOperationNode.new_primary
  0.00    79.02      0.00        1     0.01     0.02  DRC::DRCSource#initialize
  0.00    79.02      0.00        1     0.01     0.01  RBA::MacroExecutionContext.remove_debugger_scope
  0.00    79.02      0.00        2     0.00     0.00  BasicObject#singleton_method_added
  0.00    79.02      0.00        1     0.01     0.01  RBA::ReportDatabase#generator=
  0.00    79.02      0.00        1     0.01     0.01  String#to_i
  0.00    79.02      0.00        1     0.01     0.01  RBA::DBox.from_ibox
  0.00    79.02      0.00        1     0.01     0.01  Logger#level=
  0.00    79.02      0.00        1     0.01     0.01  RBA::ReportDatabase#top_cell_name=
  0.00    79.02      0.00        1     0.01     0.01  RBA::ReportDatabase#description=
  0.00    79.02      0.00        1     0.00     0.00  Float#to_s
  0.00    79.02      0.00        3     0.00     0.00  DRC::DRCShielded#initialize
  0.00    79.02      0.00        1     0.00     0.00  RBA::CompoundRegionOperationNode::ResultType#!=
  0.00    79.02      0.00        3     0.00     0.00  DRC::DRCShielded#value
  0.00    79.02      0.00        1     0.00     0.00  DRC::DRCEngine#flat
  0.00    79.02      0.00        1     0.00     0.00  RBA::Box.from_dbox
  0.00    79.02      0.00        1     0.00     0.00  RBA::DCplxTrans#initialize
  0.00    79.02      0.00        1     0.00     0.00  DRC::DRCEngine#_generator
  0.00    79.02      0.00        1     0.00     0.00  RBA::Region#each
  0.00    79.02      0.00        3     0.00     0.00  Integer#*
  0.00    79.02      0.00        1     0.00     0.00  Integer#fdiv
  0.00    79.02      0.00        1     0.00     0.00  TracePoint#disable
  0.00    79.02      0.00        1     0.00     0.00  Kernel#proc
  0.00    79.02      0.00        1     0.00     0.00  DRC::DRCEngine#verbose=
  0.00    79.02      0.00        1     0.00     0.00  TrueClass#to_s
  0.00    79.02      0.00        1     0.00     0.00  Monitor#mon_owned?
  0.00    79.02      0.00        1     0.00     0.00  Logger#datetime_format=
  0.00    79.02      0.00        2     0.00     0.00  DRC::DRCSource#layout
  0.00    79.02      0.00        1     0.00     0.00  DRC::DRCSource#cell_obj
  0.00    79.02      0.00        1     0.00     0.00  Integer._dbu=
  0.00    79.02      0.00        1     0.00     0.00  Logger::Formatter#initialize
  0.00    79.02      0.00        1     0.00     0.00  Float._dbu=
  0.00    79.02      0.00        1     0.00     0.00  DRC::DRCSource#path
  0.00    79.02      0.00        1     0.00     0.00  File.dirname
  0.00    79.02      0.00        1     0.00     0.00  File.absolute_path
  0.00    79.02      0.00        1     0.00     0.00  DRC::DRCEngine#_make_path
  0.00    79.02      0.00        1     0.00     0.00  RBA::ReportDatabase#save
  0.00    79.02      0.00        1     0.00     0.00  DRC::DRCEngine#_before_cleanup
  0.00    79.02      0.00        1     0.00     0.00  RBA::AbstractProgress#_destroy
  0.00    79.10      0.00        1     0.00 79103.14  #toplevel
22-Nov-2022 20:18:23 | INFO    | 
Congratulations !!. No DRC Violations found in spm for gf180mcu.drc rule deck with switch gfC
22-Nov-2022 20:18:23 | INFO    | Klayout GDS DRC Clean
```

Run time analysis after:
```
2022-11-22 21:25:21 +0200: Memory Usage (936020K) : DRC Total Run time 17.182142 seconds
  %   cumulative   self              self     total
 time   seconds   seconds    calls  ms/call  ms/call  name
 38.95     5.94      5.94       14   424.56   424.56  RBA::Edges#width_check
  6.49     6.93      0.99      175     5.66     5.66  RBA::Region#not_interacting
  5.04     7.70      0.77       70    10.99    10.99  RBA::Edges#&
  4.99     8.46      0.76       48    15.86    15.86  RBA::Region#complex_op
  3.37     8.98      0.51      195     2.64     2.64  RBA::Region#-
  2.98     9.43      0.45       88     5.16     5.16  RBA::Edges#interacting
  2.58     9.83      0.39      159     2.47     2.47  RBA::Region#|
  2.43    10.20      0.37      146     2.54     2.54  RBA::Region#&
  2.14    10.52      0.33       66     4.94     4.94  RBA::Region#not_inside
  1.86    10.81      0.28       81     3.50     3.50  RBA::Region#not_outside
  1.74    11.07      0.27    27555     0.01     0.04  DRC::DRCEngine#src_line
  1.70    11.33      0.26      153     1.69     1.69  RBA::Region#interacting
  1.65    11.58      0.25       55     4.58     4.58  RBA::Region#sized
  1.57    11.82      0.24       79     3.04     3.04  RBA::Region#enclosing_check
  1.45    12.04      0.22      283     0.78     0.78  RBA::Region#inside
  1.36    12.25      0.21    56698     0.00     0.00  Kernel#!~
  1.29    12.45      0.20      106     1.85     1.85  RBA::Region#merged
  1.10    12.62      0.17       41     4.08     4.08  RBA::Edges#with_length
  1.05    12.78      0.16       46     3.49     3.49  RBA::Region#space_check
  1.03    12.93      0.16       26     6.03     6.03  RBA::Edges#enclosing_check
  0.84    13.06      0.13      243     0.53     0.53  RBA::Region#edges
  0.81    13.19      0.12       14     8.87     8.87  RBA::EdgePairs#edges
  0.81    13.31      0.12       11    11.26    11.26  RBA::Edges#enclosed_check
  0.79    13.43      0.12       68     1.78     1.78  RBA::Edges#-
  0.76    13.55      0.12     4212     0.03     3.28  DRC::DRCEngine#run_timed
  0.69    13.65      0.11      149     0.71     0.71  RBA::Region#outside
  0.58    13.74      0.09    23536     0.00     0.74  DRC::DRCEngine#_context
  0.56    13.83      0.09    36806     0.00     0.00  DRC::DRCLayer#data
  0.52    13.90      0.08      620     0.13     0.13  Kernel#`
  0.51    13.98      0.08     8426     0.01     0.01  DRC::DRCEngine#_process_events
  0.48    14.06      0.07     4739     0.02     0.12  Array#each
  0.48    14.13      0.07    56698     0.00     0.00  String#=~
  0.33    14.18      0.05       94     0.53     0.53  RBA::Region#separation_check
  0.32    14.23      0.05       15     3.22     3.22  RBA::Edges#separation_check
  0.28    14.27      0.04     5996     0.01     4.56  DRC::DRCEngine#_tcmd
  0.27    14.31      0.04     4214     0.01     0.03  DRC::DRCEngine#info
  0.24    14.35      0.04     9028     0.00     0.01  Class#new
  0.21    14.38      0.03     4212     0.01     0.01  Kernel#caller
  0.21    14.41      0.03        6     5.39     5.39  RBA::Region#with_bbox_min
  0.21    14.45      0.03       19     1.67     1.67  RBA::Region#covering
  0.19    14.48      0.03    29048     0.00     0.00  Kernel#is_a?
  0.18    14.50      0.03     1229     0.02     0.03  DRC::DRCEngine#_prep_value
  0.17    14.53      0.03       28     0.94     0.94  RBA::Edges#centers
  0.17    14.55      0.03       15     1.72     1.72  RBA::Region#corners
  0.16    14.58      0.02       35     0.69     0.69  RBA::Edges#extended
  0.16    14.60      0.02        3     8.05     8.05  RBA::Edges#with_angle
  0.16    14.63      0.02      620     0.04     0.19  DRC::DRCExecutable#execute
  0.15    14.65      0.02    16852     0.00     0.00  RBA::Application.instance
  0.13    14.67      0.02     1796     0.01     0.03  DRC::DRCLayer#requires_edges_or_region
  0.12    14.69      0.02     4212     0.00     0.13  Enumerable#find
  0.11    14.70      0.02     4214     0.00     0.00  RBA::Logger.log
  0.10    14.72      0.02       41     0.37     0.37  RBA::Region#width_check
  0.10    14.73      0.01      690     0.02     0.05  DRC::DRCEngine#_output
  0.08    14.75      0.01     1105     0.01     0.03  DRC::DRCLayer#requires_same_type
  0.08    14.76      0.01       10     1.15     1.15  RBA::Edges#not_in
  0.07    14.77      0.01      620     0.02     0.25  Logger#add
  0.07    14.78      0.01       12     0.93     0.93  RBA::Edges#not_interacting
  0.07    14.79      0.01        1    10.83    10.83  RBA::Edges#in
  0.06    14.80      0.01      482     0.02     3.34  DRC::DRCLayer#interacting
  0.06    14.81      0.01      526     0.02     2.88  DRC::DRCLayer#-
  0.06    14.82      0.01     8426     0.00     0.00  RBA::Application#process_events
  0.06    14.83      0.01      534     0.02     0.59  DRC::DRCLayer#separation
  0.06    14.84      0.01      807     0.01     0.03  DRC::DRCLayer#requires_edges_texts_or_region
  0.06    14.85      0.01      521     0.02     1.74  DRC::DRCLayer#enclosing
  0.06    14.85      0.01     1380     0.01     0.17  DRC::DRCEngine#_vcmd
  0.05    14.86      0.01     1380     0.01     0.30  DRC::DRCLayer#output
  0.05    14.87      0.01     4213     0.00     0.00  File.basename
  0.05    14.88      0.01     1014     0.01     0.23  DRC::DRCLayer#polygons
  0.05    14.89      0.01      566     0.01     1.13  DRC::DRCLayer#inside
  0.05    14.89      0.01      432     0.02     5.73  DRC::DRCLayer#&
  0.05    14.90      0.01      374     0.02     5.70  DRC::DRCLayer#not_interacting
  0.05    14.91      0.01      620     0.01     0.01  Time#to_s
  0.05    14.92      0.01     4213     0.00     0.00  RBA::Timer#stop
  0.05    14.92      0.01     1240     0.01     0.02  Logger::LogDevice#write
  0.04    14.93      0.01     4212     0.00     0.00  RBA::Timer#start
  0.04    14.94      0.01     2546     0.00     0.00  RBA::Region#enable_progress
  0.04    14.94      0.01      861     0.01     0.04  DRC::DRCEngine#_make_value
  0.04    14.95      0.01     1046     0.01     0.41  DRC::DRCEngine#_cmd
  0.04    14.95      0.01      345     0.02     0.02  RBA::EdgePairs#polygons
  0.04    14.96      0.01       23     0.25     0.25  RBA::EdgePairs#first_edges
  0.04    14.97      0.01        1     5.74     5.74  RBA::Layout#read
  0.04    14.97      0.01     4657     0.00     0.00  Kernel#class
  0.04    14.98      0.01      324     0.02     0.46  DRC::DRCLayer#with_angle
  0.03    14.98      0.01      690     0.01     0.01  RBA::ReportDatabase#create_category
  0.03    14.99      0.00      514     0.01     1.26  DRC::DRCLayer#edges
  0.03    14.99      0.00       11     0.44     0.44  RBA::EdgePairs#with_length_both
  0.03    15.00      0.00     4212     0.00     0.00  RBA::Timer#initialize
  0.03    15.00      0.00      690     0.01     0.01  RBA::RdbCategory#scan_collection
  0.03    15.01      0.00      362     0.01     2.59  DRC::DRCLayer#|
  0.03    15.01      0.00     4214     0.00     0.00  String#*
  0.03    15.02      0.00      941     0.00     0.01  DRC::DRCEngine#_check_numeric
  0.03    15.02      0.00      107     0.04     0.05  DRC::DRCSource#parse_input_layers
  0.03    15.02      0.00      620     0.01     0.01  IO#write
  0.03    15.03      0.00      106     0.04     0.04  RBA::Region#with_angle
  0.03    15.03      0.00      913     0.00     0.01  DRC::DRCLayer#check_is_layer
  0.03    15.04      0.00       22     0.18     0.18  RBA::EdgePairs#second_edges
  0.03    15.04      0.00      216     0.02    55.43  DRC::DRCLayer#width
  0.03    15.04      0.00      622     0.01     0.01  Time.now
  0.02    15.05      0.00      200     0.02     1.87  DRC::DRCLayer#space
  0.02    15.05      0.00      298     0.01     1.06  DRC::DRCLayer#outside
  0.02    15.06      0.00       22     0.17     0.17  RBA::Edges#|
  0.02    15.06      0.00        4     0.92     0.92  RBA::Edges#space_check
  0.02    15.06      0.00     3516     0.00     0.00  DRC::DRCLayer#initialize
  0.02    15.07      0.00      620     0.01     0.02  Monitor#synchronize
  0.02    15.07      0.00       12     0.29     0.29  RBA::Region#extents
  0.02    15.07      0.00      620     0.01     0.25  Logger#info
  0.02    15.08      0.00      212     0.02     0.55  DRC::DRCLayer#ongrid
  0.02    15.08      0.00      106     0.03     0.03  RBA::Region#grid_check
  0.02    15.08      0.00     2546     0.00     0.00  RBA::Region#disable_progress
  0.02    15.09      0.00      620     0.01     0.19  Logger#format_message
  0.02    15.09      0.00      620     0.00     0.02  MonitorMixin#mon_synchronize
  0.02    15.09      0.00      166     0.02     3.31  DRC::DRCLayer#sized
  0.02    15.09      0.00      221     0.01     0.42  DRC::DRCLayer#extended
  0.02    15.10      0.00      379     0.01     0.02  DRC::DRCLayer#requires_region
  0.02    15.10      0.00      390     0.01     0.02  DRC::DRCLayer#requires_edge_pairs
  0.02    15.10      0.00      212     0.01     2.16  DRC::DRCLayer#merged
  0.02    15.10      0.00      524     0.00     2.90  DRC::DRCLayer#not
  0.01    15.11      0.00        1     2.28     2.28  TracePoint#enable
  0.01    15.11      0.00     1892     0.00     0.00  DRC::DRCEngine#dbu
  0.01    15.11      0.00      140     0.02     0.38  DRC::DRCLayer#overlapping
  0.01    15.11      0.00      162     0.01     3.86  DRC::DRCLayer#not_outside
  0.01    15.12      0.00       96     0.02    16.31  DRC::DRCLayer#drc
  0.01    15.12      0.00      132     0.01     5.32  DRC::DRCLayer#not_inside
  0.01    15.12      0.00      212     0.01     0.39  DRC::DRCSource#polygons
  0.01    15.12      0.00       70     0.02     0.02  RBA::Region#overlapping
  0.01    15.12      0.00      420     0.00     5.63  DRC::DRCLayer#and
  0.01    15.12      0.00      362     0.00     2.60  DRC::DRCLayer#or
  0.01    15.13      0.00      163     0.01     1.72  DRC::DRCLayer#with_length
  0.01    15.13      0.00      690     0.00     0.00  RBA::CplxTrans#initialize
  0.01    15.13      0.00      690     0.00     0.00  RBA::RdbCategory#description=
  0.01    15.13      0.00      463     0.00     0.02  Array#collect
  0.01    15.13      0.00      620     0.00     0.00  String#[]
  0.01    15.13      0.00        1     1.30     1.30  RBA::ReportDatabase#save
  0.01    15.13      0.00     1142     0.00     0.00  Float#floor
  0.01    15.13      0.00      283     0.00     0.01  DRC::DRCEngine#euclidian
  0.01    15.14      0.00       81     0.01     0.07  DRC::DRCOpNode#create_node
  0.01    15.14      0.00      621     0.00     0.00  String#+
  0.01    15.14      0.00     1145     0.00     0.00  Integer#to_i
  0.01    15.14      0.00      212     0.01     0.42  DRC::DRCEngine#polygons
  0.01    15.14      0.00      107     0.01     0.02  DRC::DRCEngine#_input
  0.01    15.14      0.00      454     0.00     0.00  RBA::Edges#enable_progress
  0.01    15.14      0.00      415     0.00     0.00  RBA::EdgePairs#enable_progress
  0.01    15.14      0.00      620     0.00     0.00  String#strip
  0.01    15.14      0.00       30     0.03     0.03  RBA::Region#with_area
  0.01    15.15      0.00      528     0.00     0.00  DRC::DRCLayer#minmax_count
  0.01    15.15      0.00      161     0.01     0.01  Array#select
  0.01    15.15      0.00       44     0.02     5.89  DRC::DRCLayer#enclosed
  0.01    15.15      0.00      341     0.00     0.00  RBA::Region::Metrics#==
  0.01    15.15      0.00      622     0.00     0.00  Time#initialize
  0.01    15.15      0.00       66     0.01     0.06  DRC::DRCEngine#_cop_enclosed
  0.01    15.15      0.00      620     0.00     0.00  Process.pid
  0.01    15.15      0.00       47     0.02     0.10  DRC::DRCOpNodeCheck#do_create_node
  0.01    15.15      0.00       19     0.04     0.04  RBA::Region#holes
  0.01    15.15      0.00      620     0.00     0.00  Logger#format_severity
  0.00    15.15      0.00      690     0.00     0.00  String#to_s
  0.00    15.15      0.00       60     0.01     0.33  DRC::DRCLayer#with_area
  0.00    15.15      0.00      622     0.00     0.00  Integer#to_s
  0.00    15.16      0.00      620     0.00     0.00  Kernel#block_given?
  0.00    15.16      0.00      620     0.00     0.00  Integer#round
  0.00    15.16      0.00       38     0.02     2.21  DRC::DRCLayer#covering
  0.00    15.16      0.00       56     0.01     1.29  DRC::DRCLayer#centers
  0.00    15.16      0.00       45     0.01     1.38  DRC::DRCLayer#corners
  0.00    15.16      0.00      454     0.00     0.00  RBA::Edges#disable_progress
  0.00    15.16      0.00      415     0.00     0.00  RBA::EdgePairs#disable_progress
  0.00    15.16      0.00       69     0.01     0.02  DRC::DRCLayer#requires_edges
  0.00    15.16      0.00       30     0.02     0.02  DRC::DRCEngine#_prep_value_area
  0.00    15.16      0.00      214     0.00     0.00  DRC::DRCEngine#layout
  0.00    15.16      0.00       88     0.01     0.02  DRC::DRCEngine#_make_value_with_nil
  0.00    15.16      0.00       42     0.01     2.52  DRC::DRCLayer#without_length
  0.00    15.16      0.00       46     0.01     0.57  DRC::DRCLayer#first_edges
  0.00    15.16      0.00       44     0.01     0.13  DRC::DRCEngine#enclosed
  0.00    15.16      0.00      485     0.00     0.00  Float#um
  0.00    15.16      0.00       52     0.01     0.02  DRC::DRCLayer#requires_edges_or_edge_pairs
  0.00    15.16      0.00      126     0.00     0.00  RBA::Region::OppositeFilter#!=
  0.00    15.16      0.00       47     0.01     0.02  DRC::DRCOpNodeCheck#initialize
  0.00    15.16      0.00       32     0.01     0.03  DRC::DRCEngine#_make_node
  0.00    15.16      0.00       44     0.01     0.51  DRC::DRCLayer#second_edges
  0.00    15.17      0.00      335     0.00     0.00  DRC::DRCMetrics#initialize
  0.00    15.17      0.00       28     0.01     0.21  DRC::DRCLayer#isolated
  0.00    15.17      0.00       72     0.00     0.01  Float#==
  0.00    15.17      0.00       24     0.01     1.33  DRC::DRCLayer#not_in
  0.00    15.17      0.00      106     0.00     0.00  RBA::Layout#find_layer
  0.00    15.17      0.00       30     0.01     0.07  DRC::DRCEngine#width
  0.00    15.17      0.00       28     0.01     0.03  DRC::DRCComparable#<=
  0.00    15.17      0.00       38     0.01     0.34  DRC::DRCLayer#holes
  0.00    15.17      0.00       33     0.01     0.01  RBA::CompoundRegionOperationNode.new_enclosed_check
  0.00    15.17      0.00       70     0.00     0.01  Kernel#dup
  0.00    15.17      0.00       58     0.00     0.02  DRC::DRCEngine#_make_area_value_with_nil
  0.00    15.17      0.00       70     0.00     0.00  Kernel#initialize_dup
  0.00    15.17      0.00       25     0.01     0.03  DRC::DRCComparable#<
  0.00    15.17      0.00      163     0.00     0.00  Kernel#object_id
  0.00    15.17      0.00      272     0.00     0.00  Array#push
  0.00    15.17      0.00       18     0.01     0.22  DRC::DRCLayer#size
  0.00    15.17      0.00       59     0.00     0.01  DRC::DRCComparable#_self_or_original
  0.00    15.17      0.00      128     0.00     0.00  RBA::CompoundRegionOperationNode#result_type
  0.00    15.17      0.00      108     0.00     0.00  RBA::Region#initialize
  0.00    15.17      0.00       15     0.02     0.04  DRC::DRCEngine#_cop_width
  0.00    15.17      0.00       48     0.00     0.01  DRC::DRCOpNodeWithCompare#initialize
  0.00    15.17      0.00       17     0.01     0.01  RBA::CompoundRegionOperationNode.new_width_check
  0.00    15.17      0.00       81     0.00     0.00  DRC::DRCOpNode#initialize
  0.00    15.17      0.00      126     0.00     0.00  RBA::Region::RectFilter#!=
  0.00    15.17      0.00       50     0.00     0.01  DRC::DRCEngine#projection
  0.00    15.17      0.00       14     0.01     0.41  DRC::DRCLayer#not_covering
  0.00    15.17      0.00       52     0.00     0.00  Integer#um
  0.00    15.17      0.00       16     0.01     0.07  DRC::DRCEngine#_cop_separation
  0.00    15.17      0.00       24     0.01     0.56  DRC::DRCLayer#extents
  0.00    15.17      0.00      127     0.00     0.00  RBA::CompoundRegionOperationNode::ResultType#==
  0.00    15.17      0.00        7     0.03     0.03  RBA::Region#isolated_check
  0.00    15.17      0.00       20     0.01     0.11  DRC::DRCLayer#overlap
  0.00    15.17      0.00       12     0.01     0.31  DRC::DRCLayer#inside_part
  0.00    15.17      0.00       32     0.01     0.01  RBA::CompoundRegionOperationNode.new_secondary
  0.00    15.17      0.00       26     0.01     0.01  RBA::RecursiveShapeIterator#initialize
  0.00    15.17      0.00        6     0.03     0.36  DRC::DRCLayer#non_rectangles
  0.00    15.17      0.00       35     0.00     0.23  Enumerable#each_with_index
  0.00    15.17      0.00       12     0.01     5.75  DRC::DRCLayer#with_bbox_min
  0.00    15.17      0.00      109     0.00     0.00  Range#begin
  0.00    15.17      0.00        8     0.02     0.41  DRC::DRCLayer#not_overlapping
  0.00    15.17      0.00      108     0.00     0.00  Range#end
  0.00    15.17      0.00      107     0.00     0.00  RBA::Cell#cell_index
  0.00    15.17      0.00       28     0.00     0.01  DRC::DRCComparable#set_lt
  0.00    15.17      0.00      122     0.00     0.00  Integer#abs
  0.00    15.17      0.00        3     0.04     0.11  DRC::DRCEngine#_cop_overlap
  0.00    15.18      0.00       14     0.01     0.26  DRC::DRCLayer#with_holes
  0.00    15.18      0.00       14     0.01     0.11  DRC::DRCEngine#separation
  0.00    15.18      0.00       64     0.00     0.00  DRC::DRCComparable#_check_bounds
  0.00    15.18      0.00       11     0.01     0.05  Float#<=
  0.00    15.18      0.00       19     0.00     0.01  DRC::DRCComparable#set_le
  0.00    15.18      0.00        6     0.01     0.06  DRC::DRCEngine#_cop_enclosing
  0.00    15.18      0.00        7     0.01     0.01  RBA::CompoundRegionOperationNode.new_separation_check
  0.00    15.18      0.00       48     0.00     0.00  RBA::CompoundRegionOperationNode#distance
  0.00    15.18      0.00       56     0.00     0.00  Kernel#respond_to?
  0.00    15.18      0.00       96     0.00     0.00  Float#to_f
  0.00    15.18      0.00       17     0.00     0.00  RBA::CompoundRegionOperationNode.new_edge_pair_to_first_edges
  0.00    15.18      0.00       47     0.00     0.00  Symbol#to_s
  0.00    15.18      0.00       74     0.00     0.00  Integer#to_f
  0.00    15.18      0.00       11     0.01     0.02  DRC::DRCComparable#coerce
  0.00    15.18      0.00       27     0.00     0.00  RBA::Layout#cell
  0.00    15.18      0.00        4     0.02     2.98  DRC::DRCEngine#source
  0.00    15.18      0.00       13     0.01     0.01  RBA::CompoundRegionOperationNode.new_geometrical_boolean
  0.00    15.18      0.00       70     0.00     0.00  Kernel#initialize_copy
  0.00    15.18      0.00       16     0.00     0.00  RBA::CompoundRegionOperationNode.new_edges
  0.00    15.18      0.00        3     0.02     0.05  DRC::DRCComparable#!=
  0.00    15.18      0.00        1     0.06     1.65  DRC::DRCEngine#_finish
  0.00    15.18      0.00       79     0.00     0.00  BasicObject#==
  0.00    15.18      0.00        8     0.01     2.96  DRC::DRCLayer#in
  0.00    15.18      0.00       13     0.00     0.01  DRC::DRCComparable#set_ge
  0.00    15.18      0.00       11     0.00     0.01  DRC::DRCEngine#joined
  0.00    15.18      0.00        3     0.02     0.22  DRC::DRCLayer#without_angle
  0.00    15.18      0.00       26     0.00     0.00  RBA::ICplxTrans#initialize
  0.00    15.18      0.00       11     0.00     0.01  DRC::DRCEngine#both
  0.00    15.18      0.00        2     0.02     0.14  DRC::DRCEngine#report
  0.00    15.18      0.00        4     0.01     0.14  DRC::DRCEngine#enclosing
  0.00    15.18      0.00        1     0.04     0.08  DRC::DRCEngine#_make_path
  0.00    15.18      0.00        4     0.01     0.01  RBA::CompoundRegionOperationNode.new_enclosing_check
  0.00    15.18      0.00        2     0.02     0.05  DRC::DRCComparable#==
  0.00    15.18      0.00       12     0.00     0.01  DRC::DRCEngine#_make_numeric_value_with_nil
  0.00    15.18      0.00       26     0.00     0.00  RBA::RecursiveShapeIterator#shape_flags=
  0.00    15.18      0.00        7     0.01     0.01  RBA::Region#with_holes
  0.00    15.18      0.00       26     0.00     0.00  RBA::RecursiveShapeIterator#global_dtrans=
  0.00    15.18      0.00        3     0.01     0.01  RBA::CompoundRegionOperationNode.new_join
  0.00    15.18      0.00       29     0.00     0.00  RBA::Layout#dbu
  0.00    15.18      0.00       33     0.00     0.00  DRC::DRCOpNode#do_create_node
  0.00    15.18      0.00        1     0.03     0.03  RBA::Layout#delete_layer
  0.00    15.18      0.00        1     0.03     1.69  DRC::DRCExecutable#cleanup
  0.00    15.18      0.00        1     0.03     0.03  RBA::ReportDatabase#create_cell
  0.00    15.18      0.00        1     0.03     0.11  DRC::DRCOpNodeEdgeLengthFilter#do_create_node
  0.00    15.18      0.00        2     0.01     0.26  DRC::DRCLayer#area
  0.00    15.18      0.00        1     0.03     0.03  RBA::ReportDatabase#initialize
  0.00    15.18      0.00        1     0.03     0.03  Time#-
  0.00    15.18      0.00        1     0.02     0.08  Logger#initialize
  0.00    15.18      0.00        7     0.00     0.00  RBA::Region#not_covering
  0.00    15.18      0.00        2     0.01     0.08  DRC::DRCEngine#_flush
  0.00    15.18      0.00        4     0.01     0.01  RBA::Region#not_overlapping
  0.00    15.18      0.00        3     0.01     0.01  RBA::Region#non_rectangles
  0.00    15.18      0.00        2     0.01     0.05  DRC::DRCSource#finish
  0.00    15.18      0.00        4     0.01     0.01  DRC::DRCComparable#set_gt
  0.00    15.18      0.00        2     0.01     0.22  DRC::DRCEngine#overlap
  0.00    15.18      0.00        2     0.01     0.01  RBA::CompoundRegionOperationNode.new_overlap_check
  0.00    15.18      0.00        7     0.00     0.00  Integer#==
  0.00    15.18      0.00        2     0.01     0.08  DRC::DRCEngine#length
  0.00    15.18      0.00        4     0.00     0.00  RBA::Region#overlap_check
  0.00    15.18      0.00        6     0.00     0.00  RBA::Region#size
  0.00    15.18      0.00        6     0.00     0.00  RBA::Edges#inside_part
  0.00    15.18      0.00       12     0.00     0.00  String#%
  0.00    15.18      0.00        1     0.02     0.02  DRC::DRCEngine#use_dbu
  0.00    15.18      0.00        1     0.02     0.02  RBA::AbstractProgress#_destroy
  0.00    15.18      0.00        1     0.02     0.02  RBA::Layout#initialize
  0.00    15.18      0.00        1     0.01     0.04  DRC::DRCEngine#make_source
  0.00    15.18      0.00        1     0.01     0.01  File.absolute_path
  0.00    15.18      0.00        3     0.00     0.01  DRC::DRCEngine#transparent
  0.00    15.18      0.00        1     0.01     0.05  DRC::DRCComparable#>
  0.00    15.18      0.00        2     0.01     0.01  DRC::DRCEngine#square
  0.00    15.18      0.00       11     0.00     0.00  DRC::DRCJoinFlag#initialize
  0.00    15.18      0.00        2     0.01     0.11  DRC::DRCEngine#_tdcmd
  0.00    15.18      0.00        2     0.01     0.01  RBA::LayoutView.current
  0.00    15.18      0.00        1     0.01     0.03  DRC::DRCEngine#_cleanup
  0.00    15.18      0.00        1     0.01     0.01  RBA::MacroExecutionContext.remove_debugger_scope
  0.00    15.18      0.00        1     0.01     0.02  DRC::DRCEngine#primary
  0.00    15.18      0.00        1     0.01     0.04  Logger::LogDevice#initialize
  0.00    15.18      0.00        1     0.01     0.02  MonitorMixin#mon_initialize
  0.00    15.18      0.00       12     0.00     0.00  BasicObject#initialize
  0.00    15.18      0.00        1     0.01     0.06  DRC::DRCEngine#_cop_length
  0.00    15.18      0.00        1     0.01     0.01  Logger::LogDevice#set_dev
  0.00    15.18      0.00        1     0.01     0.01  RBA::CompoundRegionOperationNode.new_edge_length_filter
  0.00    15.18      0.00        1     0.01     0.08  Hash#each
  0.00    15.18      0.00        1     0.01     0.01  DRC::DRCSource#initialize
  0.00    15.18      0.00        1     0.01     0.01  DRC::DRCEngine#threads
  0.00    15.18      0.00        2     0.00     0.01  DRC::DRCLayer#forget
  0.00    15.18      0.00        1     0.01     0.01  DRC::DRCOpNodeEdgeLengthFilter#initialize
  0.00    15.18      0.00        6     0.00     0.00  DRC::DRCEngine#is_tiled?
  0.00    15.18      0.00        3     0.00     0.00  RBA::Region#in
  0.00    15.18      0.00        1     0.01     0.01  RBA::CompoundRegionOperationNode.new_primary
  0.00    15.18      0.00        1     0.01     0.01  Logger#level=
  0.00    15.18      0.00        3     0.00     0.00  DRC::DRCShielded#initialize
  0.00    15.18      0.00        2     0.00     0.01  DRC::DRCSource#extent
  0.00    15.18      0.00        2     0.00     0.01  DRC::DRCEngine#extent
  0.00    15.18      0.00        1     0.00     0.01  DRC::DRCEngine#verbose
  0.00    15.18      0.00        2     0.00     0.00  RBA::Region#not_in
  0.00    15.18      0.00        1     0.00     0.03  DRC::DRCOpNode#length
  0.00    15.18      0.00        3     0.00     0.00  DRC::DRCShielded#value
  0.00    15.18      0.00        1     0.00     0.00  RBA::CompoundRegionOperationNode::ResultType#!=
  0.00    15.18      0.00        1     0.00     0.00  File.dirname
  0.00    15.18      0.00        1     0.00     0.00  RBA::Cell#name
  0.00    15.18      0.00        1     0.00     0.00  RBA::Region#_destroy
  0.00    15.18      0.00        3     0.00     0.00  Integer#*
  0.00    15.18      0.00        1     0.00     0.00  Float#to_s
  0.00    15.18      0.00        1     0.00     0.00  RBA::DCplxTrans#initialize
  0.00    15.18      0.00        1     0.00     0.00  RBA::ReportDatabase#generator=
  0.00    15.18      0.00        1     0.00     0.00  DRC::DRCEngine#flat
  0.00    15.18      0.00        1     0.00     0.00  Integer#fdiv
  0.00    15.18      0.00        1     0.00     0.00  DRC::DRCSource#path
  0.00    15.18      0.00        1     0.00     0.00  Monitor#mon_owned?
  0.00    15.18      0.00        1     0.00     0.00  Logger#datetime_format=
  0.00    15.18      0.00        1     0.00     0.00  Kernel#proc
  0.00    15.18      0.00        1     0.00     0.00  RBA::ReportDatabase#top_cell_name=
  0.00    15.18      0.00        1     0.00     0.00  RBA::ReportDatabase#description=
  0.00    15.18      0.00        1     0.00     0.00  RBA::Region#area
  0.00    15.18      0.00        1     0.00     0.00  TracePoint#disable
  0.00    15.18      0.00        1     0.00     0.00  Logger::Formatter#initialize
  0.00    15.18      0.00        2     0.00     0.00  DRC::DRCSource#layout
  0.00    15.18      0.00        1     0.00     0.00  Float._dbu=
  0.00    15.18      0.00        1     0.00     0.00  DRC::DRCEngine#_generator
  0.00    15.18      0.00        1     0.00     0.00  String#to_i
  0.00    15.18      0.00        1     0.00     0.00  DRC::DRCEngine#verbose=
  0.00    15.18      0.00        1     0.00     0.00  DRC::DRCSource#cell_obj
  0.00    15.18      0.00        1     0.00     0.00  Integer._dbu=
  0.00    15.18      0.00        3     0.00     0.00  DRC::DRCLayer#insert
  0.00    15.18      0.00        1     0.00     0.00  DRC::DRCEngine#_before_cleanup
  0.00    15.18      0.00      106     0.00     0.00  RBA::Region#count
  0.00    15.18      0.00      106     0.00     0.00  DRC::DRCLayer#count
  0.00    15.18      0.00        1     0.00     0.00  TrueClass#to_s
  0.00    15.18      0.00        2     0.00     0.00  BasicObject#singleton_method_added
  0.00    15.18      0.00        1     0.00     0.00  RBA::LayerInfo#initialize
  0.00    15.18      0.00        1     0.00     0.00  RBA::Layout#insert_layer
  0.00    15.18      0.00        2     0.00     0.00  DRC::DRCSource#input
  0.00    15.18      0.00        1     0.00     0.00  RBA::Cell#bbox
  0.00    15.18      0.00        1     0.00     0.00  RBA::DBox.from_ibox
  0.00    15.18      0.00        2     0.00     0.00  RBA::DBox#*
  0.00    15.18      0.00        1     0.00     0.00  RBA::DBox#transformed
  0.00    15.18      0.00        1     0.00     0.00  RBA::Box.from_dbox
  0.00    15.18      0.00        1     0.00     0.00  RBA::Region#insert
  0.00    15.18      0.00        1     0.00     0.00  DRC::DRCEngine#_make_area_value
  0.00    15.18      0.00        1     0.00     0.00  DRC::DRCEngine#polygon_layer
  0.00    15.18      0.00        1     0.00     0.00  RBA::Region#each
  0.00    15.26      0.00        1     0.00 15258.71  #toplevel
22-Nov-2022 21:25:21 | INFO    | 
Congratulations !!. No DRC Violations found in spm for gf180mcu.drc rule deck with switch gfC
22-Nov-2022 21:25:21 | INFO    | Klayout GDS DRC Clean
```