### PR TITLE
Klayout PyCell integration

### DIFF
--- a/src/db/db/dbPCellDeclaration.h
+++ b/src/db/db/dbPCellDeclaration.h
@@ -30,6 +30,7 @@
 #include "dbLayout.h"
 #include "tlVariant.h"
 #include "tlObject.h"
+#include "tlOptional.h"
 
 namespace db
 {
@@ -69,7 +70,7 @@ public:
    *  @brief The default constructor
    */
   PCellParameterDeclaration ()
-    : m_hidden (false), m_readonly (false), m_type (t_none)
+    : m_hidden (false), m_readonly (false), m_type (t_none), m_range()
   {
     // .. nothing yet ..
   }
@@ -78,7 +79,7 @@ public:
    *  @brief The constructor with a name
    */
   PCellParameterDeclaration (const std::string &name)
-    : m_hidden (false), m_readonly (false), m_type (t_none), m_name (name)
+    : m_hidden (false), m_readonly (false), m_type (t_none), m_name (name), m_range()
   {
     // .. nothing yet ..
   }
@@ -87,7 +88,7 @@ public:
    *  @brief The constructor with a name, type and description
    */
   PCellParameterDeclaration (const std::string &name, type t, const std::string &description)
-    : m_hidden (false), m_readonly (false), m_type (t), m_name (name), m_description (description)
+    : m_hidden (false), m_readonly (false), m_type (t), m_name (name), m_description (description), m_range()
   {
     // .. nothing yet ..
   }
@@ -96,7 +97,7 @@ public:
    *  @brief The constructor with a name, type, description and default value
    */
   PCellParameterDeclaration (const std::string &name, type t, const std::string &description, const tl::Variant &def)
-    : m_default (def), m_hidden (false), m_readonly (false), m_type (t), m_name (name), m_description (description)
+    : m_default (def), m_hidden (false), m_readonly (false), m_type (t), m_name (name), m_description (description), m_range()
   {
     // .. nothing yet ..
   }
@@ -105,7 +106,7 @@ public:
    *  @brief The constructor with a name, type, description, default value and unit
    */
   PCellParameterDeclaration (const std::string &name, type t, const std::string &description, const tl::Variant &def, const std::string &unit)
-    : m_default (def), m_hidden (false), m_readonly (false), m_type (t), m_name (name), m_description (description), m_unit (unit)
+    : m_default (def), m_hidden (false), m_readonly (false), m_type (t), m_name (name), m_description (description), m_unit (unit), m_range()
   {
     // .. nothing yet ..
   }
@@ -114,7 +115,7 @@ public:
    *  @brief The constructor with a name, type and description and choice values / choice descriptions
    */
   PCellParameterDeclaration (const std::string &name, type t, const std::string &description, const std::vector<tl::Variant> &choices, const std::vector<std::string> &choice_descriptions)
-    : m_choices (choices), m_choice_descriptions (choice_descriptions), m_hidden (false), m_readonly (false), m_type (t), m_name (name), m_description (description)
+    : m_choices (choices), m_choice_descriptions (choice_descriptions), m_hidden (false), m_readonly (false), m_type (t), m_name (name), m_description (description), m_range()
   {
     // .. nothing yet ..
   }
@@ -248,6 +249,53 @@ public:
   }
 
   /**
+   *  @brief A enum describing the action of range violated
+   */
+  enum Action {
+    t_Reject = 1,   //  reject the parameter
+    t_Accept,       //  accept the parameter
+    t_Use_Default   //  use a default parameter (currently not supported)
+  };
+
+  void set_range (const tl::Variant& low, const tl::Variant& high, const tl::Variant& resolution, Action action = t_Reject)
+  {
+    m_range = Range(low, high, resolution, action);
+  }
+
+  typedef struct _Range {
+    _Range() :
+      m_low(),
+      m_high(),
+      m_resolution(),
+      m_action(t_Reject) {}
+
+    _Range(const tl::Variant& low, const tl::Variant& high, const tl::Variant& resolution, Action action = t_Reject) :
+      m_low(low),
+      m_high(high),
+      m_resolution(resolution),
+      m_action(action) {}
+
+    bool operator== (const _Range& other) const
+    {
+      return
+        m_low == other.m_low &&
+        m_high == other.m_high &&
+        m_resolution == other.m_resolution &&
+        m_action == other.m_action;
+    }
+
+    tl::Variant m_low;
+    tl::Variant m_high;
+    tl::Variant m_resolution;
+    Action m_action;
+  } Range;
+
+  const tl::optional<Range>& get_range() const
+  {
+    return m_range;
+  }
+
+   /**
    *  @brief Getter for the choice descriptions
    *
    *  The choice descriptions correspond to choice values. The descriptions
@@ -280,7 +328,8 @@ public:
            m_type == d.m_type &&
            m_name == d.m_name &&
            m_description == d.m_description &&
-           m_unit == d.m_unit;
+           m_unit == d.m_unit &&
+           m_range == d.m_range;
   }
 
 private:
@@ -291,6 +340,7 @@ private:
   type m_type;
   std::string m_name;
   std::string m_description, m_unit;
+  tl::optional<Range> m_range;
 };
 
 /**

--- a/src/edt/edt/edtPCellParametersPage.h
+++ b/src/edt/edt/edtPCellParametersPage.h
@@ -181,6 +181,7 @@ private:
   void get_parameters_internal (db::ParameterStates &states, bool &edit_error);
   std::vector<tl::Variant> parameter_from_states (const db::ParameterStates &states) const;
   void states_from_parameters (db::ParameterStates &states, const std::vector<tl::Variant> &parameters);
+  void check_range(const tl::Variant& value, const db::PCellParameterDeclaration::Range& range);
 };
 
 }

--- a/src/gsi/gsi/gsiTypes.h
+++ b/src/gsi/gsi/gsiTypes.h
@@ -35,6 +35,7 @@
 #include <set>
 #include <stdexcept>
 #include <cstdint>
+#include <optional>
 
 #if defined(HAVE_QT)
 #include <QString>

--- a/src/pymod/distutils_src/klayout/dbcore.pyi
+++ b/src/pymod/distutils_src/klayout/dbcore.pyi
@@ -36569,6 +36569,18 @@ class PCellParameterDeclaration:
     r"""
     @brief Type code: string data
     """
+    REJECT: ClassVar[int]
+    r"""
+    @brief Action type: reject violating parameter
+    """
+    ACCEPT: ClassVar[int]
+    r"""
+    @brief Action type: accept violating parameter
+    """
+    USE_DEFAULT: ClassVar[int]
+    r"""
+    @brief Action type: use default instead violating parameter (currently not supported)
+    """
     default: Any
     r"""
     Getter:

--- a/src/tl/tl/tl.pro
+++ b/src/tl/tl/tl.pro
@@ -55,7 +55,8 @@ SOURCES = \
     tlEquivalenceClusters.cc \
     tlUniqueName.cc \
     tlRecipe.cc \
-    tlEnv.cc
+    tlEnv.cc \
+    tlOptional.cc
 
 HEADERS = \
     tlAlgorithm.h \
@@ -121,7 +122,8 @@ HEADERS = \
     tlUniqueName.h \
     tlRecipe.h \
     tlSelect.h \
-    tlEnv.h 
+    tlEnv.h \
+    tlOptional.h
 
 equals(HAVE_GIT2, "1") {
 

--- a/src/tl/tl/tlOptional.cc
+++ b/src/tl/tl/tlOptional.cc
@@ -1,0 +1,32 @@
+/*
+
+  KLayout Layout Viewer
+  Copyright (C) 2006-2024 Matthias Koefferlein
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+
+#include "tlOptional.h"
+
+namespace tl
+{
+
+#if __cplusplus < 201703L
+extern const nullopt_t nullopt = nullopt_t();
+#endif
+
+} // namespace tl

--- a/src/tl/tl/tlOptional.h
+++ b/src/tl/tl/tlOptional.h
@@ -1,0 +1,160 @@
+/*
+
+  KLayout Layout Viewer
+  Copyright (C) 2006-2024 Matthias Koefferlein
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+
+#ifndef HDR_tlOptional
+#define HDR_tlOptional
+
+#include "tlAssert.h"
+
+#include <iostream>
+#include <optional>
+
+namespace tl
+{
+
+#if __cplusplus >= 201703L
+
+template<typename T>
+class optional : public std::optional<T> {};
+
+#else
+
+struct nullopt_t {};
+
+extern const nullopt_t nullopt;
+
+/*
+ * Poor man's partly implementation of C++17's std::optional
+ */
+template<typename T>
+class optional
+{
+public:
+    optional() :
+        a_value(),
+        a_isValid(false)
+    {}
+
+    optional(const nullopt_t&) :
+        a_value(),
+        a_isValid(false)
+    {}
+
+    optional(const T &value) :
+        a_value(value),
+        a_isValid(true)
+    {}
+
+    void reset()
+    {
+        a_isValid = false;
+    }
+
+    bool has_value() const { return a_isValid; }
+
+    T &value()
+    {
+        tl_assert(a_isValid);
+
+        return a_value;
+    }
+
+    const T &value() const
+    {
+        tl_assert(a_isValid);
+
+        return a_value;
+    }
+
+    T& operator* ()
+    {
+        return value();
+    }
+
+    const T& operator* () const
+    {
+        return value();
+    }
+
+    T* operator-> ()
+    {
+        return &value();
+    }
+
+    const T* operator-> () const
+    {
+        return &value();
+    }
+
+private:
+    T a_value;
+    bool a_isValid;
+};
+
+template<typename T>
+optional<T> make_optional(const T& value)
+{
+    return optional<T>(value);
+}
+
+template<typename T>
+bool operator==(const optional<T> &lhs, const optional<T> &rhs)
+{
+    if (lhs.has_value() != rhs.has_value())
+    {
+        return false;
+    }
+
+    if (!lhs.has_value())
+    {
+        return true;
+    }
+
+    return lhs.value() == rhs.value();
+}
+
+template<typename T>
+bool operator!=(const optional<T> &lhs, const optional<T> &rhs)
+{
+    return !(lhs == rhs);
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &ostr, const optional<T> &rhs)
+{
+    if (rhs.has_value())
+    {
+        ostr << rhs.value();
+    }
+    else
+    {
+        ostr << "<invalid>";
+    }
+
+    return ostr;
+}
+
+#endif /* __cplusplus >= 201703L */
+
+} // namespace tl
+
+#endif /* HDR_tlOptional */


### PR DESCRIPTION
-added tl::optional as derivate of std::optional for c++17 and above, reduced
 implementation otherwise
-fixed missing include for c++17 and above
-added range constraints for PCell parameter