### PR TITLE
Fixed DeepShapeStore.subcircuit_hierarchy_for_nets getter

### DIFF
--- a/src/db/db/gsiDeclDbDeepShapeStore.cc
+++ b/src/db/db/gsiDeclDbDeepShapeStore.cc
@@ -190,7 +190,7 @@ Class<db::DeepShapeStore> decl_dbDeepShapeStore ("db", "DeepShapeStore",
     "\n"
     "This attribute has been introduced in version 0.28.4"
   ) +
-  gsi::method ("subcircuit_hierarchy_for_nets=", &db::DeepShapeStore::set_subcircuit_hierarchy_for_nets, gsi::arg ("value"),
+  gsi::method ("subcircuit_hierarchy_for_nets", &db::DeepShapeStore::subcircuit_hierarchy_for_nets,
     "@brief Gets a value indicating whether to build a subcircuit hierarchy per net\n"
     "See \\subcircuit_hierarchy_for_nets= for details.\n"
     "\n"


### PR DESCRIPTION
Previously introduced DeepShapeStore.subcircuit_hierarchy_for_nets getter is actually a copy&past of the setter.
As result the DeepShapeStore class has two `subcircuit_hierarchy_for_nets` setters which results in `ERROR: RuntimeError: Ambiguous overload variants - multiple setter declarations match arguments in DeepShapeStore.subcircuit_hierarchy_for_nets` when setter called from scripts. This error makes `subcircuit_hierarchy_for_nets` setter unusable/unavailable from scripts.

The fix updates `DeepShapeStore.subcircuit_hierarchy_for_nets` getter declaration, which makes setter and getter work correctly.
