### PR TITLE
Added the missing includes

### DIFF
--- a/src/gsi/gsi/gsiSerialisation.h
+++ b/src/gsi/gsi/gsiSerialisation.h
@@ -31,6 +31,7 @@
 #include <list>
 #include <memory>
 #include <cstring>
+#include <optional>
 
 namespace gsi
 {

--- a/src/gsi/gsi/gsiTypes.h
+++ b/src/gsi/gsi/gsiTypes.h
@@ -33,6 +33,8 @@
 #include <vector>
 #include <list>
 #include <set>
+#include <optional>
+#include <cstdint>
 #include <stdexcept>
 
 #if defined(HAVE_QT)


### PR DESCRIPTION
Added the missing includes <optional> and <cstdint> to GsiTypes.h.
Added the missing include <optional> to GsiSerialzation.h

fixes #1523