### PR TITLE
Fixed bug #1823 (select_all not working)

### DIFF
--- a/src/laybasic/laybasic/gsiDeclLayLayoutViewBase.cc
+++ b/src/laybasic/laybasic/gsiDeclLayLayoutViewBase.cc
@@ -1058,7 +1058,7 @@ LAYBASIC_PUBLIC Class<lay::LayoutViewBase> decl_LayoutViewBase ("lay", "LayoutVi
     "\n"
     "This method has been introduced in version 0.26.2\n"
   ) +
-  gsi::method ("select_all", (void (lay::LayoutViewBase::*) ()) &lay::LayoutViewBase::select,
+  gsi::method ("select_all", (void (lay::LayoutViewBase::*) ()) &lay::LayoutViewBase::select_all,
     "@brief Selects all objects from the view\n"
     "\n"
     "This method has been introduced in version 0.27\n"

--- a/src/laybasic/laybasic/layEditable.cc
+++ b/src/laybasic/laybasic/layEditable.cc
@@ -370,23 +370,6 @@ Editables::clear_selection ()
 }
 
 void 
-Editables::select ()
-{
-  cancel_edits ();
-  clear_transient_selection ();
-  clear_previous_selection ();
-
-  for (iterator e = begin (); e != end (); ++e) {
-    if (m_enabled.find (&*e) != m_enabled.end ()) {
-      e->select (db::DBox (), lay::Editable::Replace);  //  select "all"
-    }
-  }
-
-  //  send a signal to the observers
-  signal_selection_changed ();
-}
-
-void 
 Editables::select (const db::DBox &box, lay::Editable::SelectionMode mode)
 {
   if (box.is_point ()) {

--- a/src/laybasic/laybasic/layEditable.h
+++ b/src/laybasic/laybasic/layEditable.h
@@ -508,11 +508,6 @@ public:
   void clear_previous_selection ();
 
   /**
-   *  @brief Select "all"
-   */
-  void select ();
-
-  /**
    *  @brief Select geometrically by a rectangle
    */
   void select (const db::DBox &box, Editable::SelectionMode mode);

--- a/src/laybasic/laybasic/layFinder.cc
+++ b/src/laybasic/laybasic/layFinder.cc
@@ -324,7 +324,7 @@ ShapeFinder::find (LayoutViewBase *view, const db::DBox &region_mu)
   m_cells_with_context.clear ();
 
   lay::TextInfo text_info (view);
-  mp_text_info = (m_flags & db::ShapeIterator::Texts) != 0 ? &text_info : 0;
+  mp_text_info = (m_flags & db::ShapeIterator::Texts) != 0 && point_mode () ? &text_info : 0;
 
   std::vector<lay::LayerPropertiesConstIterator> lprops;
   for (lay::LayerPropertiesConstIterator lp = view->begin_layers (); ! lp.at_end (); ++lp) {

--- a/src/laybasic/laybasic/layLayoutViewBase.cc
+++ b/src/laybasic/laybasic/layLayoutViewBase.cc
@@ -3754,6 +3754,12 @@ LayoutViewBase::full_box () const
 }
 
 void
+LayoutViewBase::select_all ()
+{
+  select (full_box (), lay::Editable::Replace);
+}
+
+void
 LayoutViewBase::zoom_fit ()
 {
   mp_canvas->zoom_box (full_box (), true /*precious*/);

--- a/src/laybasic/laybasic/layLayoutViewBase.h
+++ b/src/laybasic/laybasic/layLayoutViewBase.h
@@ -2624,6 +2624,11 @@ public:
   db::DBox full_box () const;
 
   /**
+   *  @brief Selects everything
+   */
+  void select_all ();
+
+  /**
    *  @brief Gets called when a menu item is activated
    */
   void menu_activated (const std::string &symbol);

--- a/src/layui/layui/layLayoutViewFunctions.cc
+++ b/src/layui/layui/layLayoutViewFunctions.cc
@@ -135,7 +135,7 @@ LayoutViewFunctions::menu_activated (const std::string &symbol)
   } else if (symbol == "cm_unselect_all") {
     view ()->select (db::DBox (), lay::Editable::Reset);
   } else if (symbol == "cm_select_all") {
-    view ()->select (view ()->full_box (), lay::Editable::Replace);
+    view ()->select_all ();
   } else if (symbol == "cm_select_next_item") {
     view ()->repeat_selection (lay::Editable::Replace);
   } else if (symbol == "cm_select_next_item_add") {

--- a/testdata/ruby/layLayoutView.rb
+++ b/testdata/ruby/layLayoutView.rb
@@ -187,16 +187,22 @@ class LAYLayoutView_TestClass < TestBase
     view.set_config("search-range", "0")
     view.select_from(RBA::DBox::new(-2.5, -2.5, 2.5, 2.5))
     assert_equal(selection_changed, 1)
-    assert_equal(view.selection_size, 2)
+    assert_equal(view.selection_size, 4)
     assert_equal(view.has_selection?, true)
 
     view.select_from(RBA::DPoint::new(0, 0), RBA::LayoutView::Invert)
     assert_equal(selection_changed, 2)
-    assert_equal(view.selection_size, 3)
+    assert_equal(view.selection_size, 5)
     assert_equal(view.has_selection?, true)
 
     view.clear_selection
-    assert_equal(selection_changed, 3)
+    view.select_all
+    assert_equal(selection_changed, 4)
+    assert_equal(view.has_selection?, true)
+    assert_equal(view.selection_size, 20)
+
+    view.clear_selection
+    assert_equal(selection_changed, 5)
     assert_equal(view.has_selection?, false)
     assert_equal(view.selection_size, 0)
     selection_changed = 0


### PR DESCRIPTION
1. Fixed "LayoutView#select_all"
2. Box selection now will select texts at their origin again: this way it is included in the bounding box. Point mode still takes the text's glyph area.