### PR TITLE
Fixing issue #1782

### DIFF
--- a/src/db/db/built-in-macros/pcell_declaration_helper.lym
+++ b/src/db/db/built-in-macros/pcell_declaration_helper.lym
@@ -361,6 +361,10 @@ module RBA
 
     def param(name, type, description, args = {})
 
+      if ! args.is_a?(Hash)
+        raise("Too many positional arguments for 'param' (3 expected) - use named arguments for default value etc.")
+      end
+
       if name !~ /^[_A-Za-z]\w*$/
         raise "Invalid parameter name #{name} (needs to be a word)"
       end

--- a/src/db/db/dbLayout.cc
+++ b/src/db/db/dbLayout.cc
@@ -2526,10 +2526,25 @@ Layout::register_pcell (const std::string &name, pcell_declaration_type *declara
     //  replace any existing PCell declaration with that name.
     id = pcid->second;
     if (m_pcells [id]) {
-      delete m_pcells [id];
-    }
 
-    m_pcells [id] = new pcell_header_type (id, name, declaration);
+      std::unique_ptr<pcell_header_type> org_header (m_pcells [id]);
+      std::vector<pcell_variant_type *> variants;
+      for (auto v = org_header->begin (); v != org_header->end (); ++v) {
+        variants.push_back (v->second);
+      }
+      for (auto v = variants.begin (); v != variants.end (); ++v) {
+        (*v)->unregister ();
+      }
+
+      m_pcells [id] = new pcell_header_type (id, name, declaration);
+
+      for (auto v = variants.begin (); v != variants.end (); ++v) {
+        (*v)->reregister ();
+      }
+
+    } else {
+      m_pcells [id] = new pcell_header_type (id, name, declaration);
+    }
 
   } else {
 

--- a/src/tl/unit_tests/tlStringTests.cc
+++ b/src/tl/unit_tests/tlStringTests.cc
@@ -589,3 +589,62 @@ TEST(15)
   EXPECT_EQ (tl::to_upper_case ("nOrMaliI(\xc3\xa4\xc3\x84\xc3\xbc\xc3\x9c\xc3\xb6\xc3\x96\xc3\x9f-42\xc2\xb0+6\xe2\x82\xac)"), "NORMALII(\xc3\x84\xc3\x84\xc3\x9c\xc3\x9c\xc3\x96\xc3\x96\xc3\x9f-42\xc2\xb0+6\xe2\x82\xac)");
   EXPECT_EQ (tl::to_lower_case ("nOrMaliI(\xc3\xa4\xc3\x84\xc3\xbc\xc3\x9c\xc3\xb6\xc3\x96\xc3\x9f-42\xc2\xb0+6\xe2\x82\xac)"), "normalii(\xc3\xa4\xc3\xa4\xc3\xbc\xc3\xbc\xc3\xb6\xc3\xb6\xc3\x9f-42\xc2\xb0+6\xe2\x82\xac)");
 }
+
+//  Special numerical values
+TEST(16)
+{
+  EXPECT_EQ (tl::to_string (NAN), "nan");
+  EXPECT_EQ (tl::to_string (INFINITY), "inf");
+  EXPECT_EQ (tl::to_string (-INFINITY), "-inf");
+
+  EXPECT_EQ (tl::to_string ((float) NAN), "nan");
+  EXPECT_EQ (tl::to_string ((float) INFINITY), "inf");
+  EXPECT_EQ (tl::to_string ((float) -INFINITY), "-inf");
+
+  EXPECT_EQ (tl::micron_to_string (NAN), "nan");
+  EXPECT_EQ (tl::micron_to_string (INFINITY), "inf");
+  EXPECT_EQ (tl::micron_to_string (-INFINITY), "-inf");
+
+  EXPECT_EQ (tl::db_to_string (NAN), "nan");
+  EXPECT_EQ (tl::db_to_string (INFINITY), "inf");
+  EXPECT_EQ (tl::db_to_string (-INFINITY), "-inf");
+
+  double x = 0.0;
+  tl::from_string ("nan", x);
+  EXPECT_EQ (tl::to_string (x), "nan");
+  x = 0.0;
+  tl::from_string ("NaN", x);
+  EXPECT_EQ (tl::to_string (x), "nan");
+  x = 0.0;
+  tl::from_string ("inf", x);
+  EXPECT_EQ (tl::to_string (x), "inf");
+  x = 0.0;
+  tl::from_string ("INF", x);
+  EXPECT_EQ (tl::to_string (x), "inf");
+  x = 0.0;
+  tl::from_string ("-inf", x);
+  EXPECT_EQ (tl::to_string (x), "-inf");
+  x = 0.0;
+  tl::from_string ("-INF", x);
+  EXPECT_EQ (tl::to_string (x), "-inf");
+
+  std::string s;
+  tl::Extractor ex;
+  x = 0.0;
+  s = "  inf   nan\t -inf";
+  ex = tl::Extractor (s.c_str ());
+  EXPECT_EQ (ex.try_read (x), true);
+  EXPECT_EQ (tl::to_string (x), "inf");
+  EXPECT_EQ (ex.try_read (x), true);
+  EXPECT_EQ (tl::to_string (x), "nan");
+  EXPECT_EQ (ex.try_read (x), true);
+  EXPECT_EQ (tl::to_string (x), "-inf");
+  s = "  Inf   NaN\t -INF";
+  ex = tl::Extractor (s.c_str ());
+  EXPECT_EQ (ex.try_read (x), true);
+  EXPECT_EQ (tl::to_string (x), "inf");
+  EXPECT_EQ (ex.try_read (x), true);
+  EXPECT_EQ (tl::to_string (x), "nan");
+  EXPECT_EQ (ex.try_read (x), true);
+  EXPECT_EQ (tl::to_string (x), "-inf");
+}

--- a/src/tl/unit_tests/tlVariantTests.cc
+++ b/src/tl/unit_tests/tlVariantTests.cc
@@ -27,6 +27,8 @@
 #include "tlObject.h"
 #include "tlTypeTraits.h"
 #include "tlUnitTest.h"
+
+#include <cmath>
 #include <cstdio>
 #include <memory>
 

--- a/src/tl/unit_tests/tlVariantTests.cc
+++ b/src/tl/unit_tests/tlVariantTests.cc
@@ -1090,4 +1090,110 @@ TEST(6)
   EXPECT_EQ (tl::Variant (-0.1 * (1.0 + 1.1e-13)) < tl::Variant (0.1), true);
 }
 
+//  special numeric values
+TEST(7)
+{
+  std::string s;
+  tl::Extractor ex;
+  tl::Variant v;
+
+  s = " ##\t  0.5";
+  ex = tl::Extractor (s.c_str ());
+  EXPECT_EQ (ex.try_read (v), true);
+  EXPECT_EQ (v.to_parsable_string (), "##0.5");
+
+  s = "## nan";
+  ex = tl::Extractor (s.c_str ());
+  EXPECT_EQ (ex.try_read (v), true);
+  EXPECT_EQ (v.to_parsable_string (), "##nan");
+
+  s = "## NaN";
+  ex = tl::Extractor (s.c_str ());
+  EXPECT_EQ (ex.try_read (v), true);
+  EXPECT_EQ (v.to_parsable_string (), "##nan");
+
+  s = "## inf";
+  ex = tl::Extractor (s.c_str ());
+  EXPECT_EQ (ex.try_read (v), true);
+  EXPECT_EQ (v.to_parsable_string (), "##inf");
+
+  s = "## Inf";
+  ex = tl::Extractor (s.c_str ());
+  EXPECT_EQ (ex.try_read (v), true);
+  EXPECT_EQ (v.to_parsable_string (), "##inf");
+
+  s = "## -inf";
+  ex = tl::Extractor (s.c_str ());
+  EXPECT_EQ (ex.try_read (v), true);
+  EXPECT_EQ (v.to_parsable_string (), "##-inf");
+
+  s = "## -Inf";
+  ex = tl::Extractor (s.c_str ());
+  EXPECT_EQ (ex.try_read (v), true);
+  EXPECT_EQ (v.to_parsable_string (), "##-inf");
+
+  v = tl::Variant ("nan");
+  v = tl::Variant (v.to_double ());
+  EXPECT_EQ (v.to_parsable_string (), "##nan");
+  EXPECT_EQ (v.to_string (), "nan");
+
+  v = tl::Variant ("Inf");
+  v = tl::Variant (v.to_double ());
+  EXPECT_EQ (v.to_parsable_string (), "##inf");
+  EXPECT_EQ (v.to_string (), "inf");
+
+  v = tl::Variant (INFINITY);
+  EXPECT_EQ (v.to_parsable_string (), "##inf");
+  EXPECT_EQ (v.to_string (), "inf");
+
+  v = tl::Variant (-INFINITY);
+  EXPECT_EQ (v.to_parsable_string (), "##-inf");
+  EXPECT_EQ (v.to_string (), "-inf");
+
+  tl::Variant vinf (INFINITY);
+  tl::Variant vninf (-INFINITY);
+  tl::Variant vnan (NAN);
+  tl::Variant vzero (0.0);
+
+  EXPECT_EQ (vninf == vninf, true);
+  EXPECT_EQ (vninf == vzero, false);
+  EXPECT_EQ (vninf == vinf, false);
+  EXPECT_EQ (vninf == vnan, false);
+
+  EXPECT_EQ (vninf < vninf, false);
+  EXPECT_EQ (vninf < vzero, true);
+  EXPECT_EQ (vninf < vinf, true);
+  EXPECT_EQ (vninf < vnan, true);
+
+  EXPECT_EQ (vzero == vninf, false);
+  EXPECT_EQ (vzero == vzero, true);
+  EXPECT_EQ (vzero == vinf, false);
+  EXPECT_EQ (vzero == vnan, false);
+
+  EXPECT_EQ (vzero < vninf, false);
+  EXPECT_EQ (vzero < vzero, false);
+  EXPECT_EQ (vzero < vinf, true);
+  EXPECT_EQ (vzero < vnan, true);
+
+  EXPECT_EQ (vinf == vninf, false);
+  EXPECT_EQ (vinf == vzero, false);
+  EXPECT_EQ (vinf == vinf, true);
+  EXPECT_EQ (vinf == vnan, false);
+
+  EXPECT_EQ (vinf < vninf, false);
+  EXPECT_EQ (vinf < vzero, false);
+  EXPECT_EQ (vinf < vinf, false);
+  EXPECT_EQ (vinf < vnan, true);
+
+  EXPECT_EQ (vnan == vninf, false);
+  EXPECT_EQ (vnan == vzero, false);
+  EXPECT_EQ (vnan == vinf, false);
+  EXPECT_EQ (vnan == vnan, true);
+
+  EXPECT_EQ (vnan < vninf, false);
+  EXPECT_EQ (vnan < vzero, false);
+  EXPECT_EQ (vnan < vinf, false);
+  EXPECT_EQ (vnan < vnan, false);
+}
+
 }

--- a/testdata/ruby/dbPCells.rb
+++ b/testdata/ruby/dbPCells.rb
@@ -774,6 +774,41 @@ class DBPCell_TestClass < TestBase
 
   end
 
+  def test_11
+
+    lib = CircleLib1782::new("CircleLib")
+
+    ly = RBA::Layout::new
+
+    top = ly.create_cell("TOP")
+
+    names = []
+
+    c = ly.create_cell("Circle", "CircleLib", { "l" => RBA::LayerInfo::new(1, 0), "r" => 2.0, "n" => 64 })
+
+    # triggered another flavor of #1782
+    lib.reregister_pcell
+
+    c = ly.create_cell("Circle", "CircleLib", { "l" => RBA::LayerInfo::new(1, 0), "r" => 2.0, "n" => 64 })
+    top.insert(RBA::DCellInstArray::new(c, RBA::DTrans::new()))
+
+    tmp = File::join($ut_testtmp, "tmp.gds")
+    ly.write(tmp)
+
+    # this should not throw an internal error
+    ly._destroy
+
+    # we should be able to read the Layout back
+    ly = RBA::Layout::new
+    ly.read(tmp)
+    assert_equal(ly.top_cell.name, "TOP")
+    assert_equal(ly.cells, 2)
+    ly._destroy
+
+    lib._destroy
+
+  end
+
 end
 
 load("test_epilogue.rb")

--- a/testdata/ruby/dbPCells.rb
+++ b/testdata/ruby/dbPCells.rb
@@ -674,6 +674,106 @@ class DBPCell_TestClass < TestBase
 
   end
 
+  # issue #1782
+
+  class Circle1782 < RBA::PCellDeclarationHelper
+
+    def initialize
+      super()
+      param("l", TypeLayer, "Layer", :default => RBA::LayerInfo::new(1, 0))
+      param("r", TypeDouble, "Radius", :default => 1.0)
+      param("n", TypeInt, "Number of points", :default => 16)     
+    end
+
+    def display_text_impl
+      r = self.r
+      if !r
+        r = "nil"
+      else
+        r = '%.3f' % r
+      end
+      "Circle(L=" + self.l.to_s + ",R=" + r + ")"
+    end
+  
+    def produce_impl
+      r = self.r
+      if self.r.to_s == 'NaN'
+        r = 2.0
+      end
+      da = Math::PI * 2 / self.n
+      pts = self.n.times.collect do |i|
+        RBA::DPoint::new(r * Math::cos(i * da), r * Math::sin(i * da))
+      end
+      self.cell.shapes(self.l_layer).insert(RBA::DPolygon::new(pts))
+    end
+
+  end
+
+  class CircleLib1782 < RBA::Library
+
+    def initialize(name)
+      self.description = "Circle Library"
+      self.layout.register_pcell("Circle", Circle1782::new)
+      register(name)
+    end
+
+    def reregister_pcell
+      self.layout.register_pcell("Circle", Circle1782::new)
+    end
+
+  end
+
+  def test_10
+
+    lib = CircleLib1782::new("CircleLib")
+
+    ly = RBA::Layout::new
+
+    top = ly.create_cell("TOP")
+
+    names = []
+
+    2.times do |pass|
+      
+      5.times do |i|
+        5.times do |j|
+          if (i + j) % 2 == 0
+            r = Float::NAN
+          else
+            r = (i + j) * 0.5
+          end
+          n = i * 5 + j
+          c = ly.create_cell("Circle", "CircleLib", { "l" => RBA::LayerInfo::new(1, 0), "r" => r, "n" => n })
+          if pass == 0
+            names << c.name
+          else
+            # triggered bug #1782 - basically all variants are supposed to be unique, but 
+            # the NaN spoiled the hash maps
+            assert_equal(names.shift, c.name)
+          end
+          top.insert(RBA::DCellInstArray::new(c, RBA::DTrans::new(i * 10.0, j * 10.0)))
+        end
+      end
+
+    end
+
+    tmp = File::join($ut_testtmp, "tmp.gds")
+    ly.write(tmp)
+
+    # this should not throw an internal error
+    ly._destroy
+
+    # we should be able to read the Layout back
+    ly = RBA::Layout::new
+    ly.read(tmp)
+    assert_equal(ly.top_cell.name, "TOP")
+    assert_equal(ly.cells, 26)
+    ly._destroy
+
+    lib._destroy
+
+  end
+
 end
 
 load("test_epilogue.rb")


### PR DESCRIPTION
This patch establishes "nan", "inf" and "-inf" as
valid values for tl::Variant, so corresponding
PCell parameters can be serialized and are
properly managed.