### PR TITLE
Replace "removed" Ruby method "file.exists?" with "file.exist?"

### DIFF
--- a/src/drc/drc/built-in-macros/_drc_engine.rb
+++ b/src/drc/drc/built-in-macros/_drc_engine.rb
@@ -122,7 +122,7 @@ module DRC
 
         #  Apply waive DB if possible
         wdb_file = rdb_file + ".w"
-        if File.exists?(wdb_file)
+        if File.exist?(wdb_file)
           begin
             wdb = RBA::ReportDatabase::new
             wdb.load(wdb_file)


### PR DESCRIPTION
This PR replaces the only `file.exists?` method in the project with `file.exist?`.

`file.exists?` was deprecated [and removed from Ruby version 3.2.0](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/). I encountered this error when trying to open a DRC script with Ruby version 3.3.2 installed.