### PR TITLE
Fixed issue #1328 (width of layer selection boxes too small)

### DIFF
--- a/src/lay/lay/ClipDialog.ui
+++ b/src/lay/lay/ClipDialog.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>ClipDialog</class>
- <widget class="QDialog" name="ClipDialog" >
-  <property name="geometry" >
+ <widget class="QDialog" name="ClipDialog">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,49 +10,47 @@
     <height>421</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Clip Tool</string>
   </property>
-  <layout class="QVBoxLayout" >
-   <property name="margin" >
-    <number>9</number>
-   </property>
-   <property name="spacing" >
+  <layout class="QVBoxLayout">
+   <property name="spacing">
     <number>6</number>
    </property>
+   <property name="margin" stdset="0">
+    <number>9</number>
+   </property>
    <item>
-    <widget class="QFrame" name="frame_3" >
-     <property name="frameShape" >
+    <widget class="QFrame" name="frame_3">
+     <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
-     <property name="frameShadow" >
+     <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QHBoxLayout" >
-      <property name="margin" >
-       <number>0</number>
-      </property>
-      <property name="spacing" >
+     <layout class="QHBoxLayout">
+      <property name="spacing">
        <number>6</number>
       </property>
+      <property name="margin" stdset="0">
+       <number>0</number>
+      </property>
       <item>
-       <widget class="QLabel" name="label_13" >
-        <property name="text" >
+       <widget class="QLabel" name="label_13">
+        <property name="text">
          <string>Clip result cell name</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="le_cell_name" >
-        <property name="sizePolicy" >
-         <sizepolicy>
-          <hsizetype>7</hsizetype>
-          <vsizetype>0</vsizetype>
+       <widget class="QLineEdit" name="le_cell_name">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="text" >
+        <property name="text">
          <string>CLIP</string>
         </property>
        </widget>
@@ -61,13 +60,13 @@
    </item>
    <item>
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeType" >
+     <property name="sizeType">
       <enum>QSizePolicy::Fixed</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
        <height>10</height>
@@ -76,48 +75,48 @@
     </spacer>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox" >
-     <property name="title" >
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
       <string>Clip Box Specification</string>
      </property>
-     <layout class="QGridLayout" >
-      <property name="margin" >
+     <layout class="QGridLayout">
+      <property name="margin" stdset="0">
        <number>9</number>
       </property>
-      <property name="spacing" >
+      <property name="spacing">
        <number>6</number>
       </property>
-      <item row="2" column="0" >
-       <widget class="QFrame" name="frame" >
-        <property name="frameShape" >
+      <item row="2" column="0">
+       <widget class="QFrame" name="frame">
+        <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
         </property>
-        <property name="frameShadow" >
+        <property name="frameShadow">
          <enum>QFrame::Raised</enum>
         </property>
-        <layout class="QVBoxLayout" >
-         <property name="margin" >
-          <number>0</number>
-         </property>
-         <property name="spacing" >
+        <layout class="QVBoxLayout">
+         <property name="spacing">
           <number>6</number>
          </property>
+         <property name="margin" stdset="0">
+          <number>0</number>
+         </property>
          <item>
-          <widget class="QRadioButton" name="rb_box2" >
-           <property name="text" >
+          <widget class="QRadioButton" name="rb_box2">
+           <property name="text">
             <string>Single box with ...</string>
            </property>
-           <property name="autoExclusive" >
+           <property name="autoExclusive">
             <bool>false</bool>
            </property>
           </widget>
          </item>
          <item>
           <spacer>
-           <property name="orientation" >
+           <property name="orientation">
             <enum>Qt::Vertical</enum>
            </property>
-           <property name="sizeHint" >
+           <property name="sizeHint" stdset="0">
             <size>
              <width>20</width>
              <height>40</height>
@@ -128,40 +127,40 @@
         </layout>
        </widget>
       </item>
-      <item row="1" column="0" >
-       <widget class="QFrame" name="frame_2" >
-        <property name="frameShape" >
+      <item row="1" column="0">
+       <widget class="QFrame" name="frame_2">
+        <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
         </property>
-        <property name="frameShadow" >
+        <property name="frameShadow">
          <enum>QFrame::Raised</enum>
         </property>
-        <layout class="QVBoxLayout" >
-         <property name="margin" >
-          <number>0</number>
-         </property>
-         <property name="spacing" >
+        <layout class="QVBoxLayout">
+         <property name="spacing">
           <number>6</number>
          </property>
+         <property name="margin" stdset="0">
+          <number>0</number>
+         </property>
          <item>
-          <widget class="QRadioButton" name="rb_box1" >
-           <property name="text" >
+          <widget class="QRadioButton" name="rb_box1">
+           <property name="text">
             <string>Single box with ...</string>
            </property>
-           <property name="checked" >
+           <property name="checked">
             <bool>true</bool>
            </property>
-           <property name="autoExclusive" >
+           <property name="autoExclusive">
             <bool>false</bool>
            </property>
           </widget>
          </item>
          <item>
           <spacer>
-           <property name="orientation" >
+           <property name="orientation">
             <enum>Qt::Vertical</enum>
            </property>
-           <property name="sizeHint" >
+           <property name="sizeHint" stdset="0">
             <size>
              <width>20</width>
              <height>40</height>
@@ -172,12 +171,12 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="2" >
+      <item row="0" column="2">
        <spacer>
-        <property name="orientation" >
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeHint" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>231</width>
           <height>20</height>
@@ -185,176 +184,180 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="0" >
-       <widget class="QRadioButton" name="rb_shapes" >
-        <property name="text" >
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="rb_shapes">
+        <property name="text">
          <string>Shapes on layer (multi clip)</string>
         </property>
-        <property name="autoExclusive" >
+        <property name="autoExclusive">
          <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="1" column="1" colspan="2" >
-       <widget class="QGroupBox" name="grp_box1" >
-        <property name="title" >
+      <item row="1" column="1" colspan="2">
+       <widget class="QGroupBox" name="grp_box1">
+        <property name="title">
          <string>Box Boundaries</string>
         </property>
-        <layout class="QGridLayout" >
-         <property name="margin" >
+        <layout class="QGridLayout">
+         <property name="margin" stdset="0">
           <number>9</number>
          </property>
-         <property name="spacing" >
+         <property name="spacing">
           <number>6</number>
          </property>
-         <item row="1" column="3" >
-          <widget class="QLabel" name="label_6" >
-           <property name="text" >
+         <item row="1" column="3">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
             <string>y =</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="0" >
-          <widget class="QLabel" name="label_5" >
-           <property name="text" >
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
             <string>2nd corner</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="1" >
-          <widget class="QLabel" name="label_4" >
-           <property name="text" >
+         <item row="1" column="1">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
             <string>x =</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="0" >
-          <widget class="QLabel" name="label_3" >
-           <property name="text" >
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
             <string>1st corner</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="1" >
-          <widget class="QLabel" name="label" >
-           <property name="text" >
+         <item row="0" column="1">
+          <widget class="QLabel" name="label">
+           <property name="text">
             <string>x =</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="3" >
-          <widget class="QLabel" name="label_2" >
-           <property name="text" >
+         <item row="0" column="3">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
             <string>y =</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="4" >
-          <widget class="QLineEdit" name="le_y2" />
+         <item row="1" column="4">
+          <widget class="QLineEdit" name="le_y2"/>
          </item>
-         <item row="1" column="2" >
-          <widget class="QLineEdit" name="le_x2" />
+         <item row="1" column="2">
+          <widget class="QLineEdit" name="le_x2"/>
          </item>
-         <item row="0" column="4" >
-          <widget class="QLineEdit" name="le_y1" />
+         <item row="0" column="4">
+          <widget class="QLineEdit" name="le_y1"/>
          </item>
-         <item row="0" column="2" >
-          <widget class="QLineEdit" name="le_x1" />
+         <item row="0" column="2">
+          <widget class="QLineEdit" name="le_x1"/>
          </item>
         </layout>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2" >
-       <widget class="QGroupBox" name="grp_box2" >
-        <property name="title" >
+      <item row="2" column="1" colspan="2">
+       <widget class="QGroupBox" name="grp_box2">
+        <property name="title">
          <string>Box Center And Dimensions</string>
         </property>
-        <layout class="QGridLayout" >
-         <property name="margin" >
+        <layout class="QGridLayout">
+         <property name="margin" stdset="0">
           <number>9</number>
          </property>
-         <property name="spacing" >
+         <property name="spacing">
           <number>6</number>
          </property>
-         <item row="1" column="3" >
-          <widget class="QLabel" name="label_7" >
-           <property name="text" >
+         <item row="1" column="3">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
             <string>h =</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="0" >
-          <widget class="QLabel" name="label_8" >
-           <property name="text" >
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_8">
+           <property name="text">
             <string>Dimensions</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="1" >
-          <widget class="QLabel" name="label_9" >
-           <property name="text" >
+         <item row="1" column="1">
+          <widget class="QLabel" name="label_9">
+           <property name="text">
             <string>w =</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="0" >
-          <widget class="QLabel" name="label_10" >
-           <property name="text" >
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_10">
+           <property name="text">
             <string>Center</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="1" >
-          <widget class="QLabel" name="label_11" >
-           <property name="text" >
+         <item row="0" column="1">
+          <widget class="QLabel" name="label_11">
+           <property name="text">
             <string>x =</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="3" >
-          <widget class="QLabel" name="label_12" >
-           <property name="text" >
+         <item row="0" column="3">
+          <widget class="QLabel" name="label_12">
+           <property name="text">
             <string>y =</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="4" >
-          <widget class="QLineEdit" name="le_h" />
+         <item row="1" column="4">
+          <widget class="QLineEdit" name="le_h"/>
          </item>
-         <item row="1" column="2" >
-          <widget class="QLineEdit" name="le_w" />
+         <item row="1" column="2">
+          <widget class="QLineEdit" name="le_w"/>
          </item>
-         <item row="0" column="4" >
-          <widget class="QLineEdit" name="le_y" />
+         <item row="0" column="4">
+          <widget class="QLineEdit" name="le_y"/>
          </item>
-         <item row="0" column="2" >
-          <widget class="QLineEdit" name="le_x" />
+         <item row="0" column="2">
+          <widget class="QLineEdit" name="le_x"/>
          </item>
         </layout>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2" >
-       <widget class="QRadioButton" name="rb_rulers" >
-        <property name="text" >
+      <item row="3" column="0" colspan="2">
+       <widget class="QRadioButton" name="rb_rulers">
+        <property name="text">
          <string>From ruler start and end points (multi clip)</string>
         </property>
-        <property name="autoExclusive" >
+        <property name="autoExclusive">
          <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="0" column="1" >
-       <widget class="lay::LayerSelectionComboBox" name="cb_layer" />
+      <item row="0" column="1">
+       <widget class="lay::LayerSelectionComboBox" name="cb_layer">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
        <height>40</height>
@@ -363,12 +366,12 @@
     </spacer>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="button_box" >
-     <property name="orientation" >
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons" >
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::NoButton|QDialogButtonBox::Ok</set>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -406,11 +409,11 @@
    <receiver>ClipDialog</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>248</x>
      <y>254</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>157</x>
      <y>274</y>
     </hint>
@@ -422,11 +425,11 @@
    <receiver>ClipDialog</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>316</x>
      <y>260</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
     </hint>

--- a/src/lay/lay/FillDialog.ui
+++ b/src/lay/lay/FillDialog.ui
@@ -49,7 +49,7 @@
        <item>
         <widget class="QFrame" name="frame">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -70,8 +70,30 @@
           <property name="spacing">
            <number>6</number>
           </property>
+          <item row="0" column="1">
+           <spacer>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>15</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
           <item row="0" column="0">
            <widget class="QFrame" name="frame_5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>
@@ -131,10 +153,13 @@
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
                </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Expanding</enum>
+               </property>
                <property name="sizeHint" stdset="0">
                 <size>
                  <width>20</width>
-                 <height>40</height>
+                 <height>20</height>
                 </size>
                </property>
               </spacer>
@@ -142,20 +167,7 @@
             </layout>
            </widget>
           </item>
-          <item row="0" column="1">
-           <spacer>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="0" colspan="3">
+          <item row="2" column="0" colspan="3">
            <widget class="QFrame" name="frame_6">
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
@@ -204,19 +216,6 @@
                  <number>0</number>
                 </property>
                 <item>
-                 <spacer>
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
                  <widget class="QLabel" name="label_37">
                   <property name="text">
                    <string>Keep distance to border of fill area of</string>
@@ -251,6 +250,12 @@
           </item>
           <item row="0" column="2">
            <widget class="QStackedWidget" name="fill_area_stack">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="currentIndex">
              <number>1</number>
             </property>
@@ -277,10 +282,13 @@
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
                 </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Expanding</enum>
+                </property>
                 <property name="sizeHint" stdset="0">
                  <size>
                   <width>241</width>
-                  <height>40</height>
+                  <height>20</height>
                  </size>
                 </property>
                </spacer>
@@ -302,6 +310,9 @@
                <widget class="lay::LayerSelectionComboBox" name="cb_layer">
                 <property name="enabled">
                  <bool>true</bool>
+                </property>
+                <property name="sizeAdjustPolicy">
+                 <enum>QComboBox::AdjustToContents</enum>
                 </property>
                </widget>
               </item>
@@ -408,6 +419,22 @@
              </layout>
             </widget>
            </widget>
+          </item>
+          <item row="1" column="0" colspan="3">
+           <spacer name="verticalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>

--- a/src/lay/lay/ReplacePropertiesBox.ui
+++ b/src/lay/lay/ReplacePropertiesBox.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>ReplacePropertiesBox</class>
- <widget class="QWidget" name="ReplacePropertiesBox" >
-  <property name="geometry" >
+ <widget class="QWidget" name="ReplacePropertiesBox">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,32 +10,32 @@
     <height>265</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" >
-   <property name="margin" >
+  <layout class="QGridLayout">
+   <property name="margin" stdset="0">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="spacing">
     <number>6</number>
    </property>
-   <item row="2" column="0" >
-    <widget class="QLabel" name="label_54" >
-     <property name="text" >
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_54">
+     <property name="text">
       <string>Height</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2" >
-    <widget class="QLineEdit" name="box_height" />
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="box_height"/>
    </item>
-   <item row="3" column="0" colspan="3" >
+   <item row="3" column="0" colspan="3">
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>200</width>
        <height>40</height>
@@ -42,69 +43,79 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="1" >
-    <widget class="QLabel" name="label_60" >
-     <property name="text" >
+   <item row="2" column="1">
+    <widget class="QLabel" name="label_60">
+     <property name="text">
       <string/>
      </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" >
-    <widget class="QLabel" name="label_58" >
-     <property name="text" >
+   <item row="0" column="1">
+    <widget class="QLabel" name="label_58">
+     <property name="text">
       <string/>
      </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
      </property>
     </widget>
    </item>
-   <item row="1" column="2" >
-    <widget class="QLineEdit" name="box_width" />
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="box_width"/>
    </item>
-   <item row="1" column="0" >
-    <widget class="QLabel" name="label_55" >
-     <property name="text" >
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_55">
+     <property name="text">
       <string>Width</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1" >
-    <widget class="QLabel" name="label_59" >
-     <property name="text" >
+   <item row="1" column="1">
+    <widget class="QLabel" name="label_59">
+     <property name="text">
       <string/>
      </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" >
-    <widget class="QLabel" name="label_53" >
-     <property name="text" >
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_53">
+     <property name="text">
       <string>Layer</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="3" >
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+   <item row="1" column="3">
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="3" >
-    <widget class="QLabel" name="label_2" >
-     <property name="text" >
+   <item row="2" column="3">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2" >
-    <widget class="lay::LayerSelectionComboBox" name="box_layer" />
+   <item row="0" column="2">
+    <widget class="lay::LayerSelectionComboBox" name="box_layer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -115,6 +126,8 @@
    <header>layWidgets.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../icons/icons.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/lay/lay/ReplacePropertiesPath.ui
+++ b/src/lay/lay/ReplacePropertiesPath.ui
@@ -1,37 +1,38 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>ReplacePropertiesPath</class>
- <widget class="QWidget" name="ReplacePropertiesPath" >
-  <property name="geometry" >
+ <widget class="QWidget" name="ReplacePropertiesPath">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>239</width>
+    <width>246</width>
     <height>241</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" >
-   <property name="margin" >
+  <layout class="QGridLayout">
+   <property name="margin" stdset="0">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0" >
-    <widget class="QLabel" name="label_55" >
-     <property name="text" >
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_55">
+     <property name="text">
       <string>Width</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3" >
+   <item row="2" column="0" colspan="3">
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>200</width>
        <height>40</height>
@@ -39,42 +40,52 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="0" >
-    <widget class="QLabel" name="label_54" >
-     <property name="text" >
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_54">
+     <property name="text">
       <string>Layer</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2" >
-    <widget class="lay::LayerSelectionComboBox" name="path_layer" />
-   </item>
-   <item row="1" column="1" >
-    <widget class="QLabel" name="label_61" >
-     <property name="text" >
-      <string/>
+   <item row="0" column="2">
+    <widget class="lay::LayerSelectionComboBox" name="path_layer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2" >
-    <widget class="QLineEdit" name="path_width" />
-   </item>
-   <item row="0" column="1" >
-    <widget class="QLabel" name="label_62" >
-     <property name="text" >
-      <string/>
-     </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
      </property>
     </widget>
    </item>
-   <item row="1" column="3" >
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+   <item row="1" column="1">
+    <widget class="QLabel" name="label_61">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="path_width"/>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="label_62">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>
@@ -88,6 +99,8 @@
    <header>layWidgets.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../icons/icons.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/lay/lay/ReplacePropertiesShape.ui
+++ b/src/lay/lay/ReplacePropertiesShape.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>ReplacePropertiesShape</class>
- <widget class="QWidget" name="ReplacePropertiesShape" >
-  <property name="geometry" >
+ <widget class="QWidget" name="ReplacePropertiesShape">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,39 +10,19 @@
     <height>187</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" >
-   <property name="margin" >
-    <number>9</number>
-   </property>
-   <property name="spacing" >
+  <layout class="QGridLayout">
+   <property name="spacing">
     <number>6</number>
    </property>
-   <item row="0" column="1" >
-    <widget class="QLabel" name="label_57" >
-     <property name="text" >
-      <string/>
-     </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" >
-    <widget class="QLabel" name="label_47" >
-     <property name="text" >
-      <string>Layer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3" >
+   <item row="2" column="0" colspan="3">
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>10</width>
        <height>281</height>
@@ -49,17 +30,48 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="2" >
-    <widget class="lay::LayerSelectionComboBox" name="shape_layer" >
-     <property name="sizePolicy" >
-      <sizepolicy>
-       <hsizetype>7</hsizetype>
-       <vsizetype>5</vsizetype>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_47">
+     <property name="text">
+      <string>Layer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="lay::LayerSelectionComboBox" name="shape_layer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
     </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="label_57">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -70,6 +82,8 @@
    <header>layWidgets.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../icons/icons.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/lay/lay/ReplacePropertiesText.ui
+++ b/src/lay/lay/ReplacePropertiesText.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>ReplacePropertiesText</class>
- <widget class="QWidget" name="ReplacePropertiesText" >
-  <property name="geometry" >
+ <widget class="QWidget" name="ReplacePropertiesText">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,125 +10,133 @@
     <height>269</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" >
-   <property name="margin" >
+  <layout class="QGridLayout">
+   <property name="margin" stdset="0">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="spacing">
     <number>6</number>
    </property>
-   <item row="2" column="2" >
-    <widget class="QComboBox" name="text_orientation" >
+   <item row="2" column="2">
+    <widget class="QComboBox" name="text_orientation">
      <item>
-      <property name="text" >
+      <property name="text">
        <string/>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>R0</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/r0_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/r0_24px.png</normaloff>:/r0_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>R90</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/r90_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/r90_24px.png</normaloff>:/r90_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>R180</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/r180_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/r180_24px.png</normaloff>:/r180_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>R270</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/r270_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/r270_24px.png</normaloff>:/r270_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>M0</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/m0_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/m0_24px.png</normaloff>:/m0_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>M45</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/m45_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/m45_24px.png</normaloff>:/m45_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>M90</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/m90_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/m90_24px.png</normaloff>:/m90_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>M135</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/m135_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/m135_24px.png</normaloff>:/m135_24px.png</iconset>
       </property>
      </item>
     </widget>
    </item>
-   <item row="1" column="0" >
-    <widget class="QLabel" name="label_57" >
-     <property name="text" >
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_57">
+     <property name="text">
       <string>Text</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" >
-    <widget class="QLabel" name="label_67" >
-     <property name="text" >
+   <item row="0" column="1">
+    <widget class="QLabel" name="label_67">
+     <property name="text">
       <string/>
      </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
      </property>
     </widget>
    </item>
-   <item row="2" column="1" >
-    <widget class="QLabel" name="label_65" >
-     <property name="text" >
+   <item row="2" column="1">
+    <widget class="QLabel" name="label_65">
+     <property name="text">
       <string/>
      </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
      </property>
     </widget>
    </item>
-   <item row="3" column="2" >
-    <widget class="QLineEdit" name="text_size" />
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="text_size"/>
    </item>
-   <item row="4" column="0" colspan="3" >
+   <item row="4" column="0" colspan="3">
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>200</width>
        <height>40</height>
@@ -135,56 +144,66 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="1" >
-    <widget class="QLabel" name="label_64" >
-     <property name="text" >
+   <item row="1" column="1">
+    <widget class="QLabel" name="label_64">
+     <property name="text">
       <string/>
      </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" >
-    <widget class="QLabel" name="label_58" >
-     <property name="text" >
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_58">
+     <property name="text">
       <string>Orientation</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1" >
-    <widget class="QLabel" name="label_66" >
-     <property name="text" >
+   <item row="3" column="1">
+    <widget class="QLabel" name="label_66">
+     <property name="text">
       <string/>
      </property>
-     <property name="pixmap" >
-      <pixmap resource="layResources.qrc" >:/right_16px@2x.png</pixmap>
+     <property name="pixmap">
+      <pixmap resource="../../icons/icons.qrc">:/right_16px@2x.png</pixmap>
      </property>
     </widget>
    </item>
-   <item row="3" column="0" >
-    <widget class="QLabel" name="label_56" >
-     <property name="text" >
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_56">
+     <property name="text">
       <string>Size</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2" >
-    <widget class="QLineEdit" name="text_string" />
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="text_string"/>
    </item>
-   <item row="0" column="0" >
-    <widget class="QLabel" name="label_55" >
-     <property name="text" >
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_55">
+     <property name="text">
       <string>Layer</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2" >
-    <widget class="lay::LayerSelectionComboBox" name="text_layer" />
+   <item row="0" column="2">
+    <widget class="lay::LayerSelectionComboBox" name="text_layer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
    </item>
-   <item row="3" column="3" >
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+   <item row="3" column="3">
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>
@@ -198,6 +217,8 @@
    <header>layWidgets.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../icons/icons.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/lay/lay/SearchPropertiesBox.ui
+++ b/src/lay/lay/SearchPropertiesBox.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>SearchPropertiesBox</class>
- <widget class="QWidget" name="SearchPropertiesBox" >
-  <property name="geometry" >
+ <widget class="QWidget" name="SearchPropertiesBox">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,80 +10,80 @@
     <height>331</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" >
-   <property name="margin" >
+  <layout class="QGridLayout">
+   <property name="margin" stdset="0">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="spacing">
     <number>6</number>
    </property>
-   <item row="4" column="2" >
-    <widget class="QLineEdit" name="box_height_value" />
+   <item row="4" column="2">
+    <widget class="QLineEdit" name="box_height_value"/>
    </item>
-   <item row="4" column="3" >
-    <widget class="QLabel" name="label_3" >
-     <property name="text" >
+   <item row="4" column="3">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="3" >
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+   <item row="1" column="3">
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string>µm²</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1" >
-    <widget class="QComboBox" name="box_height_op" >
+   <item row="4" column="1">
+    <widget class="QComboBox" name="box_height_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>></string>
+      <property name="text">
+       <string>&gt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>>=</string>
+      <property name="text">
+       <string>&gt;=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="1" column="0" >
-    <widget class="QLabel" name="label_12" >
-     <property name="text" >
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="text">
       <string>Area</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="4" >
+   <item row="5" column="0" colspan="4">
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>200</width>
        <height>281</height>
@@ -90,158 +91,168 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="2" >
-    <widget class="lay::LayerSelectionComboBox" name="box_layer" />
+   <item row="0" column="2">
+    <widget class="lay::LayerSelectionComboBox" name="box_layer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
    </item>
-   <item row="3" column="1" >
-    <widget class="QComboBox" name="box_width_op" >
+   <item row="3" column="1">
+    <widget class="QComboBox" name="box_width_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>></string>
+      <property name="text">
+       <string>&gt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>>=</string>
+      <property name="text">
+       <string>&gt;=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="3" column="3" >
-    <widget class="QLabel" name="label_2" >
-     <property name="text" >
+   <item row="3" column="3">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0" >
-    <widget class="QLabel" name="label_10" >
-     <property name="text" >
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
       <string>Width</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2" >
-    <widget class="QLineEdit" name="box_area_value" />
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="box_area_value"/>
    </item>
-   <item row="1" column="1" >
-    <widget class="QComboBox" name="box_area_op" >
+   <item row="1" column="1">
+    <widget class="QComboBox" name="box_area_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>></string>
+      <property name="text">
+       <string>&gt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>>=</string>
+      <property name="text">
+       <string>&gt;=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="3" column="2" >
-    <widget class="QLineEdit" name="box_width_value" />
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="box_width_value"/>
    </item>
-   <item row="4" column="0" >
-    <widget class="QLabel" name="label_13" >
-     <property name="text" >
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_13">
+     <property name="text">
       <string>Height</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" >
-    <widget class="QLabel" name="label_11" >
-     <property name="text" >
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
       <string>Layer</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" >
-    <widget class="QLabel" name="label_4" >
-     <property name="text" >
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
       <string>Perimeter</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1" >
-    <widget class="QComboBox" name="box_perimeter_op" >
+   <item row="2" column="1">
+    <widget class="QComboBox" name="box_perimeter_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>></string>
+      <property name="text">
+       <string>&gt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>>=</string>
+      <property name="text">
+       <string>&gt;=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="2" column="2" >
-    <widget class="QLineEdit" name="box_perimeter_value" />
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="box_perimeter_value"/>
    </item>
-   <item row="2" column="3" >
-    <widget class="QLabel" name="label_5" >
-     <property name="text" >
+   <item row="2" column="3">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>

--- a/src/lay/lay/SearchPropertiesPath.ui
+++ b/src/lay/lay/SearchPropertiesPath.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>SearchPropertiesPath</class>
- <widget class="QWidget" name="SearchPropertiesPath" >
-  <property name="geometry" >
+ <widget class="QWidget" name="SearchPropertiesPath">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,134 +10,144 @@
     <height>260</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" >
-   <property name="margin" >
+  <layout class="QGridLayout">
+   <property name="margin" stdset="0">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0" >
-    <widget class="QLabel" name="label_21" >
-     <property name="text" >
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_21">
+     <property name="text">
       <string>Length</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2" >
-    <widget class="QLineEdit" name="path_width_value" />
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="path_width_value"/>
    </item>
-   <item row="2" column="0" >
-    <widget class="QLabel" name="label_22" >
-     <property name="text" >
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_22">
+     <property name="text">
       <string>Width</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" >
-    <widget class="QLabel" name="label_19" >
-     <property name="text" >
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_19">
+     <property name="text">
       <string>Layer</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1" >
-    <widget class="QComboBox" name="path_width_op" >
+   <item row="2" column="1">
+    <widget class="QComboBox" name="path_width_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>></string>
+      <property name="text">
+       <string>&gt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>>=</string>
+      <property name="text">
+       <string>&gt;=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="1" column="1" >
-    <widget class="QComboBox" name="path_length_op" >
+   <item row="1" column="1">
+    <widget class="QComboBox" name="path_length_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>></string>
+      <property name="text">
+       <string>&gt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>>=</string>
+      <property name="text">
+       <string>&gt;=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="1" column="2" >
-    <widget class="QLineEdit" name="path_length_value" />
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="path_length_value"/>
    </item>
-   <item row="1" column="3" >
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+   <item row="1" column="3">
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="3" >
-    <widget class="QLabel" name="label_2" >
-     <property name="text" >
+   <item row="2" column="3">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2" >
-    <widget class="lay::LayerSelectionComboBox" name="path_layer" />
+   <item row="0" column="2">
+    <widget class="lay::LayerSelectionComboBox" name="path_layer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
    </item>
-   <item row="3" column="0" colspan="4" >
+   <item row="3" column="0" colspan="4">
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>200</width>
        <height>40</height>

--- a/src/lay/lay/SearchPropertiesShape.ui
+++ b/src/lay/lay/SearchPropertiesShape.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>SearchPropertiesShape</class>
- <widget class="QWidget" name="SearchPropertiesShape" >
-  <property name="geometry" >
+ <widget class="QWidget" name="SearchPropertiesShape">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,134 +10,144 @@
     <height>287</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" >
-   <property name="margin" >
+  <layout class="QGridLayout">
+   <property name="margin" stdset="0">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="spacing">
     <number>6</number>
    </property>
-   <item row="0" column="0" >
-    <widget class="QLabel" name="label_5" >
-     <property name="text" >
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
       <string>Layer</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0" >
-    <widget class="QLabel" name="label_6" >
-     <property name="text" >
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
       <string>Area</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1" >
-    <widget class="QComboBox" name="shape_area_op" >
+   <item row="1" column="1">
+    <widget class="QComboBox" name="shape_area_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>></string>
+      <property name="text">
+       <string>&gt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>>=</string>
+      <property name="text">
+       <string>&gt;=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="2" column="0" >
-    <widget class="QLabel" name="label_7" >
-     <property name="text" >
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
       <string>Perimeter</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2" >
-    <widget class="QLineEdit" name="shape_area_value" />
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="shape_area_value"/>
    </item>
-   <item row="2" column="2" >
-    <widget class="QLineEdit" name="shape_perimeter_value" />
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="shape_perimeter_value"/>
    </item>
-   <item row="2" column="1" >
-    <widget class="QComboBox" name="shape_perimeter_op" >
+   <item row="2" column="1">
+    <widget class="QComboBox" name="shape_perimeter_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>></string>
+      <property name="text">
+       <string>&gt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>>=</string>
+      <property name="text">
+       <string>&gt;=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="1" column="3" >
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+   <item row="1" column="3">
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string>µm²</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="3" >
-    <widget class="QLabel" name="label_2" >
-     <property name="text" >
+   <item row="2" column="3">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
       <string>µm</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2" >
-    <widget class="lay::LayerSelectionComboBox" name="shape_layer" />
+   <item row="0" column="2">
+    <widget class="lay::LayerSelectionComboBox" name="shape_layer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
    </item>
-   <item row="3" column="0" colspan="4" >
+   <item row="3" column="0" colspan="4">
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>200</width>
        <height>281</height>

--- a/src/lay/lay/SearchPropertiesText.ui
+++ b/src/lay/lay/SearchPropertiesText.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>SearchPropertiesText</class>
- <widget class="QWidget" name="SearchPropertiesText" >
-  <property name="geometry" >
+ <widget class="QWidget" name="SearchPropertiesText">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,201 +10,219 @@
     <height>308</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" >
-   <property name="margin" >
+  <layout class="QGridLayout">
+   <property name="margin" stdset="0">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="spacing">
     <number>6</number>
    </property>
-   <item row="0" column="0" >
-    <widget class="QLabel" name="label_20" >
-     <property name="text" >
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_20">
+     <property name="text">
       <string>Layer</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0" >
-    <widget class="QLabel" name="label_24" >
-     <property name="text" >
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_24">
+     <property name="text">
       <string>Size</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="2" >
-    <widget class="QLineEdit" name="text_size_value" />
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="text_size_value"/>
    </item>
-   <item row="0" column="2" >
-    <widget class="lay::LayerSelectionComboBox" name="text_layer" />
+   <item row="0" column="2">
+    <widget class="lay::LayerSelectionComboBox" name="text_layer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
    </item>
-   <item row="1" column="1" >
-    <widget class="QComboBox" name="text_string_op" >
+   <item row="1" column="1">
+    <widget class="QComboBox" name="text_string_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>~</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!~</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="1" column="2" >
-    <widget class="QLineEdit" name="text_string_value" />
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="text_string_value"/>
    </item>
-   <item row="2" column="2" >
-    <widget class="QComboBox" name="text_orientation_value" >
+   <item row="2" column="2">
+    <widget class="QComboBox" name="text_orientation_value">
      <item>
-      <property name="text" >
+      <property name="text">
        <string/>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>R0</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/r0_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/r0_24px.png</normaloff>:/r0_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>R90</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/r90_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/r90_24px.png</normaloff>:/r90_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>R180</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/r180_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/r180_24px.png</normaloff>:/r180_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>R270</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/r270_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/r270_24px.png</normaloff>:/r270_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>M0</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/m0_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/m0_24px.png</normaloff>:/m0_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>M45</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/m45_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/m45_24px.png</normaloff>:/m45_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>M90</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/m90_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/m90_24px.png</normaloff>:/m90_24px.png</iconset>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>M135</string>
       </property>
-      <property name="icon" >
-       <iconset resource="layResources.qrc" >:/m135_24px.png</iconset>
+      <property name="icon">
+       <iconset resource="../../icons/icons.qrc">
+        <normaloff>:/m135_24px.png</normaloff>:/m135_24px.png</iconset>
       </property>
      </item>
     </widget>
    </item>
-   <item row="3" column="1" >
-    <widget class="QComboBox" name="text_size_op" >
+   <item row="3" column="1">
+    <widget class="QComboBox" name="text_size_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>&lt;=</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>></string>
+      <property name="text">
+       <string>&gt;</string>
       </property>
      </item>
      <item>
-      <property name="text" >
-       <string>>=</string>
+      <property name="text">
+       <string>&gt;=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="1" column="0" >
-    <widget class="QLabel" name="label_23" >
-     <property name="text" >
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_23">
+     <property name="text">
       <string>Text</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" >
-    <widget class="QLabel" name="label_25" >
-     <property name="text" >
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_25">
+     <property name="text">
       <string>Orientation</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1" >
-    <widget class="QComboBox" name="text_orientation_op" >
+   <item row="2" column="1">
+    <widget class="QComboBox" name="text_orientation_op">
      <item>
-      <property name="text" >
+      <property name="text">
        <string>==</string>
       </property>
      </item>
      <item>
-      <property name="text" >
+      <property name="text">
        <string>!=</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="3" column="3" >
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+   <item row="3" column="3">
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string> µm</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="4" >
+   <item row="4" column="0" colspan="4">
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>200</width>
        <height>101</height>
@@ -229,6 +248,8 @@
   <tabstop>text_size_op</tabstop>
   <tabstop>text_size_value</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../icons/icons.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/lay/lay/layClipDialog.cc
+++ b/src/lay/lay/layClipDialog.cc
@@ -91,9 +91,11 @@ ClipDialog::menu_activated (const std::string &symbol)
 {
   if (symbol == "clip_tool::show") {
 
-    lay::CellView cv = view ()->cellview (view ()->active_cellview_index ());
+    int cv_index = view ()->active_cellview_index ();
+
+    lay::CellView cv = view ()->cellview (cv_index);
     if (cv.is_valid ()) {
-      cb_layer->set_layout (&cv->layout ());
+      cb_layer->set_view (view (), cv_index);
       show ();
       activate ();
     }

--- a/src/lay/lay/layFillDialog.cc
+++ b/src/lay/lay/layFillDialog.cc
@@ -102,10 +102,12 @@ FillDialog::menu_activated (const std::string &symbol)
 {
   if (symbol == "fill_tool::show") {
 
-    lay::CellView cv = mp_view->cellview (mp_view->active_cellview_index ());
+    int cv_index = mp_view->active_cellview_index ();
+
+    lay::CellView cv = mp_view->cellview (cv_index);
     if (cv.is_valid ()) {
-      cb_layer->set_layout (&cv->layout ());
-      fc_boundary_layer->set_layout (&cv->layout ());
+      cb_layer->set_view (mp_view, cv_index);
+      fc_boundary_layer->set_view (mp_view, cv_index);
       show ();
     }
 

--- a/src/layui/layui/DuplicateLayerDialog.ui
+++ b/src/layui/layui/DuplicateLayerDialog.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>DuplicateLayerDialog</class>
- <widget class="QDialog" name="DuplicateLayerDialog" >
-  <property name="geometry" >
+ <widget class="QDialog" name="DuplicateLayerDialog">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,86 +10,82 @@
     <height>266</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Copy Layer</string>
   </property>
-  <layout class="QVBoxLayout" >
-   <property name="margin" >
-    <number>9</number>
-   </property>
-   <property name="spacing" >
+  <layout class="QVBoxLayout">
+   <property name="spacing">
     <number>6</number>
    </property>
+   <property name="margin" stdset="0">
+    <number>9</number>
+   </property>
    <item>
-    <widget class="QGroupBox" name="groupBox" >
-     <property name="title" >
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
       <string>Copy Layer</string>
      </property>
-     <layout class="QGridLayout" >
-      <property name="margin" >
+     <layout class="QGridLayout">
+      <property name="margin" stdset="0">
        <number>9</number>
       </property>
-      <property name="spacing" >
+      <property name="spacing">
        <number>6</number>
       </property>
-      <item row="3" column="0" colspan="6" >
-       <widget class="Line" name="line_2" >
-        <property name="orientation" >
+      <item row="3" column="0" colspan="6">
+       <widget class="Line" name="line_2">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="2" column="2" >
-       <widget class="lay::CellViewSelectionComboBox" name="cvr_cbx" >
-        <property name="sizePolicy" >
-         <sizepolicy>
-          <hsizetype>5</hsizetype>
-          <vsizetype>0</vsizetype>
+      <item row="2" column="2">
+       <widget class="lay::CellViewSelectionComboBox" name="cvr_cbx">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
        </widget>
       </item>
-      <item row="1" column="2" >
-       <widget class="lay::CellViewSelectionComboBox" name="cv_cbx" >
-        <property name="sizePolicy" >
-         <sizepolicy>
-          <hsizetype>5</hsizetype>
-          <vsizetype>0</vsizetype>
+      <item row="1" column="2">
+       <widget class="lay::CellViewSelectionComboBox" name="cv_cbx">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2" >
-       <widget class="QLabel" name="label_3" >
-        <property name="text" >
+      <item row="2" column="0" colspan="2">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
          <string>Copy to</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2" >
-       <widget class="QLabel" name="label" >
-        <property name="text" >
+      <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
          <string>Source layer</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="3" >
-       <widget class="QLabel" name="label_6" >
-        <property name="text" >
+      <item row="0" column="3">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
          <string>Layer</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="4" colspan="2" >
+      <item row="1" column="4" colspan="2">
        <spacer>
-        <property name="orientation" >
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeHint" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>40</width>
           <height>20</height>
@@ -96,35 +93,43 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="3" >
-       <widget class="lay::LayerSelectionComboBox" name="layer_cbx" />
+      <item row="1" column="3">
+       <widget class="lay::LayerSelectionComboBox" name="layer_cbx">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
-      <item row="2" column="3" >
-       <widget class="lay::LayerSelectionComboBox" name="layerr_cbx" />
+      <item row="2" column="3">
+       <widget class="lay::LayerSelectionComboBox" name="layerr_cbx">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
-      <item row="0" column="2" >
-       <widget class="QLabel" name="label_5" >
-        <property name="text" >
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
          <string>Layout and cell</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="5" >
-       <widget class="QCheckBox" name="clear_cb" >
-        <property name="text" >
+      <item row="2" column="5">
+       <widget class="QCheckBox" name="clear_cb">
+        <property name="text">
          <string>Replace content with source layer</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="4" >
+      <item row="2" column="4">
        <spacer>
-        <property name="orientation" >
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeType" >
+        <property name="sizeType">
          <enum>QSizePolicy::Fixed</enum>
         </property>
-        <property name="sizeHint" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>16</width>
           <height>20</height>
@@ -132,28 +137,28 @@
         </property>
        </spacer>
       </item>
-      <item row="4" column="2" colspan="4" >
-       <widget class="QComboBox" name="hier_mode_cbx" >
+      <item row="4" column="2" colspan="4">
+       <widget class="QComboBox" name="hier_mode_cbx">
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Flatten into target cell</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Top cell only</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Cell by cell below the current cell</string>
          </property>
         </item>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2" >
-       <widget class="QLabel" name="label_7" >
-        <property name="text" >
+      <item row="4" column="0" colspan="2">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
          <string>Hierarchy</string>
         </property>
        </widget>
@@ -163,10 +168,10 @@
    </item>
    <item>
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>623</width>
        <height>51</height>
@@ -175,12 +180,12 @@
     </spacer>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="orientation" >
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons" >
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::NoButton|QDialogButtonBox::Ok</set>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -188,12 +193,12 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>lay::CellViewSelectionComboBox</class>
+   <class>lay::LayerSelectionComboBox</class>
    <extends>QComboBox</extends>
    <header>layWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>lay::LayerSelectionComboBox</class>
+   <class>lay::CellViewSelectionComboBox</class>
    <extends>QComboBox</extends>
    <header>layWidgets.h</header>
   </customwidget>
@@ -206,11 +211,11 @@
    <receiver>DuplicateLayerDialog</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>248</x>
      <y>254</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>157</x>
      <y>274</y>
     </hint>
@@ -222,11 +227,11 @@
    <receiver>DuplicateLayerDialog</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>316</x>
      <y>260</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
     </hint>

--- a/src/plugins/tools/bool/lay_plugin/BooleanOptionsDialog.ui
+++ b/src/plugins/tools/bool/lay_plugin/BooleanOptionsDialog.ui
@@ -1,42 +1,43 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>BooleanOptionsDialog</class>
- <widget class="QDialog" name="BooleanOptionsDialog" >
-  <property name="geometry" >
+ <widget class="QDialog" name="BooleanOptionsDialog">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>535</width>
+    <width>578</width>
     <height>349</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Boolean Operation</string>
   </property>
-  <layout class="QVBoxLayout" >
-   <property name="margin" >
-    <number>9</number>
-   </property>
-   <property name="spacing" >
+  <layout class="QVBoxLayout">
+   <property name="spacing">
     <number>6</number>
    </property>
+   <property name="margin" stdset="0">
+    <number>9</number>
+   </property>
    <item>
-    <widget class="QGroupBox" name="groupBox" >
-     <property name="title" >
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
       <string>Boolean Operation Setup</string>
      </property>
-     <layout class="QGridLayout" >
-      <property name="margin" >
+     <layout class="QGridLayout">
+      <property name="margin" stdset="0">
        <number>9</number>
       </property>
-      <property name="spacing" >
+      <property name="spacing">
        <number>6</number>
       </property>
-      <item row="2" column="3" >
+      <item row="2" column="3">
        <spacer>
-        <property name="orientation" >
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeHint" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>40</width>
           <height>20</height>
@@ -44,158 +45,170 @@
         </property>
        </spacer>
       </item>
-      <item row="3" column="0" colspan="4" >
-       <widget class="Line" name="line" >
-        <property name="orientation" >
+      <item row="3" column="0" colspan="4">
+       <widget class="Line" name="line">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="4" column="1" >
-       <widget class="QComboBox" name="mode_cbx" >
+      <item row="4" column="1">
+       <widget class="QComboBox" name="mode_cbx">
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Union (OR)</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Intersection (AND)</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Difference (A NOT B)</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Difference (B NOT A)</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Symmetric Difference (XOR)</string>
          </property>
         </item>
        </widget>
       </item>
-      <item row="2" column="0" >
-       <widget class="QLabel" name="label_2" >
-        <property name="text" >
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
          <string>Source B</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" >
-       <widget class="QLabel" name="label" >
-        <property name="text" >
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
          <string>Source A</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" >
-       <widget class="QLabel" name="label_4" >
-        <property name="text" >
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
          <string>Mode</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0" >
-       <widget class="QLabel" name="label_3" >
-        <property name="text" >
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
          <string>Result</string>
         </property>
        </widget>
       </item>
-      <item row="8" column="0" >
-       <widget class="QLabel" name="label_7" >
-        <property name="text" >
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
          <string>Hierarchy</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="4" >
-       <widget class="Line" name="line_2" >
-        <property name="orientation" >
+      <item row="7" column="0" colspan="4">
+       <widget class="Line" name="line_2">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="0" column="1" >
-       <widget class="QLabel" name="label_5" >
-        <property name="text" >
+      <item row="0" column="1">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
          <string>Layout and cell</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="2" >
-       <widget class="QLabel" name="label_6" >
-        <property name="text" >
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
          <string>Layer</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="2" >
-       <widget class="QLabel" name="label_8" >
-        <property name="text" >
+      <item row="5" column="2">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
          <string>Layer</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1" >
-       <widget class="QLabel" name="label_9" >
-        <property name="text" >
+      <item row="5" column="1">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
          <string>Layout and cell</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1" >
-       <widget class="lay::CellViewSelectionComboBox" name="cva_cbx" />
+      <item row="1" column="1">
+       <widget class="lay::CellViewSelectionComboBox" name="cva_cbx"/>
       </item>
-      <item row="2" column="1" >
-       <widget class="lay::CellViewSelectionComboBox" name="cvb_cbx" />
+      <item row="2" column="1">
+       <widget class="lay::CellViewSelectionComboBox" name="cvb_cbx"/>
       </item>
-      <item row="6" column="1" >
-       <widget class="lay::CellViewSelectionComboBox" name="cvr_cbx" />
+      <item row="6" column="1">
+       <widget class="lay::CellViewSelectionComboBox" name="cvr_cbx"/>
       </item>
-      <item row="1" column="2" >
-       <widget class="lay::LayerSelectionComboBox" name="layera_cbx" />
+      <item row="1" column="2">
+       <widget class="lay::LayerSelectionComboBox" name="layera_cbx">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
-      <item row="2" column="2" >
-       <widget class="lay::LayerSelectionComboBox" name="layerb_cbx" />
+      <item row="2" column="2">
+       <widget class="lay::LayerSelectionComboBox" name="layerb_cbx">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
-      <item row="6" column="2" >
-       <widget class="lay::LayerSelectionComboBox" name="layerr_cbx" />
+      <item row="6" column="2">
+       <widget class="lay::LayerSelectionComboBox" name="layerr_cbx">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
-      <item row="6" column="3" >
-       <widget class="QLabel" name="label_10" >
-        <property name="text" >
+      <item row="6" column="3">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
          <string>(Layer is overwritten)</string>
         </property>
        </widget>
       </item>
-      <item row="9" column="1" colspan="3" >
-       <widget class="QCheckBox" name="min_coherence_cb" >
-        <property name="text" >
+      <item row="9" column="1" colspan="3">
+       <widget class="QCheckBox" name="min_coherence_cb">
+        <property name="text">
          <string>Minimum coherence (for touching corners)</string>
         </property>
        </widget>
       </item>
-      <item row="8" column="1" colspan="3" >
-       <widget class="QComboBox" name="hier_mode_cbx" >
+      <item row="8" column="1" colspan="3">
+       <widget class="QComboBox" name="hier_mode_cbx">
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Flat</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Top cell only</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Individually for current and subcells (semi hierarchical)</string>
          </property>
         </item>
@@ -206,10 +219,10 @@
    </item>
    <item>
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>506</width>
        <height>51</height>
@@ -218,12 +231,12 @@
     </spacer>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="orientation" >
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons" >
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::NoButton|QDialogButtonBox::Ok</set>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -231,12 +244,12 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>lay::CellViewSelectionComboBox</class>
+   <class>lay::LayerSelectionComboBox</class>
    <extends>QComboBox</extends>
    <header>layWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>lay::LayerSelectionComboBox</class>
+   <class>lay::CellViewSelectionComboBox</class>
    <extends>QComboBox</extends>
    <header>layWidgets.h</header>
   </customwidget>
@@ -249,11 +262,11 @@
    <receiver>BooleanOptionsDialog</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>248</x>
      <y>254</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>157</x>
      <y>274</y>
     </hint>
@@ -265,11 +278,11 @@
    <receiver>BooleanOptionsDialog</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>316</x>
      <y>260</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
     </hint>

--- a/src/plugins/tools/bool/lay_plugin/MergeOptionsDialog.ui
+++ b/src/plugins/tools/bool/lay_plugin/MergeOptionsDialog.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>MergeOptionsDialog</class>
- <widget class="QDialog" name="MergeOptionsDialog" >
-  <property name="geometry" >
+ <widget class="QDialog" name="MergeOptionsDialog">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,125 +10,125 @@
     <height>331</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Merge Operation</string>
   </property>
-  <layout class="QVBoxLayout" >
-   <property name="spacing" >
+  <layout class="QVBoxLayout">
+   <property name="spacing">
     <number>6</number>
    </property>
-   <property name="margin" >
+   <property name="margin" stdset="0">
     <number>9</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox" >
-     <property name="title" >
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
       <string>Merge Operation Setup</string>
      </property>
-     <layout class="QGridLayout" >
-      <property name="margin" >
+     <layout class="QGridLayout">
+      <property name="margin" stdset="0">
        <number>9</number>
       </property>
-      <property name="spacing" >
+      <property name="spacing">
        <number>6</number>
       </property>
-      <item row="7" column="1" colspan="3" >
-       <widget class="QComboBox" name="hier_mode_cbx" >
+      <item row="7" column="1" colspan="3">
+       <widget class="QComboBox" name="hier_mode_cbx">
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Flat</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Top cell only</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Individually for current and subcells (semi hierarchical)</string>
          </property>
         </item>
        </widget>
       </item>
-      <item row="5" column="3" >
-       <widget class="QLabel" name="label_10" >
-        <property name="text" >
+      <item row="5" column="3">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
          <string>(Layer is overwritten)</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="2" >
-       <widget class="QLabel" name="label_8" >
-        <property name="text" >
+      <item row="4" column="2">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
          <string>Layer</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1" >
-       <widget class="lay::CellViewSelectionComboBox" name="cvr_cbx" />
+      <item row="5" column="1">
+       <widget class="lay::CellViewSelectionComboBox" name="cvr_cbx"/>
       </item>
-      <item row="3" column="1" >
-       <widget class="QLineEdit" name="threshold_le" />
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="threshold_le"/>
       </item>
-      <item row="6" column="0" colspan="4" >
-       <widget class="Line" name="line_2" >
-        <property name="orientation" >
+      <item row="6" column="0" colspan="4">
+       <widget class="Line" name="line_2">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="7" column="0" >
-       <widget class="QLabel" name="label_7" >
-        <property name="text" >
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
          <string>Hierarchy</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1" >
-       <widget class="lay::CellViewSelectionComboBox" name="cv_cbx" />
+      <item row="1" column="1">
+       <widget class="lay::CellViewSelectionComboBox" name="cv_cbx"/>
       </item>
-      <item row="5" column="0" >
-       <widget class="QLabel" name="label_3" >
-        <property name="text" >
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
          <string>Result</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" >
-       <widget class="QLabel" name="label" >
-        <property name="text" >
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
          <string>Source</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="2" >
-       <widget class="QLabel" name="label_6" >
-        <property name="text" >
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
          <string>Layer</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="4" >
-       <widget class="Line" name="line" >
-        <property name="orientation" >
+      <item row="2" column="0" colspan="4">
+       <widget class="Line" name="line">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="8" column="1" colspan="3" >
-       <widget class="QCheckBox" name="min_coherence_cb" >
-        <property name="text" >
+      <item row="8" column="1" colspan="3">
+       <widget class="QCheckBox" name="min_coherence_cb">
+        <property name="text">
          <string>Minimum coherence (for touching corners)</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="3" >
+      <item row="1" column="3">
        <spacer>
-        <property name="orientation" >
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeHint" stdset="0" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>40</width>
           <height>20</height>
@@ -135,36 +136,44 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="2" >
-       <widget class="lay::LayerSelectionComboBox" name="layer_cbx" />
+      <item row="1" column="2">
+       <widget class="lay::LayerSelectionComboBox" name="layer_cbx">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
-      <item row="5" column="2" >
-       <widget class="lay::LayerSelectionComboBox" name="layerr_cbx" />
+      <item row="5" column="2">
+       <widget class="lay::LayerSelectionComboBox" name="layerr_cbx">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
-      <item row="3" column="2" colspan="2" >
-       <widget class="QLabel" name="label_2" >
-        <property name="text" >
+      <item row="3" column="2" colspan="2">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
          <string>(0: all polygons, 1: at least two overlapping ...)</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1" >
-       <widget class="QLabel" name="label_5" >
-        <property name="text" >
+      <item row="0" column="1">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
          <string>Layout and cell</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1" >
-       <widget class="QLabel" name="label_9" >
-        <property name="text" >
+      <item row="4" column="1">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
          <string>Layout and cell</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" >
-       <widget class="QLabel" name="label_4" >
-        <property name="text" >
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
          <string>Overlap threshold</string>
         </property>
        </widget>
@@ -174,10 +183,10 @@
    </item>
    <item>
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" stdset="0" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>506</width>
        <height>51</height>
@@ -186,11 +195,11 @@
     </spacer>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="orientation" >
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons" >
+     <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
@@ -199,12 +208,12 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>lay::CellViewSelectionComboBox</class>
+   <class>lay::LayerSelectionComboBox</class>
    <extends>QComboBox</extends>
    <header>layWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>lay::LayerSelectionComboBox</class>
+   <class>lay::CellViewSelectionComboBox</class>
    <extends>QComboBox</extends>
    <header>layWidgets.h</header>
   </customwidget>
@@ -217,11 +226,11 @@
    <receiver>MergeOptionsDialog</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>248</x>
      <y>254</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>157</x>
      <y>274</y>
     </hint>
@@ -233,11 +242,11 @@
    <receiver>MergeOptionsDialog</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>316</x>
      <y>260</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
     </hint>

--- a/src/plugins/tools/bool/lay_plugin/SizingOptionsDialog.ui
+++ b/src/plugins/tools/bool/lay_plugin/SizingOptionsDialog.ui
@@ -1,133 +1,134 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>SizingOptionsDialog</class>
- <widget class="QDialog" name="SizingOptionsDialog" >
-  <property name="geometry" >
+ <widget class="QDialog" name="SizingOptionsDialog">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>567</width>
-    <height>331</height>
+    <width>680</width>
+    <height>341</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Sizing Operation</string>
   </property>
-  <layout class="QVBoxLayout" >
-   <property name="margin" >
-    <number>9</number>
-   </property>
-   <property name="spacing" >
+  <layout class="QVBoxLayout">
+   <property name="spacing">
     <number>6</number>
    </property>
+   <property name="margin" stdset="0">
+    <number>9</number>
+   </property>
    <item>
-    <widget class="QGroupBox" name="groupBox" >
-     <property name="title" >
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
       <string>Sizing Operation Setup</string>
      </property>
-     <layout class="QGridLayout" >
-      <property name="margin" >
+     <layout class="QGridLayout">
+      <property name="margin" stdset="0">
        <number>9</number>
       </property>
-      <property name="spacing" >
+      <property name="spacing">
        <number>6</number>
       </property>
-      <item row="8" column="1" colspan="3" >
-       <widget class="QComboBox" name="hier_mode_cbx" >
+      <item row="8" column="1" colspan="3">
+       <widget class="QComboBox" name="hier_mode_cbx">
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Flat</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Top cell only</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Individually for current and subcells (semi hierarchical)</string>
          </property>
         </item>
        </widget>
       </item>
-      <item row="6" column="3" >
-       <widget class="QLabel" name="label_10" >
-        <property name="text" >
+      <item row="6" column="3">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
          <string>(Layer is overwritten)</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="2" >
-       <widget class="QLabel" name="label_8" >
-        <property name="text" >
+      <item row="5" column="2">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
          <string>Layer</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1" >
-       <widget class="lay::CellViewSelectionComboBox" name="cvr_cbx" />
+      <item row="6" column="1">
+       <widget class="lay::CellViewSelectionComboBox" name="cvr_cbx"/>
       </item>
-      <item row="3" column="1" >
-       <widget class="QLineEdit" name="value_le" />
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="value_le"/>
       </item>
-      <item row="7" column="0" colspan="4" >
-       <widget class="Line" name="line_2" >
-        <property name="orientation" >
+      <item row="7" column="0" colspan="4">
+       <widget class="Line" name="line_2">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="8" column="0" >
-       <widget class="QLabel" name="label_7" >
-        <property name="text" >
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
          <string>Hierarchy</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1" >
-       <widget class="lay::CellViewSelectionComboBox" name="cv_cbx" />
+      <item row="1" column="1">
+       <widget class="lay::CellViewSelectionComboBox" name="cv_cbx"/>
       </item>
-      <item row="6" column="0" >
-       <widget class="QLabel" name="label_3" >
-        <property name="text" >
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
          <string>Result</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" >
-       <widget class="QLabel" name="label" >
-        <property name="text" >
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
          <string>Source</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="2" >
-       <widget class="QLabel" name="label_6" >
-        <property name="text" >
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
          <string>Layer</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="4" >
-       <widget class="Line" name="line" >
-        <property name="orientation" >
+      <item row="2" column="0" colspan="4">
+       <widget class="Line" name="line">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="9" column="1" colspan="3" >
-       <widget class="QCheckBox" name="min_coherence_cb" >
-        <property name="text" >
+      <item row="9" column="1" colspan="3">
+       <widget class="QCheckBox" name="min_coherence_cb">
+        <property name="text">
          <string>Minimum coherence (for touching corners)</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="3" >
+      <item row="1" column="3">
        <spacer>
-        <property name="orientation" >
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeHint" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>40</width>
           <height>20</height>
@@ -135,76 +136,84 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="2" >
-       <widget class="lay::LayerSelectionComboBox" name="layer_cbx" />
+      <item row="1" column="2">
+       <widget class="lay::LayerSelectionComboBox" name="layer_cbx">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
-      <item row="6" column="2" >
-       <widget class="lay::LayerSelectionComboBox" name="layerr_cbx" />
+      <item row="6" column="2">
+       <widget class="lay::LayerSelectionComboBox" name="layerr_cbx">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
-      <item row="3" column="2" colspan="2" >
-       <widget class="QLabel" name="label_2" >
-        <property name="text" >
+      <item row="3" column="2" colspan="2">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
          <string>Single value or pair (one per direction: sx,sy)</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1" >
-       <widget class="QLabel" name="label_5" >
-        <property name="text" >
+      <item row="0" column="1">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
          <string>Layout and cell</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1" >
-       <widget class="QLabel" name="label_9" >
-        <property name="text" >
+      <item row="5" column="1">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
          <string>Layout and cell</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" >
-       <widget class="QLabel" name="label_4" >
-        <property name="text" >
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
          <string>Sizing value</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" >
-       <widget class="QLabel" name="label_11" >
-        <property name="text" >
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_11">
+        <property name="text">
          <string>Cutoff mode</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1" >
-       <widget class="QComboBox" name="cutoff_cbx" >
+      <item row="4" column="1">
+       <widget class="QComboBox" name="cutoff_cbx">
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Strict (diagonal)</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Strong (octagon)</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Moderate (sharp bends only)</string>
          </property>
         </item>
         <item>
-         <property name="text" >
-          <string>Weak (sharps bends >135 deg.)</string>
+         <property name="text">
+          <string>Weak (sharps bends &gt;135 deg.)</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Long limit (x10)</string>
          </property>
         </item>
         <item>
-         <property name="text" >
+         <property name="text">
           <string>Extreme limit (x100)</string>
          </property>
         </item>
@@ -215,10 +224,10 @@
    </item>
    <item>
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>506</width>
        <height>51</height>
@@ -227,12 +236,12 @@
     </spacer>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="orientation" >
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons" >
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::NoButton|QDialogButtonBox::Ok</set>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -240,12 +249,12 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>lay::CellViewSelectionComboBox</class>
+   <class>lay::LayerSelectionComboBox</class>
    <extends>QComboBox</extends>
    <header>layWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>lay::LayerSelectionComboBox</class>
+   <class>lay::CellViewSelectionComboBox</class>
    <extends>QComboBox</extends>
    <header>layWidgets.h</header>
   </customwidget>
@@ -258,11 +267,11 @@
    <receiver>SizingOptionsDialog</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>248</x>
      <y>254</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>157</x>
      <y>274</y>
     </hint>
@@ -274,11 +283,11 @@
    <receiver>SizingOptionsDialog</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>316</x>
      <y>260</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
     </hint>


### PR DESCRIPTION
Also: clip and fill dialog now display layer names from the layer view. Fixed geometry of fill dialog.

Hope I got all places where the layer selection box was configured as adjust size = on first show.