### PR TITLE
Fixing bug #1789 (Crash by add Text to hidden layer)

### DIFF
--- a/src/edt/edt/edtServiceImpl.cc
+++ b/src/edt/edt/edtServiceImpl.cc
@@ -40,6 +40,7 @@
 #include "layLayoutViewBase.h"
 
 #if defined(HAVE_QT)
+#  include "layLayoutView.h"
 #  include "layTipDialog.h"
 #  include "layDragDropData.h"
 #endif
@@ -73,6 +74,24 @@ ShapeEditService::configure (const std::string &name, const std::string &value)
 }
   
 void
+ShapeEditService::activated ()
+{
+  edt::Service::activated ();
+
+#if defined(HAVE_QT)
+  if (view () == lay::LayoutView::current ()) {
+    lay::LayerPropertiesConstIterator cl = view ()->current_layer ();
+    if (! cl.is_null () && ! cl->visible (true)) {
+      lay::TipDialog td (QApplication::activeWindow (),
+                         tl::to_string (tr ("You are about to draw on a hidden layer. The result won't be visible.")),
+                         "drawing-on-invisible-layer");
+      td.exec_dialog ();
+    }
+  }
+#endif
+}
+
+void
 ShapeEditService::get_edit_layer ()
 {
   lay::LayerPropertiesConstIterator cl = view ()->current_layer ();
@@ -88,15 +107,6 @@ ShapeEditService::get_edit_layer ()
   if (cv_index < 0 || ! cv.is_valid ()) {
     throw tl::Exception (tl::to_string (tr ("Please select a cell first")));
   }
-
-#if defined(HAVE_QT)
-  if (! cl->visible (true)) {
-    lay::TipDialog td (QApplication::activeWindow (),
-                       tl::to_string (tr ("You are about to draw on a hidden layer. The result won't be visible.")),
-                       "drawing-on-invisible-layer");
-    td.exec_dialog ();
-  }
-#endif
 
   if (layer < 0 || ! cv->layout ().is_valid_layer ((unsigned int) layer)) {
 

--- a/src/edt/edt/edtServiceImpl.h
+++ b/src/edt/edt/edtServiceImpl.h
@@ -62,6 +62,7 @@ protected:
   virtual void tap (const db::DPoint &initial);
 
   virtual bool configure (const std::string &name, const std::string &value);
+  virtual void activated ();
 
 protected:
   std::pair <bool, db::DPoint> interpolate (const db::DPoint &m, const db::DPoint &o, const db::DPoint &p) const;

--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -188,6 +188,8 @@ MainWindow::MainWindow (QApplication *app, const char *name, bool undo_enabled)
       mp_app (app),
       m_manager (undo_enabled)
 {
+  setAnimated (false);
+
   m_dispatcher.set_menu_parent_widget (this);
   m_dispatcher.make_menu ();
 


### PR DESCRIPTION
Problem was: after activating Text mode the edit
function showed the dock with the editor options.
This cause a mouse move event due to resizing
which in turn triggered the popup about invisible
layer. Apparently Qt's dock open animation does
not like popups during the animation phase which
caused the segfault.

Solution is to do the check upon activation,
not in the mouse move event.