### PR TITLE
Some enhancements to "Descend" and "Ascend"

### DIFF
--- a/src/edt/edt/edtMainService.h
+++ b/src/edt/edt/edtMainService.h
@@ -91,6 +91,11 @@ public:
   void cm_descend ();
 
   /**
+   *  @brief Descend to selection and make cell current top
+   */
+  void cm_descend_into ();
+
+  /**
    *  @brief Ascend one level
    */
   void cm_ascend ();
@@ -239,6 +244,7 @@ private:
 
   void boolean_op (int mode);
   void check_no_guiding_shapes ();
+  void descend (bool make_new_top);
 #if defined(HAVE_QT)
   edt::RoundCornerOptionsDialog *round_corners_dialog ();
   edt::AreaAndPerimeterDialog *area_and_perimeter_dialog ();

--- a/src/edt/edt/edtPlugin.cc
+++ b/src/edt/edt/edtPlugin.cc
@@ -351,6 +351,7 @@ public:
 
     menu_entries.push_back (lay::separator ("edt::hier_group", "zoom_menu.end"));
     menu_entries.push_back (lay::menu_item ("edt::descend", "descend", "zoom_menu.end", tl::to_string (tr ("Descend")) + "(Ctrl+D)"));
+    menu_entries.push_back (lay::menu_item ("edt::descend_into", "descend_into", "zoom_menu.end", tl::to_string (tr ("Descend Into")) + "(D)"));
     menu_entries.push_back (lay::menu_item ("edt::ascend", "ascend", "zoom_menu.end", tl::to_string (tr ("Ascend")) + "(Ctrl+A)"));
 
     menu_entries.push_back (lay::menu_item ("edt::sel_make_array", "make_array:edit_mode", "edit_menu.selection_menu.end", tl::to_string (tr ("Make Array"))));


### PR DESCRIPTION
- Ascend now ascends further up if a child cell is selected as top level cell
- Descend now looks into transiently selected shapes or instances too (mouse hover mode)
- New feature "Descend into" which combines "Descend" with "make new top".
- Fixed a compiler warning in layLayoutViewBase.cc