### PR TITLE
Fix tabbing order in "Editor Options / Instance / Array Instance" UI.

### DIFF
--- a/src/edt/edt/EditorOptionsInst.ui
+++ b/src/edt/edt/EditorOptionsInst.ui
@@ -548,6 +548,23 @@
    <header>layWidgets.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>lib_cbx</tabstop>
+  <tabstop>browse_pb</tabstop>
+  <tabstop>cell_le</tabstop>
+  <tabstop>place_origin_cb</tabstop>
+  <tabstop>scale_le</tabstop>
+  <tabstop>angle_le</tabstop>
+  <tabstop>mirror_cbx</tabstop>
+  <tabstop>array_grp</tabstop>
+  <tabstop>rows_le</tabstop>
+  <tabstop>columns_le</tabstop>
+  <tabstop>row_x_le</tabstop>
+  <tabstop>row_y_le</tabstop>
+  <tabstop>column_x_le</tabstop>
+  <tabstop>column_y_le</tabstop>
+ </tabstops>
  <resources>
   <include location="../../icons/icons.qrc"/>
  </resources>


### PR DESCRIPTION
Currently, in the Array Instance sub-UI that appears when inserting a new array instance, trying to use the "tab" key to move through the entry widgets results in going through them in a strange order (column step x, column step y, row step y, row step x, dimension columns, dimension rows).  This patch declares the correct (natural) tabbing order for the widgets.

(However, I didn't actually check that this works because I haven't actually looked into the build scripts for klayout yet.)