### PR TITLE
Fix logic error in hex2int.

### DIFF
--- a/src/tl/tl/tlUri.cc
+++ b/src/tl/tl/tlUri.cc
@@ -41,7 +41,7 @@ static char hex2int (char c)
     return c - '0';
   } else if (c >= 'A' && c <= 'F') {
     return (c - 'A') + 10;
-  } else if (c >= 'a' || c <= 'f') {
+  } else if (c >= 'a' && c <= 'f') {
     return (c - 'a') + 10;
   } else {
     return 0;


### PR DESCRIPTION
This was probably never noticed as it was the last branch and would behave benign on valid input.