### PR TITLE
Feature/issue 2110

### DIFF
--- a/src/db/db/dbBoxConvert.cc
+++ b/src/db/db/dbBoxConvert.cc
@@ -36,12 +36,7 @@ DB_PUBLIC db::Box cellinst_box_convert_impl (const db::CellInst &inst, const db:
   } else if (allow_empty) {
     return inst.bbox (*layout);
   } else {
-    db::Box box = inst.bbox (*layout);
-    if (box.empty ()) {
-      return db::Box (db::Point (0, 0), db::Point (0, 0));
-    } else {
-      return box;
-    }
+    return inst.bbox_with_empty (*layout);
   }
 }
 
@@ -52,11 +47,7 @@ DB_PUBLIC db::Box cell_box_convert_impl (const db::Cell &c, int layer, bool allo
   } else if (allow_empty) {
     return c.bbox ();
   } else {
-    if (c.bbox ().empty ()) {
-      return db::Box (db::Point (0, 0), db::Point (0, 0));
-    } else {
-      return c.bbox ();
-    }
+    return c.bbox_with_empty ();
   }
 }
 

--- a/src/db/db/dbCell.h
+++ b/src/db/db/dbCell.h
@@ -537,6 +537,17 @@ public:
   const box_type &bbox () const;
 
   /**
+   *  @brief Retrieve the bounding box of the cell, including empty cells
+   *
+   *  This method behaves like "bbox", but includes empty cells as single-point
+   *  boxes (0,0;0,0). This bounding box is used for drawing and allows
+   *  including empty cells.
+   *
+   *  @return The bounding box that was computed by update_bbox
+   */
+  const box_type &bbox_with_empty () const;
+
+  /**
    *  @brief Retrieve the per-layer bounding box of the cell
    *
    *  Before the bounding box can be retrieved, it must have
@@ -1098,7 +1109,7 @@ private:
   mutable db::Layout *mp_layout;
   shapes_map m_shapes_map;
   instances_type m_instances;
-  box_type m_bbox;
+  box_type m_bbox, m_bbox_with_empty;
   box_map m_bboxes;
   db::properties_id_type m_prop_id;
 

--- a/src/db/db/dbCellInst.cc
+++ b/src/db/db/dbCellInst.cc
@@ -34,6 +34,12 @@ CellInst::bbox (const db::Layout &g) const
 }
 
 CellInst::box_type
+CellInst::bbox_with_empty (const db::Layout &g) const
+{
+  return g.cell (m_cell_index).bbox_with_empty ();
+}
+
+CellInst::box_type
 CellInst::bbox (const db::Layout &g, unsigned int l) const
 {
   return g.cell (m_cell_index).bbox (l);

--- a/src/db/db/dbCellInst.h
+++ b/src/db/db/dbCellInst.h
@@ -91,6 +91,15 @@ public:
   box_type bbox (const Layout &g) const;
 
   /**
+   *  @brief Compute the bounding box, including empty cells
+   *
+   *  This method computes the bbox of the cell instance.
+   *  As a requirement, the cell's bounding box must have been
+   *  computed before.
+   */
+  box_type bbox_with_empty (const Layout &g) const;
+
+  /**
    *  @brief Compute the bounding box
    *
    *  This method computes the bbox of the cell instance

--- a/src/db/db/dbInstElement.h
+++ b/src/db/db/dbInstElement.h
@@ -85,7 +85,8 @@ struct DB_PUBLIC InstElement
    *
    *  @param bc The bounding box converter for the cell instance (db::box_convert<db::CellInst>)
    */
-  db::Box bbox (const db::box_convert<db::CellInst> &bc) const
+  template <class BoxConvert>
+  db::Box bbox (const BoxConvert &bc) const
   {
     if (whole_array ()) {
       //  this is the whole array

--- a/src/db/db/dbInstances.cc
+++ b/src/db/db/dbInstances.cc
@@ -907,6 +907,19 @@ Instance::bbox () const
   }
 }
 
+Instance::box_type
+Instance::bbox_with_empty () const
+{
+  const db::Instances *i = instances ();
+  const db::Cell *c = i ? i->cell () : 0;
+  const db::Layout *g = c ? c->layout () : 0;
+  if (g) {
+    return bbox (db::box_convert<cell_inst_type, false> (*g));
+  } else {
+    return db::Instance::box_type ();
+  }
+}
+
 // -------------------------------------------------------------------------------------
 //  Instances implementation
 

--- a/src/db/db/dbInstances.h
+++ b/src/db/db/dbInstances.h
@@ -339,6 +339,15 @@ public:
   cell_inst_array_type::box_type bbox () const;
 
   /**
+   *  @brief Returns the bounding box of this array, including empty instances
+   *
+   *  This method uses the pointers provided internally to identify container and cell.
+   *  In constrast to normal "bbox", this bounding box considers empty cells as
+   *  point-like with a box of (0,0;0,0).
+   */
+  cell_inst_array_type::box_type bbox_with_empty () const;
+
+  /**
    *  @brief Return the iterator for the instances of the array
    *
    *  This method is basically provided for convenience

--- a/src/db/unit_tests/dbCellTests.cc
+++ b/src/db/unit_tests/dbCellTests.cc
@@ -723,6 +723,7 @@ TEST(3a)
   EXPECT_EQ (inst.to_string (), "cell_index=1 r0 100,-100");
   EXPECT_EQ (inst.bbox ().to_string (), "()");
   EXPECT_EQ (inst.bbox (db::box_convert<db::CellInst, false> (g)).to_string (), "(100,-100;100,-100)");
+  EXPECT_EQ (inst.bbox_with_empty ().to_string (), "(100,-100;100,-100)");
   EXPECT_EQ (c0.bbox ().to_string (), "()");
   EXPECT_EQ (c0.bbox_with_empty ().to_string (), "(100,-100;100,-100)");
 

--- a/src/db/unit_tests/dbCellTests.cc
+++ b/src/db/unit_tests/dbCellTests.cc
@@ -33,13 +33,18 @@ TEST(1)
   db::Cell &c1 (g.cell (g.add_cell ()));
   db::Cell &c2 (g.cell (g.add_cell ()));
 
+  EXPECT_EQ (c1.bbox (), db::Box ());
+  EXPECT_EQ (c1.bbox_with_empty (), db::Box (db::Point(), db::Point ()));
+
   db::Box b (0, 100, 1000, 1200);
   c1.shapes (0).insert (b);
   EXPECT_EQ (c1.bbox (), b);
+  EXPECT_EQ (c1.bbox_with_empty (), b);
 
   db::Box bb (0, -100, 2000, 2200);
   c1.shapes (1).insert (bb);
   EXPECT_EQ (c1.bbox (), b + bb);
+  EXPECT_EQ (c1.bbox_with_empty (), b + bb);
   EXPECT_EQ (c1.bbox (0), b);
   EXPECT_EQ (c1.bbox (1), bb);
 
@@ -52,6 +57,7 @@ TEST(1)
   EXPECT_EQ (c2.bbox (0), t * b);
   EXPECT_EQ (c2.bbox (1), t * bb);
   EXPECT_EQ (c1.bbox (), (b + bb));
+  EXPECT_EQ (c1.bbox_with_empty (), (b + bb));
 
   //  some basic testing of the instance trees
   int n;
@@ -715,6 +721,10 @@ TEST(3a)
   db::Trans t (db::Vector (100, -100));
   db::Instance inst = c0.insert (db::CellInstArray (db::CellInst (c1.cell_index ()), t));
   EXPECT_EQ (inst.to_string (), "cell_index=1 r0 100,-100");
+  EXPECT_EQ (inst.bbox ().to_string (), "()");
+  EXPECT_EQ (inst.bbox (db::box_convert<db::CellInst, false> (g)).to_string (), "(100,-100;100,-100)");
+  EXPECT_EQ (c0.bbox ().to_string (), "()");
+  EXPECT_EQ (c0.bbox_with_empty ().to_string (), "(100,-100;100,-100)");
 
   inst = c0.transform (inst, db::Trans (5));
   EXPECT_EQ (inst.to_string (), "cell_index=1 m45 -100,100");

--- a/src/edt/edt/edtService.cc
+++ b/src/edt/edt/edtService.cc
@@ -1115,7 +1115,7 @@ Service::click_proximity (const db::DPoint &pos, lay::Editable::SelectionMode mo
     lay::InstFinder finder (true, view ()->is_editable () && m_top_level_sel, view ()->is_editable () /*full arrays in editable mode*/, true /*enclose_inst*/, exclude, true /*visible layers*/);
 
     //  go through all cell views
-    std::set< std::pair<db::DCplxTrans, int> > variants = view ()->cv_transform_variants ();
+    std::set< std::pair<db::DCplxTrans, int> > variants = view ()->cv_transform_variants_with_empty();
     for (std::set< std::pair<db::DCplxTrans, int> >::const_iterator v = variants.begin (); v != variants.end (); ++v) {
       finder.find (view (), v->second, v->first, search_box);
     }
@@ -1164,7 +1164,7 @@ Service::transient_select (const db::DPoint &pos)
     lay::InstFinder finder (true, view ()->is_editable () && m_top_level_sel, view ()->is_editable () /*full arrays in editable mode*/, true /*enclose instances*/, &m_previous_selection, true /*visible layers only*/);
 
     //  go through all transform variants
-    std::set< std::pair<db::DCplxTrans, int> > variants = view ()->cv_transform_variants ();
+    std::set< std::pair<db::DCplxTrans, int> > variants = view ()->cv_transform_variants_with_empty ();
     for (std::set< std::pair<db::DCplxTrans, int> >::const_iterator v = variants.begin (); v != variants.end (); ++v) {
       finder.find (view (), v->second, v->first, search_box);
     }
@@ -1185,7 +1185,7 @@ Service::transient_select (const db::DPoint &pos)
 
       db::Instance inst = r->back ().inst_ptr;
 
-      std::vector<db::DCplxTrans> tv = mp_view->cv_transform_variants (r->cv_index ());
+      std::vector<db::DCplxTrans> tv = mp_view->cv_transform_variants_with_empty (r->cv_index ());
       if (view ()->is_editable ()) {
 
 #if 0
@@ -1498,7 +1498,7 @@ Service::select (const db::DBox &box, lay::Editable::SelectionMode mode)
     lay::InstFinder finder (box.is_point (), view ()->is_editable () && m_top_level_sel, view ()->is_editable () /*full arrays in editable mode*/, true /*enclose_inst*/, exclude, true /*only visible layers*/);
 
     //  go through all cell views
-    std::set< std::pair<db::DCplxTrans, int> > variants = view ()->cv_transform_variants ();
+    std::set< std::pair<db::DCplxTrans, int> > variants = view ()->cv_transform_variants_with_empty ();
     for (std::set< std::pair<db::DCplxTrans, int> >::const_iterator v = variants.begin (); v != variants.end (); ++v) {
       finder.find (view (), v->second, v->first, search_box);
     }
@@ -1754,6 +1754,10 @@ Service::do_selection_to_view ()
   //  build the transformation variants cache
   TransformationVariants tv (view ());
 
+  //  prepare a default transformation for empty variants
+  std::vector<db::DCplxTrans> empty_tv;
+  empty_tv.push_back (db::DCplxTrans ());
+
   //  Build markers
 
   for (EditableSelectionIterator r = begin_selection (); ! r.at_end (); ++r) {
@@ -1769,39 +1773,39 @@ Service::do_selection_to_view ()
     if (m_cell_inst_service) {
 
       const std::vector<db::DCplxTrans> *tv_list = tv.per_cv (r->cv_index ());
-      if (tv_list != 0) {
+      if (tv_list == 0) {
+        tv_list = &empty_tv;
+      }
       
-        if (view ()->is_editable ()) {
+      if (view ()->is_editable ()) {
 
 #if 0
-          //  to show the content of the cell when the instance is selected:
-          lay::InstanceMarker *marker = new lay::InstanceMarker (view (), r->cv_index (), ! show_shapes_of_instances (), show_shapes_of_instances () ? max_shapes_of_instances () : 0);
+        //  to show the content of the cell when the instance is selected:
+        lay::InstanceMarker *marker = new lay::InstanceMarker (view (), r->cv_index (), ! show_shapes_of_instances (), show_shapes_of_instances () ? max_shapes_of_instances () : 0);
 #else
-          lay::InstanceMarker *marker = new lay::InstanceMarker (view (), r->cv_index ());
+        lay::InstanceMarker *marker = new lay::InstanceMarker (view (), r->cv_index ());
 #endif
-          marker->set_vertex_shape (lay::ViewOp::Cross);
-          marker->set_vertex_size (9 /*cross vertex size*/);
+        marker->set_vertex_shape (lay::ViewOp::Cross);
+        marker->set_vertex_size (9 /*cross vertex size*/);
 
-          if (r->seq () > 0 && m_indicate_secondary_selection) { 
-            marker->set_dither_pattern (3); 
-          } 
-          marker->set (r->back ().inst_ptr, gt, *tv_list);
-          m_markers.push_back (std::make_pair (r.operator-> (), marker));
-
-        } else {
-
-          lay::Marker *marker = new lay::Marker (view (), r->cv_index ());
-          marker->set_vertex_shape (lay::ViewOp::Cross);
-          marker->set_vertex_size (9 /*cross vertex size*/);
-
-          if (r->seq () > 0 && m_indicate_secondary_selection) { 
-            marker->set_dither_pattern (3); 
-          } 
-          db::box_convert<db::CellInst> bc (cv->layout ());
-          marker->set (bc (r->back ().inst_ptr.cell_inst ().object ()), gt * r->back ().inst_ptr.cell_inst ().complex_trans (*r->back ().array_inst), *tv_list);
-          m_markers.push_back (std::make_pair (r.operator-> (), marker));
-
+        if (r->seq () > 0 && m_indicate_secondary_selection) {
+          marker->set_dither_pattern (3);
         }
+        marker->set (r->back ().inst_ptr, gt, *tv_list);
+        m_markers.push_back (std::make_pair (r.operator-> (), marker));
+
+      } else {
+
+        lay::Marker *marker = new lay::Marker (view (), r->cv_index ());
+        marker->set_vertex_shape (lay::ViewOp::Cross);
+        marker->set_vertex_size (9 /*cross vertex size*/);
+
+        if (r->seq () > 0 && m_indicate_secondary_selection) {
+          marker->set_dither_pattern (3);
+        }
+        db::box_convert<db::CellInst> bc (cv->layout ());
+        marker->set (bc (r->back ().inst_ptr.cell_inst ().object ()), gt * r->back ().inst_ptr.cell_inst ().complex_trans (*r->back ().array_inst), *tv_list);
+        m_markers.push_back (std::make_pair (r.operator-> (), marker));
 
       }
 

--- a/src/edt/edt/edtService.cc
+++ b/src/edt/edt/edtService.cc
@@ -627,7 +627,7 @@ Service::selection_bbox ()
 
     db::CplxTrans ctx_trans = db::CplxTrans (layout.dbu ()) * cv.context_trans () * r->trans ();
 
-    db::box_convert<db::CellInst> bc (layout);
+    db::box_convert<db::CellInst, false> bc (layout);
     if (! r->is_cell_inst ()) {
 
       const std::vector<db::DCplxTrans> *tv_list = tv.per_cv_and_layer (r->cv_index (), r->layer ());

--- a/src/edt/edt/edtServiceImpl.cc
+++ b/src/edt/edt/edtServiceImpl.cc
@@ -1686,7 +1686,7 @@ InstService::do_begin_edit (const db::DPoint &p)
   std::pair<bool, db::cell_index_type> ci = make_cell (cv);
   if (ci.first) {
     // use the snapped lower left corner of the bbox unless the origin is inside the bbox
-    db::Box cell_bbox = cv->layout ().cell (ci.second).bbox ();
+    db::Box cell_bbox = cv->layout ().cell (ci.second).bbox_with_empty ();
     if (! m_place_origin && ! cell_bbox.contains (db::Point ())) {
       db::CplxTrans ct (1.0, m_angle, m_mirror, db::DVector ());
       m_disp = db::DPoint () + (m_disp - snap (cell_bbox.transformed (ct).lower_left () * cv->layout ().dbu ()));
@@ -1830,7 +1830,7 @@ InstService::do_mouse_move (const db::DPoint &p)
   std::pair<bool, db::cell_index_type> ci = make_cell (cv);
   if (ci.first) {
     //  use the snapped lower left corner of the bbox unless the origin is inside the bbox
-    db::Box cell_bbox = cv->layout ().cell (ci.second).bbox ();
+    db::Box cell_bbox = cv->layout ().cell (ci.second).bbox_with_empty ();
     if (! m_place_origin && ! cell_bbox.contains (db::Point ())) {
       db::CplxTrans ct (1.0, m_angle, m_mirror, db::DVector ());
       m_disp = db::DPoint () + (m_disp - snap (cell_bbox.transformed (ct).lower_left () * cv->layout ().dbu ()));

--- a/src/laybasic/laybasic/layFinder.cc
+++ b/src/laybasic/laybasic/layFinder.cc
@@ -837,9 +837,10 @@ InstFinder::visit_cell (const db::Cell &cell, const db::Box &search_box, const d
           ++*mp_progress;
 
           db::Box ibox;
-          if (inst_cell.bbox_with_empty ().empty ()) {
-            ibox = db::Box (db::Point (0, 0), db::Point (0, 0));
-          } else if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || inst_cell.is_ghost_cell () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
+          if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || inst_cell.is_ghost_cell () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
+            ibox = inst_cell.bbox_with_empty ();
+          } else if (inst_cell.bbox ().empty ()) {
+            //  empty cells cannot be found by visible layers, so we always select them here
             ibox = inst_cell.bbox_with_empty ();
           } else {
             for (std::vector<int>::const_iterator l = m_visible_layer_indexes.begin (); l != m_visible_layer_indexes.end (); ++l) {
@@ -915,9 +916,10 @@ InstFinder::visit_cell (const db::Cell &cell, const db::Box &search_box, const d
           double d = std::numeric_limits<double>::max ();
 
           db::Box ibox;
-          if (inst_cell.bbox_with_empty ().empty ()) {
-            ibox = db::Box (db::Point (0, 0), db::Point (0, 0));
-          } else if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || inst_cell.is_ghost_cell () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
+          if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || inst_cell.is_ghost_cell () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
+            ibox = inst_cell.bbox_with_empty ();
+          } else if (inst_cell.bbox ().empty ()) {
+            //  empty cells cannot be found by visible layers, so we always select them here
             ibox = inst_cell.bbox_with_empty ();
           } else {
             for (std::vector<int>::const_iterator l = m_visible_layer_indexes.begin (); l != m_visible_layer_indexes.end (); ++l) {

--- a/src/laybasic/laybasic/layFinder.cc
+++ b/src/laybasic/laybasic/layFinder.cc
@@ -100,13 +100,13 @@ Finder::start (lay::LayoutViewBase *view, unsigned int cv_index, const std::vect
 
   if (layers.size () == 1) {
 
-    m_box_convert = db::box_convert <db::CellInst> (*mp_layout, (unsigned int) layers [0]);
-    m_cell_box_convert = db::box_convert <db::Cell> ((unsigned int) layers [0]);
+    m_box_convert = db::box_convert <db::CellInst, false> (*mp_layout, (unsigned int) layers [0]);
+    m_cell_box_convert = db::box_convert <db::Cell, false> ((unsigned int) layers [0]);
 
   } else {
 
-    m_box_convert = db::box_convert <db::CellInst> (*mp_layout);
-    m_cell_box_convert = db::box_convert <db::Cell> ();
+    m_box_convert = db::box_convert <db::CellInst, false> (*mp_layout);
+    m_cell_box_convert = db::box_convert <db::Cell, false> ();
 
   }
 
@@ -836,10 +836,10 @@ InstFinder::visit_cell (const db::Cell &cell, const db::Box &search_box, const d
           ++*mp_progress;
 
           db::Box ibox;
-          if (inst_cell.bbox ().empty ()) {
+          if (inst_cell.bbox_with_empty ().empty ()) {
             ibox = db::Box (db::Point (0, 0), db::Point (0, 0));
           } else if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
-            ibox = inst_cell.bbox ();
+            ibox = inst_cell.bbox_with_empty ();
           } else {
             for (std::vector<int>::const_iterator l = m_visible_layer_indexes.begin (); l != m_visible_layer_indexes.end (); ++l) {
               ibox += inst_cell.bbox (*l);
@@ -914,10 +914,10 @@ InstFinder::visit_cell (const db::Cell &cell, const db::Box &search_box, const d
           double d = std::numeric_limits<double>::max ();
 
           db::Box ibox;
-          if (inst_cell.bbox ().empty ()) {
+          if (inst_cell.bbox_with_empty ().empty ()) {
             ibox = db::Box (db::Point (0, 0), db::Point (0, 0));
           } else if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
-            ibox = inst_cell.bbox ();
+            ibox = inst_cell.bbox_with_empty ();
           } else {
             for (std::vector<int>::const_iterator l = m_visible_layer_indexes.begin (); l != m_visible_layer_indexes.end (); ++l) {
               ibox += inst_cell.bbox (*l);

--- a/src/laybasic/laybasic/layFinder.cc
+++ b/src/laybasic/laybasic/layFinder.cc
@@ -735,7 +735,7 @@ InstFinder::find (lay::LayoutViewBase *view, const db::DBox &region_mu)
   progress.set_format ("");
   mp_progress = &progress;
 
-  std::set< std::pair<db::DCplxTrans, int> > variants = view->cv_transform_variants ();
+  std::set< std::pair<db::DCplxTrans, int> > variants = view->cv_transform_variants_with_empty ();
   for (std::set< std::pair<db::DCplxTrans, int> >::const_iterator v = variants.begin (); v != variants.end (); ++v) {
     find (view, v->second, v->first, region_mu);
   }

--- a/src/laybasic/laybasic/layFinder.cc
+++ b/src/laybasic/laybasic/layFinder.cc
@@ -217,7 +217,8 @@ Finder::do_find (const db::Cell &cell, int level, const db::DCplxTrans &vp, cons
   } else if (level < m_max_level 
       && (t * m_cell_box_convert (cell)).touches (m_scan_region)
       && (mp_view->select_inside_pcells_mode () || !cell.is_proxy ()) 
-      && !mp_view->is_cell_hidden (cell.cell_index (), m_cv_index)) {
+      && !mp_view->is_cell_hidden (cell.cell_index (), m_cv_index)
+      && !cell.is_ghost_cell ()) {
 
     db::ICplxTrans it = t.inverted ();
     db::Box scan_box (it * m_scan_region);
@@ -828,7 +829,7 @@ InstFinder::visit_cell (const db::Cell &cell, const db::Box &search_box, const d
       //  just consider the instances exactly at the last level of 
       //  hierarchy (this is where the boxes are drawn) or of cells that
       //  are hidden.
-      if (level == max_level () - 1 || inst_cell.is_proxy () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
+      if (level == max_level () - 1 || inst_cell.is_proxy () || inst_cell.is_ghost_cell () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
 
         db::box_convert <db::CellInst, false> bc (layout ());
         for (db::CellInstArray::iterator p = cell_inst.begin_touching (search_box, bc); ! p.at_end (); ++p) {
@@ -838,7 +839,7 @@ InstFinder::visit_cell (const db::Cell &cell, const db::Box &search_box, const d
           db::Box ibox;
           if (inst_cell.bbox_with_empty ().empty ()) {
             ibox = db::Box (db::Point (0, 0), db::Point (0, 0));
-          } else if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
+          } else if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || inst_cell.is_ghost_cell () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
             ibox = inst_cell.bbox_with_empty ();
           } else {
             for (std::vector<int>::const_iterator l = m_visible_layer_indexes.begin (); l != m_visible_layer_indexes.end (); ++l) {
@@ -903,7 +904,7 @@ InstFinder::visit_cell (const db::Cell &cell, const db::Box &search_box, const d
       //  just consider the instances exactly at the last level of 
       //  hierarchy (this is where the boxes are drawn) or if of cells that
       //  are hidden.
-      if (level == max_level () - 1 || inst_cell.is_proxy () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
+      if (level == max_level () - 1 || inst_cell.is_proxy () || inst_cell.is_ghost_cell () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
 
         db::box_convert <db::CellInst, false> bc (layout ());
         for (db::CellInstArray::iterator p = cell_inst.begin_touching (search_box, bc); ! p.at_end (); ++p) {
@@ -916,7 +917,7 @@ InstFinder::visit_cell (const db::Cell &cell, const db::Box &search_box, const d
           db::Box ibox;
           if (inst_cell.bbox_with_empty ().empty ()) {
             ibox = db::Box (db::Point (0, 0), db::Point (0, 0));
-          } else if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
+          } else if (! m_visible_layers || level == mp_view->get_max_hier_levels () - 1 || inst_cell.is_ghost_cell () || mp_view->is_cell_hidden (inst_cell.cell_index (), m_cv_index)) {
             ibox = inst_cell.bbox_with_empty ();
           } else {
             for (std::vector<int>::const_iterator l = m_visible_layer_indexes.begin (); l != m_visible_layer_indexes.end (); ++l) {

--- a/src/laybasic/laybasic/layFinder.h
+++ b/src/laybasic/laybasic/layFinder.h
@@ -218,8 +218,8 @@ private:
   bool m_point_mode;
   bool m_catch_all;
   bool m_top_level_sel;
-  db::box_convert <db::CellInst> m_box_convert;
-  db::box_convert <db::Cell> m_cell_box_convert;
+  db::box_convert <db::CellInst, false> m_box_convert;
+  db::box_convert <db::Cell, false> m_cell_box_convert;
 };
 
 /**

--- a/src/laybasic/laybasic/layLayerProperties.cc
+++ b/src/laybasic/laybasic/layLayerProperties.cc
@@ -790,7 +790,29 @@ LayerPropertiesNode::set_parent (const LayerPropertiesNode *parent)
   mp_parent.reset (const_cast<LayerPropertiesNode *>(parent));
 }
 
-db::DBox 
+db::DBox
+LayerPropertiesNode::overall_bbox () const
+{
+  tl_assert (mp_view);
+  lay::CellView cv = mp_view->cellview (cellview_index ());
+
+  if (! cv.is_valid ()) {
+
+    return db::DBox ();
+
+  } else {
+
+    db::DBox b;
+    double dbu = cv->layout ().dbu ();
+    for (std::vector<db::DCplxTrans>::const_iterator t = trans ().begin (); t != trans ().end (); ++t) {
+      b += (*t * db::CplxTrans (dbu) * cv.context_trans ()) * cv.cell ()->bbox_with_empty ();
+    }
+    return b;
+
+  }
+}
+
+db::DBox
 LayerPropertiesNode::bbox () const
 {
   tl_assert (mp_view);
@@ -802,12 +824,7 @@ LayerPropertiesNode::bbox () const
 
   } else if (is_cell_box_layer ()) {
 
-    db::DBox b;
-    double dbu = cv->layout ().dbu ();
-    for (std::vector<db::DCplxTrans>::const_iterator t = trans ().begin (); t != trans ().end (); ++t) {
-      b += (*t * db::CplxTrans (dbu) * cv.context_trans ()) * cv.cell ()->bbox ();
-    }
-    return b;
+    return overall_bbox ();
 
   } else {
 

--- a/src/laybasic/laybasic/layLayerProperties.h
+++ b/src/laybasic/laybasic/layLayerProperties.h
@@ -1182,7 +1182,17 @@ public:
    *  @return A bbox in micron units
    */
   db::DBox bbox () const;
-  
+
+  /**
+   *  @brief Computes the overall box of this layer
+   *
+   *  This is not a layer specific box, but an all-layer box,
+   *  including transformations (if specified).
+   *  This box is equivalent to the box delivered by
+   *  a cell frame layer.
+   */
+  db::DBox overall_bbox () const;
+
   /**
    *  @brief Attach to a view
    *

--- a/src/laybasic/laybasic/layLayoutViewBase.cc
+++ b/src/laybasic/laybasic/layLayoutViewBase.cc
@@ -6078,7 +6078,9 @@ LayoutViewBase::cv_transform_variants_with_empty () const
   }
 
   for (auto i = cv_present.begin (); i != cv_present.end (); ++i) {
-    box_variants.insert (std::make_pair (db::DCplxTrans (), int (i - cv_present.begin ())));
+    if (!*i) {
+      box_variants.insert (std::make_pair (db::DCplxTrans (), int (i - cv_present.begin ())));
+    }
   }
 
   return box_variants;

--- a/src/laybasic/laybasic/layLayoutViewBase.cc
+++ b/src/laybasic/laybasic/layLayoutViewBase.cc
@@ -3865,7 +3865,7 @@ LayoutViewBase::full_box () const
   db::DBox bbox;
 
   for (LayerPropertiesConstIterator l = get_properties ().begin_const_recursive (); ! l.at_end (); ++l) {
-    bbox += l->bbox ();
+    bbox += l->overall_bbox ();
   }
 
   for (lay::AnnotationShapes::iterator a = annotation_shapes ().begin (); ! a.at_end (); ++a) {

--- a/src/laybasic/laybasic/layLayoutViewBase.cc
+++ b/src/laybasic/laybasic/layLayoutViewBase.cc
@@ -79,6 +79,9 @@ const double zoom_factor = 0.7;
 //  factor by which panning is faster in "fast" (+Shift) mode
 const double fast_factor = 3.0;
 
+//  size of cross
+const int mark_size = 9;
+
 // -------------------------------------------------------------
 
 struct OpHideShowCell 
@@ -4241,7 +4244,7 @@ LayoutViewBase::set_view_ops ()
   //  cell boxes
   if (m_cell_box_visible) {
 
-    lay::ViewOp vop;
+    lay::ViewOp vop, vopv;
 
     //  context level
     if (m_ctx_color.is_valid ()) {
@@ -4249,12 +4252,15 @@ LayoutViewBase::set_view_ops ()
     } else {
       vop = lay::ViewOp (lay::LayerProperties::brighter (box_color.rgb (), brightness_for_context), lay::ViewOp::Copy, 0, 0, 0);
     }
+    vopv = vop;
+    vopv.shape (lay::ViewOp::Cross);
+    vopv.width (mark_size);
 
     //  fill, frame, text, vertex
     view_ops.push_back (lay::ViewOp (0, lay::ViewOp::Or, 0, 0, 0));
     view_ops.push_back (vop);
     view_ops.push_back (vop);
-    view_ops.push_back (lay::ViewOp (0, lay::ViewOp::Or, 0, 0, 0));
+    view_ops.push_back (vopv);
 
     //  child level
     if (m_child_ctx_color.is_valid ()) {
@@ -4262,21 +4268,27 @@ LayoutViewBase::set_view_ops ()
     } else {
       vop = lay::ViewOp (lay::LayerProperties::brighter (box_color.rgb (), brightness_for_context), lay::ViewOp::Copy, 0, 0, 0);
     }
+    vopv = vop;
+    vopv.shape (lay::ViewOp::Cross);
+    vopv.width (mark_size);
 
     //  fill, frame, text, vertex
     view_ops.push_back (lay::ViewOp (0, lay::ViewOp::Or, 0, 0, 0));
     view_ops.push_back (vop);
     view_ops.push_back (vop);
-    view_ops.push_back (lay::ViewOp (0, lay::ViewOp::Or, 0, 0, 0));
+    view_ops.push_back (vopv);
 
     //  current level
     vop = lay::ViewOp (box_color.rgb (), lay::ViewOp::Copy, 0, 0, 0);
+    vopv = vop;
+    vopv.shape (lay::ViewOp::Cross);
+    vopv.width (mark_size);
 
     //  fill, frame, text, vertex
     view_ops.push_back (lay::ViewOp (0, lay::ViewOp::Or, 0, 0, 0));
     view_ops.push_back (vop);
     view_ops.push_back (vop);
-    view_ops.push_back (lay::ViewOp (0, lay::ViewOp::Or, 0, 0, 0));
+    view_ops.push_back (vopv);
 
   } else {
     //  invisible
@@ -4487,7 +4499,7 @@ LayoutViewBase::set_view_ops ()
           view_ops.push_back (lay::ViewOp (0, lay::ViewOp::Or, 0, 0, 0));
         }
         // vertex 
-        view_ops.push_back (lay::ViewOp (frame_color, mode, 0, 0, 0, lay::ViewOp::Cross, l->marked (true /*real*/) ? 9/*mark size*/ : 0)); // vertex
+        view_ops.push_back (lay::ViewOp (frame_color, mode, 0, 0, 0, lay::ViewOp::Cross, l->marked (true /*real*/) ? mark_size : 0)); // vertex
 
       } else {
         for (unsigned int i = 0; i < (unsigned int) planes_per_layer / 3; ++i) {

--- a/src/laybasic/laybasic/layLayoutViewBase.h
+++ b/src/laybasic/laybasic/layLayoutViewBase.h
@@ -1675,9 +1675,25 @@ public:
   std::set< std::pair<db::DCplxTrans, int> > cv_transform_variants () const;
   
   /**
+   *  @brief Get a list of cellview index and transform variants including empty cellviews
+   *
+   *  This version delivers a unit-transformation variant for cell views for which
+   *  no layer is present. This version is used for instance box drawing.
+   */
+  std::set< std::pair<db::DCplxTrans, int> > cv_transform_variants_with_empty () const;
+
+  /**
    *  @brief Get the global transform variants for a given cellview index
    */
   std::vector<db::DCplxTrans> cv_transform_variants (int cv_index) const;
+
+  /**
+   *  @brief Get the global transform variants for a given cellview index including empty cellviews
+   *
+   *  This version delivers a unit-transformation variant for cell views for which
+   *  no layer is present. This version is used for instance box drawing.
+   */
+  std::vector<db::DCplxTrans> cv_transform_variants_with_empty (int cv_index) const;
 
   /**
    *  @brief Get the global transform variants for a given cellview index and layer

--- a/src/laybasic/laybasic/layMarker.cc
+++ b/src/laybasic/laybasic/layMarker.cc
@@ -53,7 +53,7 @@ void render_cell_inst (const db::Layout &layout, const db::CellInstArray &inst, 
 
   const db::Cell &cell = layout.cell (inst.object ().cell_index ());
   std::string cell_name = layout.display_name (inst.object ().cell_index ());
-  db::Box cell_box = cell.bbox ();
+  db::Box cell_box = cell.bbox_with_empty ();
 
   db::Vector a, b;
   unsigned long amax = 0, bmax = 0;
@@ -589,7 +589,12 @@ InstanceMarker::set_max_shapes (size_t s)
 db::DBox
 InstanceMarker::item_bbox () const 
 {
-  return db::DBox (m_inst.bbox ());
+  const db::Layout *ly = layout ();
+  if (! ly) {
+    return db::DBox ();
+  }
+
+  return db::DBox (m_inst.bbox_with_empty ());
 }
 
 // ------------------------------------------------------------------------
@@ -1059,7 +1064,7 @@ Marker::item_bbox () const
   } else if (m_type == Instance) {
     const db::Layout *ly = layout ();
     if (ly) {
-      return db::DBox (m_object.inst->bbox (db::box_convert <db::CellInst> (*ly)));
+      return db::DBox (m_object.inst->bbox (db::box_convert <db::CellInst, false> (*ly)));
     }
   }
   return db::DBox ();

--- a/src/laybasic/laybasic/layRedrawThreadWorker.cc
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.cc
@@ -738,12 +738,6 @@ RedrawThreadWorker::draw_boxes (bool drawing_context, db::cell_index_type ci, co
   }
 }
 
-db::Box
-RedrawThreadWorker::empty_cell_replacement_box ()
-{
-  return db::Box (db::Point (), db::Point ());
-}
-
 void
 RedrawThreadWorker::draw_boxes (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const db::Box &redraw_box, int level)
 {
@@ -751,12 +745,8 @@ RedrawThreadWorker::draw_boxes (bool drawing_context, db::cell_index_type ci, co
   const db::Cell &cell = mp_layout->cell (ci);
 
   //  For small bboxes, the cell outline can be reduced ..
-  db::Box bbox = cell.bbox ();
-  bool empty_cell = false;
-  if (bbox.empty ()) {
-    bbox = empty_cell_replacement_box ();
-    empty_cell = true;
-  }
+  db::Box bbox = cell.bbox_with_empty ();
+  bool empty_cell = cell.bbox ().empty ();
 
   if (m_drop_small_cells && drop_cell (cell, trans)) {
 
@@ -811,12 +801,8 @@ RedrawThreadWorker::draw_boxes (bool drawing_context, db::cell_index_type ci, co
             const db::CellInstArray &cell_inst = inst->cell_inst ();
 
             db::cell_index_type new_ci = cell_inst.object ().cell_index ();
-            db::Box new_cell_box = mp_layout->cell (new_ci).bbox ();
-            bool empty_inst_cell = false;
-            if (new_cell_box.empty ()) {
-              new_cell_box = empty_cell_replacement_box ();
-              empty_inst_cell = true;
-            }
+            db::Box new_cell_box = mp_layout->cell (new_ci).bbox_with_empty ();
+            bool empty_inst_cell = mp_layout->cell (new_ci).bbox ().empty ();
 
             if (last_ci != new_ci) {
               //  Hint: don't use any_cell_box on partially visible cells because that will degrade performance

--- a/src/laybasic/laybasic/layRedrawThreadWorker.cc
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.cc
@@ -867,10 +867,10 @@ RedrawThreadWorker::draw_boxes (bool drawing_context, db::cell_index_type ci, co
                   if (empty_inst_cell) {
                     lay::CanvasPlane *vertices  = m_planes[3 + plane_group * (planes_per_layer / 3)];
                     r.draw (cell_inst.bbox (bc), trans, 0, 0, vertices, 0);
-                  } else {
-                    lay::CanvasPlane *contour  = m_planes[1 + plane_group * (planes_per_layer / 3)];
-                    r.draw (cell_inst.bbox (bc), trans, contour, 0, 0, 0);
                   }
+
+                  lay::CanvasPlane *contour  = m_planes[1 + plane_group * (planes_per_layer / 3)];
+                  r.draw (cell_inst.bbox (bc), trans, contour, contour, 0, 0);
 
                 }
 

--- a/src/laybasic/laybasic/layRedrawThreadWorker.cc
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.cc
@@ -2282,7 +2282,7 @@ RedrawThreadWorker::iterate_variants_rec (const std::vector <db::Box> &redraw_re
       db::Coord lim = std::numeric_limits<db::Coord>::max ();
       db::DBox world (trans * db::Box (db::Point (-lim, -lim), db::Point (lim, lim)));
       db::Box vp = db::Box (trans.inverted () * (world & db::DBox (*rr)));
-      vp &= mp_layout->cell (ci).bbox (); // this avoids problems when accessing designs through very large viewports
+      vp &= mp_layout->cell (ci).bbox_with_empty (); // this avoids problems when accessing designs through very large viewports
       if (! vp.empty ()) {
         actual_regions.push_back (vp);
       }

--- a/src/laybasic/laybasic/layRedrawThreadWorker.cc
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.cc
@@ -575,7 +575,7 @@ RedrawThreadWorker::setup (LayoutViewBase *view, RedrawThreadCanvas *canvas, con
 
   m_nlayers = mp_redraw_thread->num_layers (); 
 
-  m_box_variants = view->cv_transform_variants ();
+  m_box_variants = view->cv_transform_variants_with_empty ();
 }
 
 void

--- a/src/laybasic/laybasic/layRedrawThreadWorker.cc
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.cc
@@ -742,7 +742,6 @@ RedrawThreadWorker::draw_boxes (bool drawing_context, db::cell_index_type ci, co
 {
   lay::Renderer &r = *mp_renderer;
   const db::Cell &cell = mp_layout->cell (ci);
-  tl::warn << "@@@ level=" << level << " to_level=" << m_to_level << " " << mp_layout->display_name (ci);
 
   //  For small bboxes, the cell outline can be reduced ..
   db::Box bbox = cell.bbox_with_empty ();
@@ -813,7 +812,6 @@ RedrawThreadWorker::draw_boxes (bool drawing_context, db::cell_index_type ci, co
                 anything = true;
               }
             }
-            tl::warn << "@@@1 " << mp_layout->display_name (new_ci) << " anything=" << anything;
 
             if (anything) {
 

--- a/src/laybasic/laybasic/layRedrawThreadWorker.cc
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.cc
@@ -631,7 +631,7 @@ RedrawThreadWorker::draw_cell (bool drawing_context, int level, const db::CplxTr
   lay::CanvasPlane *vertices = m_planes[3 + plane_group * (planes_per_layer / 3)];
 
   if (empty_cell) {
-    r.draw (dbox, 0, 0, vertices, 0);
+    r.draw (dbox, 0, contour, vertices, 0);
   } else {
     r.draw (dbox, fill, contour, 0, 0);
   }

--- a/src/laybasic/laybasic/layRedrawThreadWorker.h
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.h
@@ -186,7 +186,7 @@ private:
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level);
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level, db::properties_id_type prop_id);
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const db::Box &redraw_box, int level, db::properties_id_type prop_id);
-  void draw_cell (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, const std::string &txt);
+  void draw_cell (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, bool empty_cell, const std::string &txt);
   void draw_cell_properties (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, db::properties_id_type prop_id);
   void draw_cell_shapes (const db::CplxTrans &trans, const db::Cell &cell, const db::Box &vp, lay::CanvasPlane *fill, lay::CanvasPlane *frame, lay::CanvasPlane *vertex, lay::CanvasPlane *text);
   void test_snapshot (const UpdateSnapshotCallback *update_snapshot);
@@ -199,6 +199,8 @@ private:
   bool any_shapes (db::cell_index_type cell_index, unsigned int levels);
   bool any_text_shapes (db::cell_index_type cell_index, unsigned int levels);
   bool any_cell_box (db::cell_index_type cell_index, unsigned int levels);
+  bool need_draw_box (const db::Layout *layout, const db::Cell &cell, int level);
+  db::Box empty_cell_replacement_box ();
 
   RedrawThread *mp_redraw_thread;
   std::vector <db::Box> m_redraw_region;
@@ -232,6 +234,7 @@ private:
   unsigned int m_cache_hits, m_cache_misses;
   std::set <std::pair <db::DCplxTrans, int> > m_box_variants;
   std::vector <std::set <lay::LayoutViewBase::cell_index_type> > m_hidden_cells;
+  std::vector <std::set <lay::LayoutViewBase::cell_index_type> > m_ghost_cells;
   std::vector <lay::CellView> m_cellviews;
   const db::Layout *mp_layout;
   int m_cv_index;

--- a/src/laybasic/laybasic/layRedrawThreadWorker.h
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.h
@@ -186,8 +186,8 @@ private:
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level);
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level, db::properties_id_type prop_id);
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const db::Box &redraw_box, int level, db::properties_id_type prop_id);
-  void draw_cell (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, bool empty_cell, const std::string &txt);
-  void draw_cell_properties (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, db::properties_id_type prop_id);
+  void draw_cell (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, bool empty_cell);
+  void draw_cell_properties (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, bool empty_cell, db::properties_id_type prop_id, const std::string &txt);
   void draw_cell_shapes (const db::CplxTrans &trans, const db::Cell &cell, const db::Box &vp, lay::CanvasPlane *fill, lay::CanvasPlane *frame, lay::CanvasPlane *vertex, lay::CanvasPlane *text);
   void test_snapshot (const UpdateSnapshotCallback *update_snapshot);
   void transfer ();

--- a/src/laybasic/laybasic/layRedrawThreadWorker.h
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.h
@@ -200,7 +200,6 @@ private:
   bool any_text_shapes (db::cell_index_type cell_index, unsigned int levels);
   bool any_cell_box (db::cell_index_type cell_index, unsigned int levels);
   bool need_draw_box (const db::Layout *layout, const db::Cell &cell, int level);
-  db::Box empty_cell_replacement_box ();
 
   RedrawThread *mp_redraw_thread;
   std::vector <db::Box> m_redraw_region;

--- a/src/laybasic/laybasic/layRedrawThreadWorker.h
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.h
@@ -186,8 +186,8 @@ private:
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level);
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level, db::properties_id_type prop_id);
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const db::Box &redraw_box, int level, db::properties_id_type prop_id);
-  void draw_cell (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, bool empty_cell);
-  void draw_cell_properties (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, bool empty_cell, db::properties_id_type prop_id, const std::string &txt);
+  void draw_cell (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, bool empty_cell, const std::string &txt);
+  void draw_cell_properties (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, db::properties_id_type prop_id);
   void draw_cell_shapes (const db::CplxTrans &trans, const db::Cell &cell, const db::Box &vp, lay::CanvasPlane *fill, lay::CanvasPlane *frame, lay::CanvasPlane *vertex, lay::CanvasPlane *text);
   void test_snapshot (const UpdateSnapshotCallback *update_snapshot);
   void transfer ();


### PR DESCRIPTION
Description of the solution:

* Empty cells are treated as cells with boxes (0,0;0,0)
* Ghost cells are treated as hidden cells

The effect is that ghost and empty cells are now visible and can be edited. As they are point-like, selecting them is most conveniently done by dragging a selection box. 

Empty cells are also considered for the bounding boxes in the drawing context, so the cell boxes include empty cells now as well and "zoom fit" will also take them into account as point-like, origin-centered cells.