### PR TITLE
Fixing issue #1948 (crash on dragging a cell) - problem was the popup…

### DIFF
--- a/src/laybasic/laybasic/layViewObject.cc
+++ b/src/laybasic/laybasic/layViewObject.cc
@@ -293,7 +293,8 @@ public:
 
     }
 
-  END_PROTECTED
+  //  Note: Qt does not like popups during drag-and-drop operations ...
+  END_PROTECTED_SILENT
   }
 
   void dragLeaveEvent (QDragLeaveEvent * /*event*/)
@@ -309,7 +310,8 @@ public:
       svc = next;
     }
 
-  END_PROTECTED
+  //  Note: Qt does not like popups during drag-and-drop operations ...
+  END_PROTECTED_SILENT
   }
 
   void dragMoveEvent (QDragMoveEvent *event)
@@ -332,7 +334,8 @@ public:
 
     }
 
-  END_PROTECTED
+  //  Note: Qt does not like popups during drag-and-drop operations ...
+  END_PROTECTED_SILENT
   }
 
   void dropEvent (QDropEvent *event)
@@ -355,7 +358,8 @@ public:
 
     }
 
-  END_PROTECTED
+  //  Note: Qt does not like popups during drag-and-drop operations ...
+  END_PROTECTED_SILENT
   }
 
   void mouseMoveEvent (QMouseEvent *e)


### PR DESCRIPTION
… which Qt does not like during drag-and-drop operations.