### PR TITLE
Fixed issue #1373 (shapes with user properties are skipped from secon…

### DIFF
--- a/src/db/db/dbFlatRegion.cc
+++ b/src/db/db/dbFlatRegion.cc
@@ -313,6 +313,7 @@ RegionDelegate *FlatRegion::add (const Region &other) const
   if (other_flat) {
 
     new_region->raw_polygons ().insert (other_flat->raw_polygons ().get_layer<db::Polygon, db::unstable_layer_tag> ().begin (), other_flat->raw_polygons ().get_layer<db::Polygon, db::unstable_layer_tag> ().end ());
+    new_region->raw_polygons ().insert (other_flat->raw_polygons ().get_layer<db::PolygonWithProperties, db::unstable_layer_tag> ().begin (), other_flat->raw_polygons ().get_layer<db::PolygonWithProperties, db::unstable_layer_tag> ().end ());
 
   } else {
 
@@ -343,6 +344,7 @@ RegionDelegate *FlatRegion::add_in_place (const Region &other)
   if (other_flat) {
 
     polygons.insert (other_flat->raw_polygons ().get_layer<db::Polygon, db::unstable_layer_tag> ().begin (), other_flat->raw_polygons ().get_layer<db::Polygon, db::unstable_layer_tag> ().end ());
+    polygons.insert (other_flat->raw_polygons ().get_layer<db::PolygonWithProperties, db::unstable_layer_tag> ().begin (), other_flat->raw_polygons ().get_layer<db::PolygonWithProperties, db::unstable_layer_tag> ().end ());
 
   } else {
 

--- a/src/db/unit_tests/dbRegionTests.cc
+++ b/src/db/unit_tests/dbRegionTests.cc
@@ -2081,6 +2081,24 @@ TEST(50_PropertiesFlat)
   EXPECT_EQ (s.at_end (), true);
 }
 
+//  "+" operator with properties (issue #1373)
+TEST(50b_PropertiesFlat)
+{
+  db::Region r, rr;
+
+  r.insert (db::Box (0, 0, 10, 20));
+  rr.insert (db::Box (0, 0, 100, 200));
+  rr.insert (db::BoxWithProperties (db::Box (1, 2, 101, 202), 1));
+
+  EXPECT_EQ ((db::Region () + rr).to_string (), "(0,0;0,200;100,200;100,0);(1,2;1,202;101,202;101,2)");
+  EXPECT_EQ ((rr + db::Region ()).to_string (), "(0,0;0,200;100,200;100,0);(1,2;1,202;101,202;101,2)");
+  EXPECT_EQ ((r + rr).to_string (), "(0,0;0,20;10,20;10,0);(0,0;0,200;100,200;100,0);(1,2;1,202;101,202;101,2)");
+
+  r += rr;
+
+  EXPECT_EQ (r.to_string (), "(0,0;0,20;10,20;10,0);(0,0;0,200;100,200;100,0);(1,2;1,202;101,202;101,2)");
+}
+
 TEST(51_PropertiesFlatFromLayout)
 {
   db::Layout ly;


### PR DESCRIPTION
…d input of flat region's '+' operator)