### PR TITLE
building arm64 wheels with cibuildwheel (uses intel runner)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,12 +49,13 @@ jobs:
           HOST_CCACHE_DIR="$(ccache -k cache_dir)"
           mkdir -p $HOST_CCACHE_DIR
       - name: Build wheels  # check https://cibuildwheel.readthedocs.io/en/stable/setup/#github-actions
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.12.3
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value
         env:
           CIBW_BUILD: ${{ matrix.cibuild }}
+
       - name: Download Cache from Docker (linux only)
         if: ${{ runner.os == 'Linux' }}
         # hack until https://github.com/pypa/cibuildwheel/issues/1030 is fixed

--- a/ci-scripts/macos/libpng-patch.sh
+++ b/ci-scripts/macos/libpng-patch.sh
@@ -1,0 +1,29 @@
+# Solves issue #1346
+# Deprecate patch when Github Actions provides Apple Silicon runners.
+# WARNING: Only run this in a CI runner
+
+# Issue: klayout depends on libpng, which is loaded by homebrew.
+# But M1 wheels are cross-compiled in an intel host, so by default
+# libpng.dylib has an x86 architecture. This prevents linking the library
+# in the tl library.
+
+# Patch solution: manually download libpng arm64 pre-built library from homebrew
+
+# Reading
+# https://stackoverflow.com/questions/55110564/how-can-i-install-a-homebrew-bottle-designed-for-a-different-previous-version
+# https://github.com/Homebrew/homebrew-core/blob/6abea16e917b12d6af4912736f66eb8d42bf089b/Formula/libpng.rb
+
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+
+# Check if we're about to build an arm64 wheel. WARNING universal wheels not supported
+if [ "$_PYTHON_HOST_PLATFORM" == "macosx-11.0-arm64" ]
+then
+    # Exit early if done
+    test -f /tmp/libpng-apple-silicon-installed && exit 0
+    curl -L -H "Authorization: Bearer QQ==" -o /tmp/libpng-1.6.39.arm64_big_sur.bottle.1.tar.gz https://ghcr.io/v2/homebrew/core/libpng/blobs/sha256:cf59cedc91afc6f2f3377567ba82b99b97744c60925a5d1df6ecf923fdb2f234
+    brew reinstall -f /tmp/libpng-1.6.39.arm64_big_sur.bottle.1.tar.gz || exit 1
+    touch /tmp/libpng-apple-silicon-installed
+elif [ -f "/tmp/libpng-apple-silicon-installed" ]; then
+    brew reinstall -f libpng && rm -f /tmp/libpng-apple-silicon-installed
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ test-command = [
 # Disable building PyPy wheels on all platforms
 skip = "pp*"
 
+# Skip trying to test arm64 builds on Intel Macs
+test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
+
 [tool.cibuildwheel.linux]
 # beware: the before-all script does not persist environment variables!
 # No point in defining $PATH or $CCACHE_DIR
@@ -27,6 +30,14 @@ environment-pass = ["HOST_CCACHE_DIR"]
 before-all = [
   "brew install libpng",
   "brew deps --tree --installed",
+]
+
+# TEMP while Github Actions does not provide an Apple Silicon runner
+# TODO Simply remove it when it's available
+archs = ["x86_64", "arm64"]
+before-build = [
+  "ccache -s",
+  "bash {project}/ci-scripts/macos/libpng-patch.sh",
 ]
 # Repair macOS wheels (include libpng with the wheel, for example)
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v --ignore-missing-dependencies {wheel}"


### PR DESCRIPTION
Currently cibuildwheel will attempt to build arm64 in an intel machine. Though this might work, I am not sure the external libraries would load correctly. I want to try and compare wheels built on an M1 machine.