### PR TITLE
Fixing issue #2102 (internal error on R extraction)

### DIFF
--- a/src/db/db/dbPLCConvexDecomposition.cc
+++ b/src/db/db/dbPLCConvexDecomposition.cc
@@ -430,12 +430,6 @@ ConvexDecomposition::decompose (const db::Polygon &poly, const ConvexDecompositi
 }
 
 void
-ConvexDecomposition::decompose (const db::Polygon &poly, const std::vector<db::Point> &vertexes, const ConvexDecompositionParameters &parameters, double dbu)
-{
-  decompose (poly, vertexes, parameters, db::CplxTrans (dbu));
-}
-
-void
 ConvexDecomposition::decompose (const db::Polygon &poly, const ConvexDecompositionParameters &parameters, const db::CplxTrans &trans)
 {
   Triangulation tri (mp_graph);
@@ -445,28 +439,10 @@ ConvexDecomposition::decompose (const db::Polygon &poly, const ConvexDecompositi
 }
 
 void
-ConvexDecomposition::decompose (const db::Polygon &poly, const std::vector<db::Point> &vertexes, const ConvexDecompositionParameters &parameters, const db::CplxTrans &trans)
-{
-  Triangulation tri (mp_graph);
-  tri.triangulate (poly, vertexes, parameters.tri_param, trans);
-
-  hertel_mehlhorn_decomposition (tri, parameters);
-}
-
-void
 ConvexDecomposition::decompose (const db::DPolygon &poly, const ConvexDecompositionParameters &parameters, const db::DCplxTrans &trans)
 {
   Triangulation tri (mp_graph);
   tri.triangulate (poly, parameters.tri_param, trans);
-
-  hertel_mehlhorn_decomposition (tri, parameters);
-}
-
-void
-ConvexDecomposition::decompose (const db::DPolygon &poly, const std::vector<db::DPoint> &vertexes, const ConvexDecompositionParameters &parameters, const db::DCplxTrans &trans)
-{
-  Triangulation tri (mp_graph);
-  tri.triangulate (poly, vertexes, parameters.tri_param, trans);
 
   hertel_mehlhorn_decomposition (tri, parameters);
 }

--- a/src/db/db/dbPLCConvexDecomposition.h
+++ b/src/db/db/dbPLCConvexDecomposition.h
@@ -118,15 +118,12 @@ public:
   //  more versions
   void decompose (const db::Region &region, const ConvexDecompositionParameters &parameters, const db::CplxTrans &trans = db::CplxTrans ());
   void decompose (const db::Polygon &poly, const ConvexDecompositionParameters &parameters, double dbu = 1.0);
-  void decompose (const db::Polygon &poly, const std::vector<db::Point> &vertexes, const ConvexDecompositionParameters &parameters, double dbu = 1.0);
   void decompose (const db::Polygon &poly, const ConvexDecompositionParameters &parameters, const db::CplxTrans &trans = db::CplxTrans ());
-  void decompose (const db::Polygon &poly, const std::vector<db::Point> &vertexes, const ConvexDecompositionParameters &parameters, const db::CplxTrans &trans = db::CplxTrans ());
 
   /**
    *  @brief Decomposes a floating-point polygon
    */
   void decompose (const db::DPolygon &poly, const ConvexDecompositionParameters &parameters, const db::DCplxTrans &trans = db::DCplxTrans ());
-  void decompose (const db::DPolygon &poly, const std::vector<db::DPoint> &vertexes, const ConvexDecompositionParameters &parameters, const db::DCplxTrans &trans = db::DCplxTrans ());
 
 private:
   Graph *mp_graph;

--- a/src/db/unit_tests/dbPLCConvexDecompositionTests.cc
+++ b/src/db/unit_tests/dbPLCConvexDecompositionTests.cc
@@ -110,49 +110,6 @@ TEST(basic)
   db::compare_layouts (_this, *ly, tl::testdata () + "/algo/hm_decomposition_au4.gds");
 }
 
-TEST(internal_vertex)
-{
-  db::plc::Graph plc;
-  TestableConvexDecomposition decomp (&plc);
-
-  db::Point contour[] = {
-    db::Point (0, 0),
-    db::Point (0, 100),
-    db::Point (1000, 100),
-    db::Point (1000, 0)
-  };
-
-  std::vector<db::Point> vertexes;
-  vertexes.push_back (db::Point (0, 50));  // on edge
-  vertexes.push_back (db::Point (200, 70));
-  vertexes.push_back (db::Point (0, 0));  //  on vertex
-
-  db::Polygon poly;
-  poly.assign_hull (contour + 0, contour + sizeof (contour) / sizeof (contour[0]));
-
-  double dbu = 0.001;
-
-  db::plc::ConvexDecompositionParameters param;
-  decomp.decompose (poly, vertexes, param, dbu);
-
-  EXPECT_EQ (plc.begin () == plc.end (), false);
-  if (plc.begin () == plc.end ()) {
-    return;
-  }
-
-  auto p = plc.begin ();
-  EXPECT_EQ (p->polygon ().to_string (), "(0,0;0,0.05;0,0.1;1,0.1;1,0)");
-
-  std::vector<std::string> ip;
-  for (size_t i = 0; i < p->internal_vertexes (); ++i) {
-    ip.push_back (p->internal_vertex (i)->to_string () + "#" + tl::join (p->internal_vertex (i)->ids ().begin (), p->internal_vertex (i)->ids ().end (), ","));
-  }
-  std::sort (ip.begin (), ip.end ());
-  EXPECT_EQ (tl::join (ip, "/"), "(0, 0)#2/(0, 0.05)#0/(0.2, 0.07)#1");
-
-  EXPECT_EQ (++p == plc.end (), true);
-}
-
 TEST(problematic_polygon)
 {
   db::Point contour[] = {

--- a/src/pex/unit_tests/pexSquareCountingRExtractorTests.cc
+++ b/src/pex/unit_tests/pexSquareCountingRExtractorTests.cc
@@ -213,3 +213,35 @@ TEST(extraction_meander)
     "R V0(0.3,0;0.3,0) V1(4.3,1;4.3,1) 10.0543767445"          //  that is pretty much the length of the center line / width :)
   )
 }
+
+TEST(issue_2102)
+{
+  db::Point contour[] = {
+    db::Point (-85, -610),
+    db::Point (-85, 610),
+    db::Point (85, 610),
+    db::Point (85, 440),
+    db::Point (65, 440),
+    db::Point (65, -610)
+  };
+
+  db::Polygon poly;
+  poly.assign_hull (contour + 0, contour + sizeof (contour) / sizeof (contour[0]));
+
+  double dbu = 0.001;
+
+  pex::RNetwork rn;
+  pex::SquareCountingRExtractor rex (dbu);
+
+  std::vector<db::Point> vertex_ports;
+  vertex_ports.push_back (db::Point (0, 525));
+  vertex_ports.push_back (db::Point (-85, -610));
+
+  std::vector<db::Polygon> polygon_ports;
+
+  rex.extract (poly, vertex_ports, polygon_ports, rn);
+
+  EXPECT_EQ (network2s (rn),
+    "R V0(0,0.525;0,0.525) V1(-0.085,-0.61;-0.085,-0.61) 7.89600487195"          //  was crashing before
+  )
+}


### PR DESCRIPTION
Problem was a conceptual problem: the triangulation for Hertel-Mehlhorn decomposition must not contain internal vertexes. So we need a different solution for including vertex ports.