### PR TITLE
Add include needed for git_error_set_str for libgit2>=1.8

### DIFF
--- a/src/tl/tl/tlGit.cc
+++ b/src/tl/tl/tlGit.cc
@@ -30,6 +30,9 @@
 #include "tlEnv.h"
 
 #include <git2.h>
+#if LIBGIT2_VER_MAJOR > 1 || (LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR >= 8)
+    #include <git2/sys/errors.h>
+#endif
 #include <cstdio>
 
 namespace tl


### PR DESCRIPTION
`git_error_set_str` was moved into the `sys` subdirectory in libgit2 1.8.0. See [this pull
request](https://github.com/libgit2/libgit2/pull/6625) for details and [this issue](https://github.com/libgit2/libgit2/issues/6776) for more context.