### PR TITLE
Provide a solution of feature request #2024

### DIFF
--- a/src/laybasic/laybasic/laybasicConfig.h
+++ b/src/laybasic/laybasic/laybasicConfig.h
@@ -43,6 +43,7 @@ static const std::string cfg_grid_grid_color ("grid-grid-color");
 static const std::string cfg_grid_style0 ("grid-style0");
 static const std::string cfg_grid_style1 ("grid-style1");
 static const std::string cfg_grid_style2 ("grid-style2");
+static const std::string cfg_grid_density ("grid-density");
 static const std::string cfg_grid_visible ("grid-visible");
 static const std::string cfg_grid_micron ("grid-micron");
 static const std::string cfg_grid_show_ruler ("grid-show-ruler");

--- a/src/layview/layview/GridNetConfigPage.ui
+++ b/src/layview/layview/GridNetConfigPage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>483</width>
-    <height>341</height>
+    <height>361</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -59,6 +59,23 @@
       <property name="spacing">
        <number>6</number>
       </property>
+      <item row="3" column="1">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Far style</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="2" colspan="2">
+       <widget class="QCheckBox" name="show_ruler">
+        <property name="text">
+         <string>Show ruler</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="2" colspan="2">
        <widget class="QComboBox" name="style1_cbx">
         <item>
@@ -108,7 +125,122 @@
         </item>
        </widget>
       </item>
-      <item row="10" column="1">
+      <item row="2" column="4">
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="3">
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0" colspan="5">
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="2">
+       <widget class="QPushButton" name="grid_axis_color_pb">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Grid   </string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="5">
+       <widget class="Line" name="line_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QPushButton" name="grid_net_color_pb">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Ruler</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="2">
+       <widget class="QPushButton" name="grid_ruler_color_pb">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Axis</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QPushButton" name="grid_grid_color_pb">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="Close style">
+        <property name="text">
+         <string>Close style</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Color (all)</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
        <widget class="QLabel" name="label_7">
         <property name="text">
          <string>Color</string>
@@ -118,14 +250,17 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="5">
-       <widget class="Line" name="line_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+      <item row="7" column="1">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Style</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="6" column="2" colspan="2">
+      <item row="7" column="2" colspan="2">
        <widget class="QComboBox" name="style0_cbx">
         <item>
          <property name="text">
@@ -169,30 +304,23 @@
         </item>
        </widget>
       </item>
-      <item row="0" column="3">
-       <spacer>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="10" column="2">
-       <widget class="QPushButton" name="grid_ruler_color_pb">
+      <item row="8" column="1">
+       <widget class="QLabel" name="label_6">
         <property name="text">
-         <string/>
+         <string>Color</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="5">
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+      <item row="4" column="1">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Color</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -245,138 +373,34 @@
         </item>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Far style</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="Close style">
-        <property name="text">
-         <string>Close style</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Color (all)</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="QPushButton" name="grid_grid_color_pb">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Grid   </string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="2" colspan="2">
-       <widget class="QCheckBox" name="show_ruler">
-        <property name="text">
-         <string>Show Ruler</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="2">
-       <widget class="QPushButton" name="grid_axis_color_pb">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4">
-       <spacer>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="6" column="1">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Style</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Color</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QPushButton" name="grid_net_color_pb">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>Axis</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Color</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0">
-       <widget class="QLabel" name="label_8">
-        <property name="text">
-         <string>Ruler</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0" colspan="5">
+      <item row="9" column="0" colspan="5">
        <widget class="Line" name="line_3">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="QSpinBox" name="grid_density_sb">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Min. spacing</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="3" colspan="2">
+       <widget class="QLabel" name="label_11">
+        <property name="text">
+         <string>(Font height units)</string>
         </property>
        </widget>
       </item>

--- a/src/layview/layview/layGridNet.h
+++ b/src/layview/layview/layGridNet.h
@@ -87,6 +87,7 @@ private:
   GridStyle m_style0;
   GridStyle m_style1;
   GridStyle m_style2;
+  int m_density;
 };
 
 class GridNetStyleConverter
@@ -94,6 +95,13 @@ class GridNetStyleConverter
 public:
   void from_string (const std::string &value, lay::GridNet::GridStyle &style);
   std::string to_string (lay::GridNet::GridStyle style);
+};
+
+class GridNetDensityConverter
+{
+public:
+  void from_string (const std::string &value, int &density);
+  std::string to_string (int density);
 };
 
 }

--- a/src/layview/layview/layGridNetConfigPage.cc
+++ b/src/layview/layview/layGridNetConfigPage.cc
@@ -94,6 +94,10 @@ GridNetConfigPage::setup (lay::Dispatcher *root)
   style = lay::GridNet::Invisible;
   root->config_get (cfg_grid_style2, style, GridNetStyleConverter ());
   mp_ui->style2_cbx->setCurrentIndex (int (style));
+
+  int density = 0;
+  root->config_get (cfg_grid_density, density, GridNetDensityConverter ());
+  mp_ui->grid_density_sb->setValue (density);
 }
 
 void
@@ -108,6 +112,7 @@ GridNetConfigPage::commit (lay::Dispatcher *root)
   root->config_set (cfg_grid_style0, lay::GridNet::GridStyle (mp_ui->style0_cbx->currentIndex ()), GridNetStyleConverter ());
   root->config_set (cfg_grid_style1, lay::GridNet::GridStyle (mp_ui->style1_cbx->currentIndex ()), GridNetStyleConverter ());
   root->config_set (cfg_grid_style2, lay::GridNet::GridStyle (mp_ui->style2_cbx->currentIndex ()), GridNetStyleConverter ());
+  root->config_set (cfg_grid_density, mp_ui->grid_density_sb->value (), GridNetDensityConverter ());
 }
 
 } // namespace lay


### PR DESCRIPTION
- There is a new configuration page entry called "Min spacing" for the grid. The default value is 4. The value specifies the grid min spacing in units of UI font height.
- A bugfix is included: the ruler now is drawn after the grid, hence is not hidden by it (specifically in checkerboard pattern mode)
- To allow bigger grid spacing, the ruler now is allowed to grow bigger than before.