### PR TITLE
Correct typo gsiDeclDbNetlist.cc

### DIFF
--- a/src/db/db/gsiDeclDbNetlist.cc
+++ b/src/db/db/gsiDeclDbNetlist.cc
@@ -2269,7 +2269,7 @@ Class<db::Netlist> decl_dbNetlist ("db", "Netlist",
     "This method is a convenience method that runs \\make_top_level_pins, \\purge, \\combine_devices and \\purge_nets."
   ) +
   gsi::method_ext ("read", &read_netlist, gsi::arg ("file"), gsi::arg ("reader"),
-    "@brief Writes the netlist to the given file using the given reader object to parse the file\n"
+    "@brief Reads the netlist from the given file using the given reader object to parse the file\n"
     "See \\NetlistSpiceReader for an example for a parser. "
   ) +
   gsi::method_ext ("write", &write_netlist, gsi::arg ("file"), gsi::arg ("writer"), gsi::arg ("description", std::string ()),


### PR DESCRIPTION
Corrected a typo that has the docs say the Netlist.read method 'Writes the netlist to the given file'. It now accurately matches the function behavior.