### PR TITLE
Improve compile time by 30% using pre-compiled headers (proof of concept)

### DIFF
--- a/src/db/db/db.pro
+++ b/src/db/db/db.pro
@@ -6,6 +6,9 @@ include($$PWD/../../lib.pri)
 
 DEFINES += MAKE_DB_LIBRARY
 
+CONFIG += precompile_header
+PRECOMPILED_HEADER = stable.h
+
 SOURCES = \
   dbArray.cc \
   dbBox.cc \

--- a/src/db/db/stable.h
+++ b/src/db/db/stable.h
@@ -1,0 +1,12 @@
+#include "dbCommon.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "gsiClass.h"
+#include "tlObject.h"
+#include "tlString.h"
+
+#include "dbCell.h"

--- a/src/tl/tl/stable.h
+++ b/src/tl/tl/stable.h
@@ -1,0 +1,7 @@
+#include "tlCommon.h"
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "tlString.h"

--- a/src/tl/tl/tl.pro
+++ b/src/tl/tl/tl.pro
@@ -6,6 +6,9 @@ include($$PWD/../../lib.pri)
 
 DEFINES += MAKE_TL_LIBRARY
 
+CONFIG += precompile_header
+PRECOMPILED_HEADER = stable.h
+
 FORMS =
 
 SOURCES = \


### PR DESCRIPTION
This is a proof of concept that hopes to improve KLayout compile time by ~30% using [pre-compiled headers](https://doc.qt.io/qt-6/qmake-precompiledheaders.html) (PCH's).

Parsing and compiling headers takes time, especially if they are large. Effort spent parsing and compiling headers is then potentially repeated across multiple translation units. A pre-compiled header (PCH) collects the most frequently used or expensive headers, pre-compiles it, and caches it for use in other translation units.

### Benefits
I picked two KLayout source directories and made a small proof of concept PCH. I selected headers to include in the PCH based on:

1. How expensive compiling them appeared in clang's `-ftime-trace` output
2. How stable they looked, i.e. whether or not they were from the standard library or used in multiple files

On my 2019 x86-64 machine running FreeBSD and clang 14.0.5 with a single make job started in these two subdirectories, I saw significantly improved compile time:

| Directory | Without PCH (sec) | With PCH (sec) | Speedup |
| --- | ------- | ----- | ----- |
| `tl/tl` | 52.56 | 25.57 | 51% |
| `db/db` | 731 | 541 | 26% |

There are no source changes per-se. It is enough to identify headers that would be suitable for inclusion in the PCH and adding those to a separate file.

### Disadvantages
Header files that are included in the PCH need to be stable, i.e. not change very frequently. This is because if any of these headers change, then the PCH needs to be re-built, and subsequently all of the translation units depending on the PCH must also be re-built. This means that including headers that are changed frequently may make rebuilds slower, because more translation units may need to be re-compiled.

Unfortunately, I'm not familiar enough with the codebase to accurately gauge whether or not certain headers will likely change or not, and so I have probably not picked the best header files to include in the PCH. Hence this is a proof of concept.

### Conclusion
Using PCH might be a promising way to improve KLayout's build time by upwards of 30%. The whole code base need not be converted all at one time; it's possible to focus on the slowest source directories first. Somebody with more knowledge about the codebase should identify the right headers to include in the PCH (in addition to using compiler profiler output).