### PR TITLE
Update `build.sh` to error-out on bad `$BUILD` or `$BIN`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -597,8 +597,8 @@ mkdir -p $BUILD
 # qmake needs absolute paths, so we get them now:
 #   OSX does not have `readlink -f` command. Use equivalent Perl script.
 if [ "$IS_MAC" = "no" ]; then
-  BUILD=`readlink -f $BUILD`
-  BIN=`readlink -f $BIN`
+  BUILD=`realpath --canonicalize-existing $BUILD`
+  BIN=`realpath --canonicalize-existing $BIN`
 else
   BUILD=`perl -MCwd -le 'print Cwd::abs_path(shift)' $BUILD`
   BIN=`perl -MCwd -le 'print Cwd::abs_path(shift)' $BIN`

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 #
 # KLayout Layout Viewer

--- a/build.sh
+++ b/build.sh
@@ -595,7 +595,7 @@ mkdir -p $BUILD
 . $(dirname $(which $0))/version.sh
 
 # qmake needs absolute paths, so we get them now:
-#   OSX does not have `readlink -f` command. Use equivalent Perl script.
+#   OSX does not have `realpath --canonicalize-existing` command. Use equivalent Perl script.
 if [ "$IS_MAC" = "no" ]; then
   BUILD=`realpath --canonicalize-existing $BUILD`
   BIN=`realpath --canonicalize-existing $BIN`


### PR DESCRIPTION
I tried to install to a directory that did not exist, and I got some unexpected behavior...

`build.sh` did not fail, it just continued to run and spew-out errors.

I added a `-e` after the bash sh-bang to help with catching issues sooner (portion of man page pasted below), and I changed `readlink -f` to `realpath --canonicalize-existing` (man page pasted also):

>-e      Exit immediately if a pipeline (which may consist of a single simple command), a list,  or  a  com‐
>        pound  command (see SHELL GRAMMAR above), exits with a non-zero status.  The shell does not exit if
>        the command that fails is part of the command list immediately following a while or until  keyword,
>        part  of  the test following the if or elif reserved words, part of any command executed in a && or
>        || list except the command following the final && or ||, any command in a pipeline but the last, or
>        if  the  command's  return value is being inverted with !.  If a compound command other than a sub‐
>        shell returns a non-zero status because a command failed while -e was being ignored, the shell does
>        not  exit.   A trap on ERR, if set, is executed before the shell exits.  This option applies to the
>        shell environment and each subshell  environment  separately  (see  COMMAND  EXECUTION  ENVIRONMENT
>        above), and may cause subshells to exit before executing all the commands in the subshell.

>READLINK(1)              User Commands              READLINK(1)
>
>NAME
>       readlink  -  print  resolved symbolic links or canonical
>       file names
>
>SYNOPSIS
>       readlink [OPTION]... FILE...
>
>DESCRIPTION
>       Note realpath(1) is the preferred  command  to  use  for
>       canonicalization functionality.

Honestly, not sure if this would work on _all_ POSIX-like systems that the project is targeting, but it built for me on Pop!_OS 22.04 LTS and `klayout` launches.

I am open to suggestions or learnings if `realpath` or `-e` is not suitable for some reason.