### PR TITLE
Fixed #1885

### DIFF
--- a/src/buddies/src/bd/bdWriterOptions.cc
+++ b/src/buddies/src/bd/bdWriterOptions.cc
@@ -57,7 +57,8 @@ GenericWriterOptions::GenericWriterOptions ()
   m_oasis_recompress = save_options.get_option_by_name ("oasis_recompress").to_bool ();
   m_oasis_permissive = save_options.get_option_by_name ("oasis_permissive").to_bool ();
   m_oasis_write_std_properties = save_options.get_option_by_name ("oasis_write_std_properties").to_int ();
-  m_oasis_subst_char = save_options.get_option_by_name ("oasis_substitution_char").to_string ();
+  //  No substitution by default (issue #1885), so skip this:
+  //  m_oasis_subst_char = save_options.get_option_by_name ("oasis_substitution_char").to_string ();
 
   m_cif_dummy_calls = save_options.get_option_by_name ("cif_dummy_calls").to_bool ();
   m_cif_blank_separator = save_options.get_option_by_name ("cif_blank_separator").to_bool ();
@@ -310,6 +311,8 @@ void GenericWriterOptions::set_oasis_substitution_char (const std::string &text)
 {
   if (! text.empty ()) {
     m_oasis_subst_char = text[0];
+  } else {
+    m_oasis_subst_char = std::string ();
   }
 }
 

--- a/src/buddies/unit_tests/bdBasicTests.cc
+++ b/src/buddies/unit_tests/bdBasicTests.cc
@@ -313,3 +313,41 @@ TEST(11)
   EXPECT_EQ (stream_opt.get_option_by_name ("cell_conflict_resolution").to_string (), "RenameCell");
 }
 
+//  Testing writer options
+TEST(12_issue1885)
+{
+  bd::GenericWriterOptions opt;
+  tl::CommandLineOptions cmd;
+
+  opt.add_options (cmd);
+
+  db::Layout layout;
+
+  db::SaveLayoutOptions stream_opt;
+  opt.configure (stream_opt, layout);
+
+  EXPECT_EQ (stream_opt.get_option_by_name ("oasis_substitution_char").to_string (), "");
+
+  const char *argv[] = {
+                   "x",
+                   "--subst-char=x",
+                 };
+
+  cmd.parse (sizeof (argv) / sizeof (argv[0]), const_cast<char **> (argv));
+
+  opt.configure (stream_opt, layout);
+
+  EXPECT_EQ (stream_opt.get_option_by_name ("oasis_substitution_char").to_string (), "x");
+
+  const char *argv2[] = {
+                   "x",
+                   "--subst-char=",
+                 };
+
+  cmd.parse (sizeof (argv2) / sizeof (argv2[0]), const_cast<char **> (argv2));
+
+  opt.configure (stream_opt, layout);
+
+  EXPECT_EQ (stream_opt.get_option_by_name ("oasis_substitution_char").to_string (), "");
+}
+


### PR DESCRIPTION
Now, the default of --subst-char in strm2oas is "don't substitute". You can explicitly specify "don't substitute" using "--subst-char=" (without value).