### PR TITLE
Implemented solution for issue #1228

### DIFF
--- a/src/edt/edt/edtConfig.cc
+++ b/src/edt/edt/edtConfig.cc
@@ -60,6 +60,7 @@ std::string cfg_edit_top_level_selection ("edit-top-level-selection");
 std::string cfg_edit_hier_copy_mode ("edit-hier-copy-mode");
 std::string cfg_edit_show_shapes_of_instances ("edit-show-shapes-of-instances");
 std::string cfg_edit_max_shapes_of_instances ("edit-max-shapes-of-instances");
+std::string cfg_edit_pcell_show_parameter_names ("edit-pcell-show-parameter-names");
 std::string cfg_edit_global_grid ("grid-micron");
 std::string cfg_edit_combine_mode ("combine-mode");
 

--- a/src/edt/edt/edtConfig.h
+++ b/src/edt/edt/edtConfig.h
@@ -68,6 +68,7 @@ extern EDT_PUBLIC std::string cfg_edit_inst_column_x;
 extern EDT_PUBLIC std::string cfg_edit_inst_column_y;
 extern EDT_PUBLIC std::string cfg_edit_inst_place_origin;
 extern EDT_PUBLIC std::string cfg_edit_top_level_selection;
+extern EDT_PUBLIC std::string cfg_edit_pcell_show_parameter_names;
 extern EDT_PUBLIC std::string cfg_edit_hier_copy_mode;
 extern EDT_PUBLIC std::string cfg_edit_combine_mode;
 

--- a/src/edt/edt/edtEditorOptionsPages.cc
+++ b/src/edt/edt/edtEditorOptionsPages.cc
@@ -853,6 +853,8 @@ EditorOptionsInstPCellParam::update_pcell_parameters (const std::vector <tl::Var
     pc = layout->pcell_by_name (tl::to_string (m_cell_name).c_str ());
   }
 
+  //  TODO: don't re-generate the PCellParametersPage unless the PCell has changed
+
   PCellParametersPage::State pcp_state;
 
   //  Hint: we shall not delete the page immediately. This gives a segmentation fault in some cases.
@@ -872,7 +874,7 @@ EditorOptionsInstPCellParam::update_pcell_parameters (const std::vector <tl::Var
 
   if (pc.first && layout->pcell_declaration (pc.second) && view ()->cellview (m_cv_index).is_valid ()) {
 
-    mp_pcell_parameters = new PCellParametersPage (this, true /*dense*/);
+    mp_pcell_parameters = new PCellParametersPage (this, dispatcher (), true /*dense*/);
     mp_pcell_parameters->setup (view (), m_cv_index, layout->pcell_declaration (pc.second), parameters);
     this->layout ()->addWidget (mp_pcell_parameters);
 

--- a/src/edt/edt/edtInstPropertiesPage.cc
+++ b/src/edt/edt/edtInstPropertiesPage.cc
@@ -1009,7 +1009,7 @@ InstPropertiesPage::update_pcell_parameters ()
         mp_pcell_parameters->deleteLater ();
       }
 
-      mp_pcell_parameters = new PCellParametersPage (pcell_tab);
+      mp_pcell_parameters = new PCellParametersPage (pcell_tab, mp_service->view ()->dispatcher ());
       connect (mp_pcell_parameters, SIGNAL (edited ()), this, SIGNAL (edited ()));
       mp_pcell_parameters->setup (mp_service->view (), pos->cv_index (), layout->pcell_declaration (pc.second), parameters);
       pcell_tab->layout ()->addWidget (mp_pcell_parameters);

--- a/src/edt/edt/edtPCellParametersPage.h
+++ b/src/edt/edt/edtPCellParametersPage.h
@@ -37,6 +37,7 @@
 namespace lay
 {
   class LayoutViewBase;
+  class Dispatcher;
 }
 
 namespace edt
@@ -53,10 +54,9 @@ Q_OBJECT
 public:
   struct State
   {
-    State () : valid (false), show_parameter_names (false), hScrollPosition (0), vScrollPosition (0) { }
+    State () : valid (false), hScrollPosition (0), vScrollPosition (0) { }
 
     bool valid;
-    bool show_parameter_names;
     int hScrollPosition;
     int vScrollPosition;
     QString focusWidget;
@@ -69,7 +69,7 @@ public:
    *
    *  @param dense Use a dense layout if true
    */
-  PCellParametersPage (QWidget *parent, bool dense = false);
+  PCellParametersPage (QWidget *parent, lay::Dispatcher *dispatcher, bool dense = false);
 
   /**
    *  @brief initialization
@@ -148,6 +148,7 @@ private slots:
   void update_button_pressed ();
 
 private:
+  lay::Dispatcher *mp_dispatcher;
   QScrollArea *mp_parameters_area;
   QLabel *mp_error_label;
   QLabel *mp_error_icon;

--- a/src/edt/edt/edtPlugin.cc
+++ b/src/edt/edt/edtPlugin.cc
@@ -140,6 +140,7 @@ void get_inst_options (std::vector < std::pair<std::string, std::string> > &opti
   options.push_back (std::pair<std::string, std::string> (cfg_edit_inst_column_x, "0.0"));
   options.push_back (std::pair<std::string, std::string> (cfg_edit_inst_column_y, "0.0"));
   options.push_back (std::pair<std::string, std::string> (cfg_edit_inst_place_origin, "false"));
+  options.push_back (std::pair<std::string, std::string> (cfg_edit_pcell_show_parameter_names, "false"));
   options.push_back (std::pair<std::string, std::string> (cfg_edit_max_shapes_of_instances, "1000"));
   options.push_back (std::pair<std::string, std::string> (cfg_edit_show_shapes_of_instances, "true"));
 }


### PR DESCRIPTION
The "show parameter names" setting is now persisted. Side effect: changing this setting will now trigger a configuration update which has some side effects - e.g. when "lazy update" is configured (parameters are reset). But that appears to be acceptable.

In addition a second flaw was fixed: errors were not properly reported by showing the error indicator.
The indicator was hidden immediately after showing it.