### PR TITLE
src/unit_tests: do not link docs/icons with no qt

### DIFF
--- a/src/unit_tests/unit_test_main.cc
+++ b/src/unit_tests/unit_test_main.cc
@@ -41,9 +41,11 @@
 //  This hard-links the GSI test classes
 #include "../gsi_test/gsiTestForceLink.h"
 
-//  For testing the document structure
+#if defined(HAVE_QT)
+//  For testing thedocument structure
 #include "docForceLink.h"
 #include "iconsForceLink.h"
+#endif
 
 #include "version.h"
 

--- a/src/unit_tests/unit_tests.pro
+++ b/src/unit_tests/unit_tests.pro
@@ -6,11 +6,13 @@ include($$PWD/../with_all_libs.pri)
 
 # NOTE: doc is needed for testing help sources
 
-INCLUDEPATH += $$DOC_INC $$ICONS_INC
-DEPENDPATH += $$DOC_INC $$ICONS_INC
+!equals(HAVE_QT, "0") {
+  INCLUDEPATH += $$DOC_INC $$ICONS_INC
+  DEPENDPATH += $$DOC_INC $$ICONS_INC
 
-LIBS += -lklayout_doc -lklayout_icons
-
+  LIBS += -lklayout_doc -lklayout_icons
+}
+  
 TEMPLATE = app
 
 # Don't build the ut_runner app as ordinary command line tool on MacOS


### PR DESCRIPTION
without this the `without-qt` builds fails with:
```
ld: cannot find -lklayout_icons: No such file or directory
```