### PR TITLE
Fixed issue #1287

### DIFF
--- a/src/ant/ant/RulerPropertiesPage.ui
+++ b/src/ant/ant/RulerPropertiesPage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>622</width>
+    <width>669</width>
     <height>621</height>
    </rect>
   </property>
@@ -1142,10 +1142,34 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>fmt_le</tabstop>
+  <tabstop>main_position</tabstop>
+  <tabstop>main_xalign</tabstop>
+  <tabstop>main_yalign</tabstop>
   <tabstop>fmt_x_le</tabstop>
+  <tabstop>xlabel_xalign</tabstop>
+  <tabstop>xlabel_yalign</tabstop>
   <tabstop>fmt_y_le</tabstop>
+  <tabstop>ylabel_xalign</tabstop>
+  <tabstop>ylabel_yalign</tabstop>
   <tabstop>style_cb</tabstop>
   <tabstop>outline_cb</tabstop>
+  <tabstop>segments_tab</tabstop>
+  <tabstop>x0</tabstop>
+  <tabstop>y0</tabstop>
+  <tabstop>x1</tabstop>
+  <tabstop>y1</tabstop>
+  <tabstop>x2</tabstop>
+  <tabstop>y2</tabstop>
+  <tabstop>swap_points</tabstop>
+  <tabstop>p1_to_layout</tabstop>
+  <tabstop>p2_to_layout</tabstop>
+  <tabstop>both_to_layout</tabstop>
+  <tabstop>dx</tabstop>
+  <tabstop>dy</tabstop>
+  <tabstop>dd</tabstop>
+  <tabstop>point_list</tabstop>
+  <tabstop>points_edit</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ant/ant/antObject.cc
+++ b/src/ant/ant/antObject.cc
@@ -331,7 +331,7 @@ Object::seg_p2 (size_t seg_index, const db::DPoint &p)
 void
 Object::p1 (const db::DPoint &p)
 {
-  if (! p1 ().equal (p)) {
+  if (m_points.size () < 1 || ! p1 ().equal (p)) {
     if (m_points.size () < 1) {
       m_points.push_back (p);
     } else {
@@ -348,7 +348,7 @@ Object::p1 (const db::DPoint &p)
 void
 Object::p2 (const db::DPoint &p)
 {
-  if (! p2 ().equal (p)) {
+  if (m_points.size () < 2 || ! p2 ().equal (p)) {
     if (m_points.size () < 2) {
       if (m_points.empty ()) {
         m_points.push_back (db::DPoint ());

--- a/src/ant/unit_tests/antBasicTests.cc
+++ b/src/ant/unit_tests/antBasicTests.cc
@@ -25,6 +25,8 @@
 #include "antObject.h"
 #include "antTemplate.h"
 
+//  NOTE: most tests are in ruby/antTest.rb
+
 TEST(1) 
 {
   ant::Template tmp = ant::Template ("title", "fmt_x", "fmt_y", "fmt",
@@ -48,3 +50,84 @@ TEST(1)
   EXPECT_EQ (a.category (), "cat");
 }
 
+TEST(2)
+{
+  ant::Template tmp = ant::Template ("title", "fmt_x", "fmt_y", "fmt",
+                                     ant::Object::STY_arrow_both,
+                                     ant::Object::OL_diag_xy,
+                                     true,
+                                     lay::AC_Ortho,
+                                     "cat");
+
+  ant::Object obj;
+
+  EXPECT_EQ (obj.p1 ().to_string (), "0,0");
+  EXPECT_EQ (obj.p2 ().to_string (), "0,0");
+
+  EXPECT_EQ (int (obj.segments ()), 1);
+  EXPECT_EQ (int (obj.points ().size ()), 0);
+
+  obj.p1 (db::DPoint (1, 2));
+
+  EXPECT_EQ (obj.p1 ().to_string (), "1,2");
+  EXPECT_EQ (obj.p2 ().to_string (), "1,2");
+
+  EXPECT_EQ (int (obj.segments ()), 1);
+  EXPECT_EQ (int (obj.points ().size ()), 1);
+
+  obj.p2 (db::DPoint (2, 3));
+
+  EXPECT_EQ (obj.p1 ().to_string (), "1,2");
+  EXPECT_EQ (obj.p2 ().to_string (), "2,3");
+
+  EXPECT_EQ (int (obj.segments ()), 1);
+  EXPECT_EQ (int (obj.points ().size ()), 2);
+
+  obj = ant::Object ();
+
+  EXPECT_EQ (obj.p1 ().to_string (), "0,0");
+  EXPECT_EQ (obj.p2 ().to_string (), "0,0");
+
+  EXPECT_EQ (int (obj.segments ()), 1);
+  EXPECT_EQ (int (obj.points ().size ()), 0);
+
+  obj.p1 (db::DPoint ());
+
+  EXPECT_EQ (obj.p1 ().to_string (), "0,0");
+  EXPECT_EQ (obj.p2 ().to_string (), "0,0");
+
+  EXPECT_EQ (int (obj.segments ()), 1);
+  EXPECT_EQ (int (obj.points ().size ()), 1);
+
+  obj.p2 (db::DPoint ());
+
+  EXPECT_EQ (obj.p1 ().to_string (), "0,0");
+  EXPECT_EQ (obj.p2 ().to_string (), "0,0");
+
+  EXPECT_EQ (int (obj.segments ()), 1);
+  EXPECT_EQ (int (obj.points ().size ()), 1);
+
+  obj = ant::Object (db::DPoint (1, 2), db::DPoint (2, 3), 0, tmp);
+
+  EXPECT_EQ (obj.p1 ().to_string (), "1,2");
+  EXPECT_EQ (obj.p2 ().to_string (), "2,3");
+
+  EXPECT_EQ (int (obj.segments ()), 1);
+  EXPECT_EQ (int (obj.points ().size ()), 2);
+
+  obj = ant::Object (db::DPoint (1, 2), db::DPoint (1, 2), 0, tmp);
+
+  EXPECT_EQ (obj.p1 ().to_string (), "1,2");
+  EXPECT_EQ (obj.p2 ().to_string (), "1,2");
+
+  EXPECT_EQ (int (obj.segments ()), 1);
+  EXPECT_EQ (int (obj.points ().size ()), 1);
+
+  obj = ant::Object (db::DPoint (), db::DPoint (), 0, tmp);
+
+  EXPECT_EQ (obj.p1 ().to_string (), "0,0");
+  EXPECT_EQ (obj.p2 ().to_string (), "0,0");
+
+  EXPECT_EQ (int (obj.segments ()), 1);
+  EXPECT_EQ (int (obj.points ().size ()), 1);
+}


### PR DESCRIPTION
The problem was introduced during implementation
of multi-segment rulers.

This patch also fixes the tab order of the ruler
properties dialog and adds some tests.