### PR TITLE
 Adding freecad python modules

### DIFF
--- a/scripts/deploy-win-mingw.sh
+++ b/scripts/deploy-win-mingw.sh
@@ -176,6 +176,15 @@ if ! [ -e $target/klayout.exe ]; then
 fi
 
 # ----------------------------------------------------------
+# FreeCAD
+if [ "$MSYSTEM" == "UCRT64" ]; then
+cp /ucrt64/bin/FreeCAD.exe  $target
+cp /ucrt64/bin/FreeCAD.pyd  $target
+cp /ucrt64/bin/FreeCADCmd.exe $target
+cp /ucrt64/bin/FreeCADGui.pyd $target
+fi
+
+# ----------------------------------------------------------
 # cert.pem
 
 echo "Installing cert.pem .."

--- a/scripts/deploy-win-mingw.sh
+++ b/scripts/deploy-win-mingw.sh
@@ -391,6 +391,8 @@ echo "Making .zip file $zipname.zip .."
 rm -rf $zipname $zipname.zip
 mkdir $zipname
 cp -Rv strm*.exe *.dll cert.pem .*-paths.txt db_plugins lay_plugins pymod $plugins lib $zipname | sed -u 's/.*/echo -n ./' | sh
+cp klayout.exe $zipname/klayout_app.exe
+cp klayout.exe $zipname/klayout_vo_app.exe
 if [ "$MSYSTEM" == "UCRT64" ]; then
   cp -r bin $zipname/
   cp -r Ext $zipname/

--- a/scripts/deploy-win-mingw.sh
+++ b/scripts/deploy-win-mingw.sh
@@ -298,7 +298,7 @@ if [ "$MSYSTEM" == "UCRT64" ]; then
 # ----------------------------------------------------------
 # FreeCAD Binary dependencies
   pushd $target
-  pushd $bin
+  pushd bin
   new_libs=$(find . -name "*.exe" -or -name "*.dll" -or -name "*.pyd" -or -name "*.so")
 
   while [ "$new_libs" != "" ]; do

--- a/scripts/deploy-win-mingw.sh
+++ b/scripts/deploy-win-mingw.sh
@@ -289,17 +289,21 @@ echo ']' >>$target/.python-paths.txt
 # FreeCAD
 if [ "$MSYSTEM" == "UCRT64" ]; then
   mkdir $target/bin
-  cp /ucrt64/bin/FreeCAD.exe  $target/bin
   cp /ucrt64/bin/FreeCAD.pyd  $target/bin
   cp /ucrt64/bin/FreeCADCmd.exe $target/bin
   cp /ucrt64/bin/FreeCADGui.pyd $target/bin
   cp -r /ucrt64/Ext $target/
-  cp -r /ucrt64/Mod $target/
+  mkdir $target/Mod
+  cp -r /ucrt64/Mod/Part $target/Mod
+  cp -r /ucrt64/Mod/PartDesign $target/Mod
+  cp -r /ucrt64/Mod/Sketcher $target/Mod
+  cp -r /ucrt64/Mod/Draft $target/Mod
+  cp -r /ucrt64/Mod/Import $target/Mod
 # ----------------------------------------------------------
 # FreeCAD Binary dependencies
   pushd $target
   pushd bin
-  new_libs=$(find . -name "*.exe" -or -name "*.dll" -or -name "*.pyd" -or -name "*.so")
+  new_libs=$(find . -name "*.dll" -or -name "*.pyd" -or -name "*.so")
 
   while [ "$new_libs" != "" ]; do
     echo "Analyzing FreeCAD dependencies of $new_libs .."

--- a/scripts/deploy-win-ucrt64.sh
+++ b/scripts/deploy-win-ucrt64.sh
@@ -2,6 +2,8 @@
 
 # deploy-win-ucrt64.sh is an alias for deploy-win-mingw.sh now
 
+export PYTHONPATH=/ucrt64/bin:$PYTHONPATH
+
 inst=$(dirname $(which $0))
 $inst/deploy-win-mingw.sh -ucrt $*
 

--- a/scripts/klayout-inst.nsis
+++ b/scripts/klayout-inst.nsis
@@ -72,6 +72,9 @@ section
   file /r db_plugins
   file /r lay_plugins
   file /r pymod
+  file /r bin
+  file /r Ext
+  file /r Mod
   file /nonfatal /r audio
   file /nonfatal /r generic
   file /nonfatal /r iconengines


### PR DESCRIPTION
The change of PYTHONPATH made in script deploy-win-ucrt64 is required for importing
 FreeCAD, Part, and other FreeCAD submodules.

FreeCAD must be installed in the MSYS2 before running that script.This is done with command:  "pacman -S mingw-w64-ucrt-x86_64-freecad".

I have also done a full upgrade of my MSYS2 system with "pacman -Suy" because it was very outdated. Then I have built klayout 30.1 and It seems working well but there is a problem: FreCAD python modules were included in subfolders Ext and Mod of bin-release-win64-ucrt but not included in the NSIS package.