### PR TITLE
Solution for Issue 1265 - shipping libpng with macos wheels + autodetecting libpng when installing from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           HOST_CCACHE_DIR="$(ccache -k cache_dir)"
           mkdir -p $HOST_CCACHE_DIR
       - name: Build wheels  # check https://cibuildwheel.readthedocs.io/en/stable/setup/#github-actions
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v2.12.0
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         path: dist/*.tar.gz
-     
+
   upload_to_test_pypy:
     needs: [build, make_sdist]
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ before-build = "ccache -s"
 environment-pass = ["HOST_CCACHE_DIR"]
 
 [tool.cibuildwheel.macos]
-before-all = "brew deps --tree --installed"
+before-all = [
+  "brew install libpng",
+  "brew deps --tree --installed",
+]
 # Repair macOS wheels (include libpng with the wheel, for example)
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v --ignore-missing-dependencies {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,6 @@ before-build = "ccache -s"
 environment-pass = ["HOST_CCACHE_DIR"]
 
 [tool.cibuildwheel.macos]
-# Don't repair macOS wheels
-repair-wheel-command = ""
 before-all = "brew deps --tree --installed"
+# Repair macOS wheels (include libpng with the wheel, for example)
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v --ignore-missing-dependencies {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,4 @@ environment-pass = ["HOST_CCACHE_DIR"]
 [tool.cibuildwheel.macos]
 # Don't repair macOS wheels
 repair-wheel-command = ""
+before-all = "brew deps --tree --installed"


### PR DESCRIPTION
Fixes issue #1265 

Changelog:
- Bugfix: %GITHUB%/issues/1275 libpng was missing in macos installations.

Details:
- setup.py now looks for `libpng-config` in macos installations.
- in macos wheels, the "repair wheel" step was reinstated. it uses the `delocate` project which looks for non-system libraries and patches the wheel before uploading to pypi. this project is well maintained by pypa, so it should be stable.
- setup.py can be easily set up so that it can be installed gracefully without libpng (@klayoutmatthias decision)

Missing:
- test case for a proper use of the png library. (optional?)