### PR TITLE
Add option to enable 'Show parameter names' by default

### DIFF
--- a/src/edt/edt/edtPCellParametersPage.cc
+++ b/src/edt/edt/edtPCellParametersPage.cc
@@ -227,7 +227,8 @@ PCellParametersPage::init ()
 
   mp_show_parameter_names_cb = new QCheckBox (this);
   mp_show_parameter_names_cb->setText (tr ("Show parameter names"));
-  mp_show_parameter_names_cb->setChecked (m_show_parameter_names);
+  // start as checked if chosen to do so in setup
+  mp_show_parameter_names_cb->setChecked (m_show_parameter_names || m_always_show_parameter_names);
   frame_layout->addWidget (mp_show_parameter_names_cb, 3, 0, 1, 1);
 
   connect (mp_show_parameter_names_cb, SIGNAL (clicked (bool)), this, SLOT (show_parameter_names (bool)));

--- a/src/lay/lay/MainConfigPage7.ui
+++ b/src/lay/lay/MainConfigPage7.ui
@@ -154,6 +154,44 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Always show PCell Parameter Names in Properties</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="always_show_parameter_names">
+        <property name="text">
+         <string>Show PCell Parameter Names by Defaul</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>If this option is enabled, the PCell properties window has 'Show parameter names' checked by default.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/src/lay/lay/layConfig.h
+++ b/src/lay/lay/layConfig.h
@@ -63,6 +63,7 @@ static const std::string cfg_micron_digits ("digits-micron");
 static const std::string cfg_dbu_digits ("digits-dbu");
 static const std::string cfg_assistant_bookmarks ("assistant-bookmarks");
 static const std::string cfg_always_exit_without_saving ("always-exit-without-saving");
+static const std::string cfg_always_show_parameter_names ("always-show-parameter-names");
 
 }
 

--- a/src/lay/lay/layMainConfigPages.cc
+++ b/src/lay/lay/layMainConfigPages.cc
@@ -85,6 +85,7 @@ public:
     options.push_back (std::pair<std::string, std::string> (cfg_reader_options_show_always, "false"));
     options.push_back (std::pair<std::string, std::string> (cfg_assistant_bookmarks, ""));
     options.push_back (std::pair<std::string, std::string> (cfg_always_exit_without_saving, "false"));
+    options.push_back (std::pair<std::string, std::string> (cfg_always_show_parameter_names, "false"));
   }
 
   virtual std::vector<std::pair <std::string, ConfigPage *> > config_pages (QWidget *parent) const 
@@ -203,6 +204,11 @@ MainConfigPage7::setup (lay::Dispatcher *root)
   bool ex = false;
   root->config_get (cfg_always_exit_without_saving, ex);
   mp_ui->always_exit_without_saving->setChecked (ex);
+  
+  bool sp = false;
+  root->config_get (cfg_always_show_parameter_names, sp);
+  mp_ui->always_show_parameter_names->setChecked (sp);
+  
 }
 
 void
@@ -212,6 +218,7 @@ MainConfigPage7::commit (lay::Dispatcher *root)
     root->config_set (cfg_layout_file_watcher_enabled, mp_ui->check_for_updates->isChecked ());
     root->config_set (cfg_keep_backups, mp_ui->keep_backups->value ());
     root->config_set (cfg_always_exit_without_saving, mp_ui->always_exit_without_saving->isChecked ());
+    root->config_set (cfg_always_show_parameter_names, mp_ui->always_show_parameter_names->isChecked ());
   } catch (...) { }
 }
 

--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -1247,6 +1247,11 @@ MainWindow::configure (const std::string &name, const std::string &value)
     tl::from_string (value, m_always_exit_without_saving);
     return true;
 
+  } else if (name == cfg_always_show_parameter_names) {
+
+    tl::from_string (value, m_always_show_parameter_names);
+    return true;
+
   } else {
     return false;
   }

--- a/src/lay/lay/layMainWindow.h
+++ b/src/lay/lay/layMainWindow.h
@@ -695,7 +695,7 @@ private:
   lay::Navigator *mp_navigator;
   QDockWidget *mp_hp_dock_widget, *mp_lp_dock_widget, *mp_libs_dock_widget, *mp_eo_dock_widget, *mp_bm_dock_widget;
   ControlWidgetStack *mp_hp_stack, *mp_lp_stack, *mp_layer_toolbox_stack, *mp_libs_stack, *mp_eo_stack, *mp_bm_stack;
-  bool m_hp_visible, m_lp_visible, m_libs_visible, m_eo_visible, m_bm_visible, m_navigator_visible, m_layer_toolbox_visible, m_always_exit_without_saving;
+  bool m_hp_visible, m_lp_visible, m_libs_visible, m_eo_visible, m_bm_visible, m_navigator_visible, m_layer_toolbox_visible, m_always_exit_without_saving, m_always_show_parameter_names;
   QDockWidget *mp_layer_toolbox_dock_widget;
   ViewWidgetStack *mp_view_stack;
   lay::FileDialog *mp_bookmarks_fdia;


### PR DESCRIPTION
This PR adds an option to enable 'Show parameter names' by default. This option itself should be off by default

Not sure what the location for this should be in the setup, so I put it to General for now.

Drafted before tested to work.

Closes #1228