### PR TITLE
Fixed issue-1349 (Add application events for indicating start/finish …

### DIFF
--- a/src/lay/lay/gsiDeclLayMainWindow.cc
+++ b/src/lay/lay/gsiDeclLayMainWindow.cc
@@ -760,6 +760,16 @@ Class<lay::MainWindow> decl_MainWindow (QT_EXTERNAL_BASE (QMainWindow) "lay", "M
     "\n"
     "This event has been added in version 0.25.\n"
   ) +
+  gsi::event ("on_session_about_to_be_restored", &lay::MainWindow::begin_restore_session,
+    "@brief An event indicating that a session is about to be restored\n"
+    "\n"
+    "This event has been added in version 0.28.8.\n"
+  ) +
+  gsi::event ("on_session_restored", &lay::MainWindow::end_restore_session,
+    "@brief An event indicating that a session was restored\n"
+    "\n"
+    "This event has been added in version 0.28.8.\n"
+  ) +
   gsi::method ("show_macro_editor", &lay::MainWindow::show_macro_editor, gsi::arg ("cat", std::string ()), gsi::arg ("add", false),
     "@brief Shows the macro editor\n"
     "If 'cat' is given, this category will be selected in the category tab. "

--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -2062,8 +2062,17 @@ MainWindow::restore_session (const std::string &fn)
   m_current_session = fn;
   lay::Session session;
   session.load (fn);
-  session.restore (*this);
-  read_dock_widget_state ();
+
+  begin_restore_session ();
+  try {
+    session.restore (*this);
+    read_dock_widget_state ();
+    end_restore_session ();
+  } catch (...) {
+    read_dock_widget_state ();
+    end_restore_session ();
+    throw;
+  }
 }
 
 void

--- a/src/lay/lay/layMainWindow.h
+++ b/src/lay/lay/layMainWindow.h
@@ -533,28 +533,6 @@ public:
   std::string all_layout_file_formats () const;
 
   /**
-   *  @brief An event indicating that the current view has changed
-   *  This event is fired if the current view was changed.
-   *  The current view's reference is updated if the event is issued.
-   */
-  tl::Event current_view_changed_event;
-
-  /**
-   *  @brief An event indicating that a view was closed
-   *  If a view is closed, this event is triggered. When the signal is sent,
-   *  the view still points to the view being closed which is still valid.
-   *  The integer parameter will receive the index of the view about to be closed.
-   */
-  tl::event<int> view_closed_event;
-
-  /**
-   *  @brief An event indicating that a new view is created
-   *  If a new view is created, this event will be triggered.
-   *  The integer parameter will receive the index of the view that was created.
-   */
-  tl::event<int> view_created_event;
-
-  /**
    *  @brief Adds an entry to the MRU list with the initial technology
    */
   void add_mru (const std::string &fn);
@@ -594,6 +572,38 @@ public:
    *  @brief Reimplementation of the dropEvent event handler
    */
   void dropEvent(QDropEvent *event);
+
+  /**
+   *  @brief An event indicating that the current view has changed
+   *  This event is fired if the current view was changed.
+   *  The current view's reference is updated if the event is issued.
+   */
+  tl::Event current_view_changed_event;
+
+  /**
+   *  @brief An event indicating that a view was closed
+   *  If a view is closed, this event is triggered. When the signal is sent,
+   *  the view still points to the view being closed which is still valid.
+   *  The integer parameter will receive the index of the view about to be closed.
+   */
+  tl::event<int> view_closed_event;
+
+  /**
+   *  @brief An event indicating that a new view is created
+   *  If a new view is created, this event will be triggered.
+   *  The integer parameter will receive the index of the view that was created.
+   */
+  tl::event<int> view_created_event;
+
+  /**
+   *  @brief An event indicating the start of a session restore
+   */
+  tl::Event begin_restore_session;
+
+  /**
+   *  @brief An event indicating the end of a session restore
+   */
+  tl::Event end_restore_session;
 
 signals:
   void closed ();


### PR DESCRIPTION
…of restoring session)

The new events are called
* MainWindow#on_session_about_to_be_restored (called before the session is restored)
* MainWindow#on_session_restored (called after the session was restored)