### PR TITLE
Fixing bug #1955

### DIFF
--- a/src/db/db/dbAsIfFlatRegion.cc
+++ b/src/db/db/dbAsIfFlatRegion.cc
@@ -1298,7 +1298,7 @@ AsIfFlatRegion::sized (coord_type dx, coord_type dy, unsigned int mode) const
 
     //  simplified handling for a box
     db::Box b = bbox ().enlarged (db::Vector (dx, dy));
-    return region_from_box (b, properties_repository (), begin ()->prop_id ());
+    return region_from_box (b, properties_repository (), db::RegionIterator (begin ()).prop_id ());
 
   } else if (! merged_semantics () || is_merged ()) {
 
@@ -1478,13 +1478,13 @@ AsIfFlatRegion::and_with (const Region &other, PropertyConstraint property_const
 
   } else if (is_box () && other.is_box ()) {
 
-    if (pc_skip (property_constraint) || pc_match (property_constraint, begin ()->prop_id (), other.begin ().prop_id ())) {
+    if (pc_skip (property_constraint) || pc_match (property_constraint, db::RegionIterator (begin ()).prop_id (), other.begin ().prop_id ())) {
 
       //  Simplified handling for boxes
       db::Box b = bbox ();
       b &= other.bbox ();
 
-      db::properties_id_type prop_id_out = pc_norm (property_constraint, begin ()->prop_id ());
+      db::properties_id_type prop_id_out = pc_norm (property_constraint, db::RegionIterator (begin ()).prop_id ());
 
       return region_from_box (b, properties_repository (), prop_id_out);
 
@@ -1494,7 +1494,7 @@ AsIfFlatRegion::and_with (const Region &other, PropertyConstraint property_const
 
   } else if (is_box () && ! other.strict_handling ()) {
 
-    db::properties_id_type self_prop_id = pc_skip (property_constraint) ? 0 : begin ()->prop_id ();
+    db::properties_id_type self_prop_id = pc_skip (property_constraint) ? 0 : db::RegionIterator (begin ()).prop_id ();
 
     //  map AND with box to clip ..
     db::Box b = bbox ();

--- a/src/db/db/dbDeepRegion.cc
+++ b/src/db/db/dbDeepRegion.cc
@@ -784,7 +784,6 @@ RegionDelegate *
 DeepRegion::and_with (const Region &other, PropertyConstraint property_constraint) const
 {
   const DeepRegion *other_deep = dynamic_cast <const DeepRegion *> (other.delegate ());
-
   if (empty ()) {
 
     return clone ()->remove_properties (pc_remove (property_constraint));

--- a/src/db/db/dbGenericShapeIterator.h
+++ b/src/db/db/dbGenericShapeIterator.h
@@ -32,6 +32,9 @@ namespace db
 {
 
 template <class T>
+class generic_shape_iterator;
+
+template <class T>
 class DB_PUBLIC generic_shape_iterator_delegate_base
 {
 public:
@@ -39,6 +42,9 @@ public:
 
   generic_shape_iterator_delegate_base () { }
   virtual ~generic_shape_iterator_delegate_base () { }
+
+protected:
+  friend class generic_shape_iterator<T>;
 
   virtual void do_reset (const db::Box & /*region*/, bool /*overlapping*/) { }
   virtual db::Box bbox () const { return db::Box::world (); }
@@ -62,6 +68,7 @@ public:
     : m_iter (from), m_from (from), m_to (to)
   { }
 
+protected:
   virtual bool is_addressable () const
   {
     return addressable;
@@ -122,6 +129,7 @@ public:
     : m_iter (from), m_from (from)
   { }
 
+protected:
   virtual bool is_addressable () const
   {
     return addressable;
@@ -185,6 +193,7 @@ public:
     set ();
   }
 
+protected:
   virtual bool is_addressable () const
   {
     return m_is_addressable;


### PR DESCRIPTION
Problem was caused by a leaking PolygonIteratorDelegate that locked the DSS layout object. Solved by wrapping in PolygonIterator and changing the interface such that PolygonIteratorDelegegate is no longer useful.