### PR TITLE
First attempt to implement a solution for issue #2016

### DIFF
--- a/src/ant/ant/antPropertiesPage.cc
+++ b/src/ant/ant/antPropertiesPage.cc
@@ -517,7 +517,7 @@ PropertiesPage::readonly ()
 }
 
 void 
-PropertiesPage::apply ()
+PropertiesPage::apply (bool /*commit*/)
 {
   ant::Object obj;
   get_object (obj);

--- a/src/ant/ant/antPropertiesPage.h
+++ b/src/ant/ant/antPropertiesPage.h
@@ -50,7 +50,7 @@ public:
   virtual void update ();
   virtual void leave ();
   virtual bool readonly ();
-  virtual void apply ();
+  virtual void apply (bool commit);
 
 private slots:
   void swap_points_clicked ();

--- a/src/edt/edt/edtInstPropertiesPage.cc
+++ b/src/edt/edt/edtInstPropertiesPage.cc
@@ -925,7 +925,7 @@ InstPropertiesPage::do_apply (bool current_only, bool relative)
 }
 
 void 
-InstPropertiesPage::apply ()
+InstPropertiesPage::apply (bool /*commit*/)
 {
   do_apply (true, false);
 }
@@ -937,7 +937,7 @@ InstPropertiesPage::can_apply_to_all () const
 }
 
 void 
-InstPropertiesPage::apply_to_all (bool relative)
+InstPropertiesPage::apply_to_all (bool relative, bool /*commit*/)
 {
   do_apply (false, relative);
 }

--- a/src/edt/edt/edtInstPropertiesPage.h
+++ b/src/edt/edt/edtInstPropertiesPage.h
@@ -66,8 +66,8 @@ protected:
   edt::PCellParametersPage *mp_pcell_parameters;
 
   virtual bool readonly ();
-  virtual void apply (); 
-  virtual void apply_to_all (bool relative);
+  virtual void apply (bool commit);
+  virtual void apply_to_all (bool relative, bool commit);
   virtual bool can_apply_to_all () const;
   void do_apply (bool current_only, bool relative);
   virtual ChangeApplicator *create_applicator (db::Cell &cell, const db::Instance &inst, double dbu);

--- a/src/edt/edt/edtPropertiesPages.cc
+++ b/src/edt/edt/edtPropertiesPages.cc
@@ -215,7 +215,7 @@ ShapePropertiesPage::recompute_selection_ptrs (const std::vector<lay::ObjectInst
 }
 
 void 
-ShapePropertiesPage::do_apply (bool current_only, bool relative)
+ShapePropertiesPage::do_apply (bool current_only, bool relative, bool commit)
 {
   if (m_indexes.empty ()) {
     return;
@@ -321,7 +321,7 @@ ShapePropertiesPage::do_apply (bool current_only, bool relative)
       }
 
       //  handle the case of guiding shape updates
-      std::pair<bool, lay::ObjectInstPath> gs = mp_service->handle_guiding_shape_changes (new_sel[index]);
+      std::pair<bool, lay::ObjectInstPath> gs = mp_service->handle_guiding_shape_changes (new_sel[index], commit);
       if (gs.first) {
 
         new_sel[index] = gs.second;
@@ -350,9 +350,9 @@ ShapePropertiesPage::do_apply (bool current_only, bool relative)
 }
 
 void 
-ShapePropertiesPage::apply ()
+ShapePropertiesPage::apply (bool commit)
 {
-  do_apply (true, false);
+  do_apply (true, false, commit);
 }
 
 bool
@@ -362,9 +362,9 @@ ShapePropertiesPage::can_apply_to_all () const
 }
 
 void 
-ShapePropertiesPage::apply_to_all (bool relative)
+ShapePropertiesPage::apply_to_all (bool relative, bool commit)
 {
-  do_apply (false, relative);
+  do_apply (false, relative, commit);
 }
 
 void 

--- a/src/edt/edt/edtPropertiesPages.h
+++ b/src/edt/edt/edtPropertiesPages.h
@@ -63,10 +63,10 @@ protected:
 
 private:
   virtual void update ();
-  virtual void apply ();
-  virtual void apply_to_all (bool relative);
+  virtual void apply (bool commit);
+  virtual void apply_to_all (bool relative, bool commit);
   virtual bool can_apply_to_all () const;
-  virtual void do_apply (bool current_only, bool relative);
+  virtual void do_apply (bool current_only, bool relative, bool commit);
   void recompute_selection_ptrs (const std::vector<lay::ObjectInstPath> &new_sel);
 
 protected:

--- a/src/edt/edt/edtService.h
+++ b/src/edt/edt/edtService.h
@@ -398,17 +398,19 @@ public:
    *
    *  @return true, if PCells have been updated, indicating that our selection is no longer valid
    *
+   *  @param commit If true, changes are "final" (and PCells are updated also in lazy evaluation mode)
+   *
    *  This version assumes there is only one guiding shape selected and will update the selection.
    *  It will also call layout.cleanup() if required.
    */
-  bool handle_guiding_shape_changes ();
+  bool handle_guiding_shape_changes (bool commit);
 
   /**
    *  @brief Handle changes in a specific guiding shape, i.e. create new PCell variants if required
    *
    *  @return A pair of bool (indicating that the object path has changed) and the new guiding shape path
    */
-  std::pair<bool, lay::ObjectInstPath> handle_guiding_shape_changes (const lay::ObjectInstPath &obj) const;
+  std::pair<bool, lay::ObjectInstPath> handle_guiding_shape_changes (const lay::ObjectInstPath &obj, bool commit) const;
 
   /**
    *  @brief Gets a value indicating whether a move operation is ongoing
@@ -672,9 +674,12 @@ private:
   bool m_snap_to_objects;
   bool m_snap_objects_to_grid;
   db::DVector m_global_grid;
+
+  //  Other attributes
   bool m_top_level_sel;
   bool m_show_shapes_of_instances;
   unsigned int m_max_shapes_of_instances;
+  int m_pcell_lazy_evaluation;
 
   //  Hierarchical copy mode (-1: ask, 0: shallow, 1: deep)
   int m_hier_copy_mode;

--- a/src/img/img/imgPropertiesPage.cc
+++ b/src/img/img/imgPropertiesPage.cc
@@ -784,7 +784,7 @@ PropertiesPage::reverse_color_order ()
 }
 
 void 
-PropertiesPage::apply ()
+PropertiesPage::apply (bool /*commit*/)
 {
   bool has_error = false;
 
@@ -915,7 +915,7 @@ PropertiesPage::browse ()
 {
 BEGIN_PROTECTED
 
-  apply ();
+  apply (true);
 
   lay::FileDialog file_dialog (this, tl::to_string (QObject::tr ("Load Image File")), tl::to_string (QObject::tr ("All files (*)")));
 
@@ -941,7 +941,7 @@ PropertiesPage::save_pressed ()
 {
 BEGIN_PROTECTED
 
-  apply ();
+  apply (true);
 
   lay::FileDialog file_dialog (this, tl::to_string (QObject::tr ("Save As KLayout Image File")), tl::to_string (QObject::tr ("KLayout image files (*.lyimg);;All files (*)")));
 

--- a/src/img/img/imgPropertiesPage.h
+++ b/src/img/img/imgPropertiesPage.h
@@ -57,7 +57,7 @@ public:
   virtual void update ();
   virtual void leave ();
   virtual bool readonly ();
-  virtual void apply (); 
+  virtual void apply (bool commit);
 
   void set_direct_image (img::Object *image);
 

--- a/src/img/img/imgService.cc
+++ b/src/img/img/imgService.cc
@@ -71,7 +71,7 @@ public:
     BEGIN_PROTECTED 
 
     properties_frame->set_direct_image (mp_image_object);
-    properties_frame->apply ();
+    properties_frame->apply (true);
 
     if (mp_image_object->is_empty ()) {
       throw tl::Exception (tl::to_string (tr ("No data loaded for that image")));

--- a/src/laybasic/laybasic/layProperties.h
+++ b/src/laybasic/laybasic/layProperties.h
@@ -154,8 +154,10 @@ public:
    *  Apply any changes to the current objects. If nothing was
    *  changed, the object may be left untouched.
    *  The dialog will start a transaction on the manager object.
+   *
+   *  @param commit Is true for the "final" changes (i.e. not during editing)
    */
-  virtual void apply () 
+  virtual void apply (bool /*commit*/)
   {
     //  default implementation is empty.
   }
@@ -174,8 +176,11 @@ public:
    *  Apply any changes to the current object plus all other objects of the same kind. 
    *  If nothing was changed, the objects may be left untouched.
    *  The dialog will start a transaction on the manager object.
+   *
+   *  @param relative Is true if relative mode is selected
+   *  @param commit Is true for the "final" changes (i.e. not during editing)
    */
-  virtual void apply_to_all (bool /*relative*/)
+  virtual void apply_to_all (bool /*relative*/, bool /*commit*/)
   {
     //  default implementation is empty.
   }

--- a/src/layui/layui/layPropertiesDialog.cc
+++ b/src/layui/layui/layPropertiesDialog.cc
@@ -197,7 +197,7 @@ PropertiesDialog::PropertiesDialog (QWidget * /*parent*/, db::Manager *manager, 
   }
   for (size_t i = 0; i < mp_properties_pages.size (); ++i) {
     mp_stack->addWidget (mp_properties_pages [i]);
-    connect (mp_properties_pages [i], SIGNAL (edited ()), this, SLOT (apply ()));
+    connect (mp_properties_pages [i], SIGNAL (edited ()), this, SLOT (properties_edited ()));
   }
 
   //  Necessary to maintain the page order for UI regression testing of 0.18 vs. 0.19 (because tl::Collection has changed to order) ..
@@ -314,7 +314,7 @@ PropertiesDialog::current_index_changed (const QModelIndex &index, const QModelI
 
         db::Transaction t (mp_manager, tl::to_string (QObject::tr ("Apply changes")), m_transaction_id);
 
-        mp_properties_pages [m_index]->apply ();
+        mp_properties_pages [m_index]->apply (true);
 
         if (! t.is_empty ()) {
           m_transaction_id = t.id ();
@@ -437,7 +437,7 @@ BEGIN_PROTECTED
 
   if (! mp_properties_pages [m_index]->readonly ()) {
     db::Transaction t (mp_manager, tl::to_string (QObject::tr ("Apply changes")), m_transaction_id);
-    mp_properties_pages [m_index]->apply ();
+    mp_properties_pages [m_index]->apply (true);
     if (! t.is_empty ()) {
       m_transaction_id = t.id ();
     }
@@ -485,7 +485,7 @@ BEGIN_PROTECTED
 
   if (! mp_properties_pages [m_index]->readonly ()) {
     db::Transaction t (mp_manager, tl::to_string (QObject::tr ("Apply changes")), m_transaction_id);
-    mp_properties_pages [m_index]->apply ();
+    mp_properties_pages [m_index]->apply (true);
     if (! t.is_empty ()) {
       m_transaction_id = t.id ();
     }
@@ -567,7 +567,7 @@ PropertiesDialog::any_prev () const
 }
 
 void
-PropertiesDialog::apply ()
+PropertiesDialog::properties_edited ()
 {
 BEGIN_PROTECTED
 
@@ -580,9 +580,9 @@ BEGIN_PROTECTED
   try {
 
     if (mp_ui->apply_to_all_cbx->isChecked () && mp_properties_pages [m_index]->can_apply_to_all ()) {
-      mp_properties_pages [m_index]->apply_to_all (mp_ui->relative_cbx->isChecked ());
+      mp_properties_pages [m_index]->apply_to_all (mp_ui->relative_cbx->isChecked (), false);
     } else {
-      mp_properties_pages [m_index]->apply ();
+      mp_properties_pages [m_index]->apply (false);
     }
     mp_properties_pages [m_index]->update ();
 
@@ -632,7 +632,7 @@ BEGIN_PROTECTED
 
     db::Transaction t (mp_manager, tl::to_string (QObject::tr ("Apply changes")), m_transaction_id);
 
-    mp_properties_pages [m_index]->apply ();
+    mp_properties_pages [m_index]->apply (true);
     mp_properties_pages [m_index]->update ();
 
     if (! t.is_empty ()) {

--- a/src/layui/layui/layPropertiesDialog.h
+++ b/src/layui/layui/layPropertiesDialog.h
@@ -105,7 +105,7 @@ private:
   void update_controls ();
 
 public slots:
-  void apply ();
+  void properties_edited ();
   void next_pressed ();
   void prev_pressed ();
   void cancel_pressed ();


### PR DESCRIPTION
The implementation will not update the PCell on
property sheet edits of the guiding shape
if lazy evaluation is requested. Still, changes
are committed to the PCell on committing the
property page.