### PR TITLE
Round database unit to the nearest attometer when reading from GDS2

### DIFF
--- a/src/plugins/streamers/gds2/db_plugin/dbGDS2ReaderBase.cc
+++ b/src/plugins/streamers/gds2/db_plugin/dbGDS2ReaderBase.cc
@@ -22,6 +22,7 @@
 
 
 #include "dbGDS2ReaderBase.h"
+#include <cmath>
 #include "dbGDS2Format.h"
 #include "dbGDS2.h"
 #include "dbArray.h"
@@ -240,6 +241,11 @@ GDS2ReaderBase::do_read (db::Layout &layout)
 
       m_dbuu = dbuu;
       m_dbu = dbum * 1e6; /*in micron*/
+      // round to (approximately) the nearest attometer. This enables
+      // preserving DBU values precisely during round trips through GDS2.
+      // Use a power of two so that the division doesn't introduce errors.
+      const double factor = 1024.0 * 1024.0 * 1024.0 * 1024.0;
+      m_dbu = round (m_dbu * factor) / factor;
       layout.dbu (m_dbu);
 
     } else {


### PR DESCRIPTION
Currently if you create a layout with a DBU of (e.g.) 16, write it to GDS2, and then read it again, you don't get exactly 16, but 16.000000000000004. It would be nice if reasonable database unit values roundtrip exactly.