### PR TITLE
make_stubs now automatically detects installed klayout in python environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,15 +71,12 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-# The following was taken from https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/
+  # The following was taken from https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0  # Optional, use if you use setuptools_scm
-        submodules: true  # Optional, use if you have submodules
+    - uses: actions/checkout@v3
 
     - name: Build SDist
       run: pipx run build --sdist
@@ -102,7 +99,7 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
 
   upload_to_pypi:
     needs: [build, make_sdist]


### PR DESCRIPTION
Solves a minor issue introduced in #1390. Now I can run make_stubs without calling it from the built pymod folder -- suffices to have klayout in a python site packages.