### PR TITLE
Minor update of the macOS build system to suppress some deprecation warnings

### DIFF
--- a/macbuild/build4mac_util.py
+++ b/macbuild/build4mac_util.py
@@ -499,7 +499,7 @@ def GetKLayoutVersionFrom( verfile='version.h' ):
     except Exception as e:
         return version
 
-    verReg = re.compile( u'(KLAYOUT_VERSION=\")([0-9A-Z_a-z\.]+)(\")' )
+    verReg = re.compile( r'(KLAYOUT_VERSION=\")([0-9A-Z_a-z\.]+)(\")' )
     for line in contents:
         m = verReg.match(line)
         if m:

--- a/macbuild/makeDMG4mac.py
+++ b/macbuild/makeDMG4mac.py
@@ -279,7 +279,7 @@ def CheckPkgDirectory():
     #     * LW-qt6MP.pkg.macos-Sonoma-release-Rmp33Pmp312
     #-----------------------------------------------------------------------------------------------
     #                  0      1      2                      3                  4                    5         6        7
-    patQRP = u'(ST|LW|HW|EX)([-])([qt5|qt6][0-9A-Za-z]+)([.]pkg[.])([A-Za-z]+[-][A-Za-z]+[-])(release|debug)([-])([0-9A-Za-z]+)'
+    patQRP = r'(ST|LW|HW|EX)([-])([qt5|qt6][0-9A-Za-z]+)([.]pkg[.])([A-Za-z]+[-][A-Za-z]+[-])(release|debug)([-])([0-9A-Za-z]+)'
     regQRP = re.compile(patQRP)
     if not regQRP.match(PkgDir):
         print( "! Cannot identify (Qt, Ruby, Python) from the package directory name" )
@@ -721,7 +721,9 @@ def MakeTargetDMGFile(msg=""):
     #      The folder will open on mount.
     #--------------------------------------------------------
     print( ">>> (10) Setting volume bootability and startup disk options..." )
-    command = "bless --folder %s --openfolder %s" % (MountDir, MountDir)
+    #command = "bless --folder %s --openfolder %s" % (MountDir, MountDir)
+    #bless: The 'openfolder' option is deprecated
+    command = "bless --folder %s" % MountDir
     os.system(command)
     sleep(2)
 


### PR DESCRIPTION
Fixed SyntaxWarning: invalid escape sequence '\.' and suppress a deprecation warning