### PR TITLE
Implemented a fix for #1794 (giant meta info produces invalid GDS)

### DIFF
--- a/src/plugins/streamers/gds2/db_plugin/dbGDS2WriterBase.h
+++ b/src/plugins/streamers/gds2/db_plugin/dbGDS2WriterBase.h
@@ -169,6 +169,7 @@ private:
 
   void write_properties (const db::Layout &layout, db::properties_id_type prop_id);
   void write_context_cell (db::Layout &layout, const short *time_data, const std::vector<cell_index_type> &cells);
+  void write_context_string (size_t n, const std::string &s);
 };
 
 } // namespace db


### PR DESCRIPTION
This fix solves two problems:
* Too large meta info data
* Too many meta info entries

The first problem is fixed by splitting the strings that serialize the meta info.

The second problem is fixed by introducing prefixed strings that indicate the attribute index within the string, not inside the PROPATTR record.

The solution is backward compatible, although old versions will not read all meta info and skip entries that exceed the GDS capacity.

Caveat: the produced GDS files may contain duplicate PROPATTR keys. This is not strictly illegal, but some third-party processors may drop such entries.