### PR TITLE
Implemented solution for issue-1678

### DIFF
--- a/src/lay/lay/layHelpSource.cc
+++ b/src/lay/lay/layHelpSource.cc
@@ -23,6 +23,7 @@
 
 #include "layHelpSource.h"
 #include "layApplication.h"
+#include "layVersion.h"
 
 #include "tlLog.h"
 #include "tlTimer.h"
@@ -273,7 +274,8 @@ HelpSource::initialize_index ()
 
     bool ok = false;
 
-    const QString help_index_cache_file = QString::fromUtf8 ("help-index.xml");
+    QString help_index_cache_file = QString::fromUtf8 (tl::sprintf ("help-index-%s-qt%d.xml.gz", lay::Version::version (), int (QT_VERSION_MAJOR)));
+
     std::string per_user_cache_file;
     if (! lay::ApplicationBase::instance ()->appdata_path ().empty ()) {
       per_user_cache_file = tl::to_string (QDir (tl::to_qstring (lay::ApplicationBase::instance ()->appdata_path ())).absoluteFilePath (help_index_cache_file));
@@ -341,7 +343,7 @@ HelpSource::produce_index_file (const std::string &path)
 
   try {
 
-    tl::OutputStream os (path, tl::OutputStream::OM_Plain);
+    tl::OutputStream os (path, tl::OutputStream::OM_Zlib);
     help_index_structure.write (os, *this);
 
   } catch (tl::Exception &ex) {

--- a/src/lay/lay/layHelpSource.cc
+++ b/src/lay/lay/layHelpSource.cc
@@ -274,7 +274,8 @@ HelpSource::initialize_index ()
 
     bool ok = false;
 
-    QString help_index_cache_file = tl::to_qstring (tl::sprintf ("help-index-%s-qt%d.xml.gz", lay::Version::version (), int (QT_VERSION_MAJOR)));
+    int qt = int (QT_VERSION >> 16);
+    QString help_index_cache_file = tl::to_qstring (tl::sprintf ("help-index-%s-qt%d.xml.gz", lay::Version::version (), qt));
 
     std::string per_user_cache_file;
     if (! lay::ApplicationBase::instance ()->appdata_path ().empty ()) {

--- a/src/lay/lay/layHelpSource.cc
+++ b/src/lay/lay/layHelpSource.cc
@@ -274,7 +274,7 @@ HelpSource::initialize_index ()
 
     bool ok = false;
 
-    QString help_index_cache_file = QString::fromUtf8 (tl::sprintf ("help-index-%s-qt%d.xml.gz", lay::Version::version (), int (QT_VERSION_MAJOR)));
+    QString help_index_cache_file = tl::to_qstring (tl::sprintf ("help-index-%s-qt%d.xml.gz", lay::Version::version (), int (QT_VERSION_MAJOR)));
 
     std::string per_user_cache_file;
     if (! lay::ApplicationBase::instance ()->appdata_path ().empty ()) {


### PR DESCRIPTION
* Help index file name encodes KLayout version and Qt version
* Help index file is gzip compressed to save space as many files are expected to accumulate now