### PR TITLE
Allow no-GIL wheels to be uploaded to PyPI as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibuild }}
           CIBW_ARCHS_MACOS: ${{ matrix.macos-arch }}
           CIBW_DEPENDENCY_VERSIONS_MACOS: cibw_constraints.txt
+          CIBW_ENABLE: cpython-freethreading
 
       - name: Download Cache from Docker (linux only)
         if: ${{ runner.os == 'Linux' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ test-command = [
 ]
 # Disable building PyPy wheels on all platforms
 skip = "pp* cp36-* cp37-*"
+enable = ["cpython-freethreading"]
 
 [tool.cibuildwheel.linux]
 # beware: the before-all script does not persist environment variables!


### PR DESCRIPTION
Supercedes #2047 by not building wheels for pre-release CPython versions

As evident by https://github.com/clin1234/klayout/actions/runs/15031698862, free-threaded wheels for 3.13 builds successfully