### PR TITLE
fix passing `mi.persisted` to `add_meta_info` of `Layout` and `Cell`

### DIFF
--- a/src/db/db/gsiDeclDbCell.cc
+++ b/src/db/db/gsiDeclDbCell.cc
@@ -1000,7 +1000,7 @@ static void cell_remove_meta_info (db::Cell *cell, const std::string &name)
 static void cell_add_meta_info (db::Cell *cell, const MetaInfo &mi)
 {
   if (cell->layout ()) {
-    cell->layout ()->add_meta_info (cell->cell_index (), mi.name, db::MetaInfo (mi.description, mi.value));
+    cell->layout ()->add_meta_info (cell->cell_index (), mi.name, db::MetaInfo (mi.description, mi.value, mi.persisted));
   }
 }
 

--- a/src/db/db/gsiDeclDbLayout.cc
+++ b/src/db/db/gsiDeclDbLayout.cc
@@ -905,7 +905,7 @@ static db::Cell *create_cell4 (db::Layout *layout, const std::string &name, cons
 
 static void layout_add_meta_info (db::Layout *layout, const MetaInfo &mi)
 {
-  layout->add_meta_info (mi.name, db::MetaInfo (mi.description, mi.value));
+  layout->add_meta_info (mi.name, db::MetaInfo (mi.description, mi.value, mi.persisted));
 }
 
 static MetaInfo *layout_get_meta_info (db::Layout *layout, const std::string &name)


### PR DESCRIPTION
Hi Matthias,

First of all thanks a lot for 0.28.8! It was way faster than I expected ;)

Unfortunately, I think the LayoutMetaInfo still don't get written to the gds (at least with the example in [LayoutMetaInfo](https://klayout.de/doc/code/class_LayoutMetaInfo.html).

I have a full test case for the python module here:

<details>

<summary>test.py</summary>

```python
import klayout.db as kdb
from pathlib import Path

ly1 = kdb.Layout()
c1 = ly1.create_cell("A")
meta = kdb.LayoutMetaInfo("answer", 42)
meta.persisted = True
c1.add_meta_info(meta)
meta_get = c1.meta_info("answer")
print(f"{meta_get.name=}", f"{meta_get.value=}", meta_get.is_persisted())
meta_ly = kdb.LayoutMetaInfo("also-answer", 42)
meta_ly.persisted = True
ly1.add_meta_info(meta_ly)
ly1.write("test.gds")
print("wrote gds with meta")
print("reading gds with meta")
ly2 = kdb.Layout()
ly2.read("test.gds")
c2 = ly2.cell("A")
print("trying to get meta info")
for meta_info in c2.each_meta_info():
    print(f"{meta_info.name=}", f"{meta_info.value=}")
    break
else:
    print("couldn't find any meta info, trying to find it in layout")
for meta_info in ly2.each_meta_info():
    print(f"{meta_info.name=}", f"{meta_info.value=}")
```
</details>

<details>
<summary>output</summary>

```bash
meta_get.name='answer' meta_get.value=42 False
wrote gds with meta
reading gds with meta
trying to get meta info
couldn't find any meta info, trying to find it in layout
meta_info.name='mod_time' meta_info.value='5/25/2023 13:28:03'
meta_info.name='access_time' meta_info.value='5/25/2023 13:28:03'
meta_info.name='dbuu' meta_info.value='0.001'
meta_info.name='dbum' meta_info.value='1e-09'
meta_info.name='libname' meta_info.value='LIB'
```
</details>

I have also tried to do it in the GUI, same result.


I believe these two fixes, should fix it. After testing int he python module from this:

<details>

<summary>output</summary>

```bash
meta_get.name='answer' meta_get.value=42 True
wrote gds with meta
reading gds with meta
trying to get meta info
meta_info.name='answer' meta_info.value=42
meta_info.name='mod_time' meta_info.value='5/25/2023 13:42:22'
meta_info.name='access_time' meta_info.value='5/25/2023 13:42:22'
meta_info.name='dbuu' meta_info.value='0.001'
meta_info.name='dbum' meta_info.value='1e-09'
meta_info.name='libname' meta_info.value='LIB'
meta_info.name='also-answer' meta_info.value=42
```
</details>

The Layout one works, but the Cell one still doesn't work. But when inspecting the resulting gds (with `strm2gdstxt`):

<details>

<summary>to.gds.txt</summary>

```
HEADER 600 
BGNLIB 5/25/2023 13:50:03 5/25/2023 13:50:03 
LIBNAME LIB
UNITS 0.001 1e-09 

BGNSTR 5/25/2023 13:50:03 5/25/2023 13:50:03 
STRNAME $$$CONTEXT_INFO$$$

BOUNDARY 
LAYER 0 
DATATYPE 0 
XY 0: 0
0: 0
0: 0
0: 0
0: 0
PROPATTR 0 
PROPVALUE META('also-answer')=#l42
ENDEL 
SREF 
SNAME A
XY 0: 0
PROPATTR 1 
PROPVALUE META(answer)=#l42
PROPATTR 0 
PROPVALUE CELL=A
ENDEL 
ENDSTR 

BGNSTR 5/25/2023 13:50:03 5/25/2023 13:50:03 
STRNAME A
ENDSTR 
ENDLIB
```

</details>

We can see the meta data is there. Maybe there is another bug/missing piece of code in the loader for the metadata?