### PR TITLE
Fixed issue #2174 - two new events

### DIFF
--- a/src/laybasic/laybasic/gsiDeclLayLayoutViewBase.cc
+++ b/src/laybasic/laybasic/gsiDeclLayLayoutViewBase.cc
@@ -1781,6 +1781,21 @@ LAYBASIC_PUBLIC Class<lay::LayoutViewBase> decl_LayoutViewBase (decl_Dispatcher,
     "\n"
     "This event was introduced in version 0.25.\n"
   ) +
+  gsi::event ("on_current_layer_changed", static_cast<tl::event<const lay::LayerPropertiesConstIterator &> (lay::LayoutViewBase::*)> (&lay::LayoutViewBase::current_layer_changed_event), gsi::arg ("new_layer"),
+    "@brief An event indicating the current layer has changed\n"
+    "@param new_layer The layer iterator of the new current layer\n"
+    "\n"
+    "This event is triggered after the current layer was changed - i.e. a new layer is selected in the layer list.\n"
+    "\n"
+    "This event was introduced in version 0.30.5.\n"
+  ) +
+  gsi::event ("on_selected_layers_changed", static_cast<tl::Event (lay::LayoutViewBase::*)> (&lay::LayoutViewBase::selected_layers_changed_event),
+    "@brief An event indicating the layer selection has changed\n"
+    "\n"
+    "This event is triggered after the layer selection was changed - i.e. layers got selected or unselected.\n"
+    "\n"
+    "This event was introduced in version 0.30.5.\n"
+  ) +
   gsi::event ("on_cell_visibility_changed", static_cast<tl::Event (lay::LayoutViewBase::*)> (&lay::LayoutViewBase::cell_visibility_changed_event),
     "@brief An event indicating that the visibility of one or more cells has changed\n"
     "\n"

--- a/src/laybasic/laybasic/layLayoutViewBase.cc
+++ b/src/laybasic/laybasic/layLayoutViewBase.cc
@@ -5643,7 +5643,13 @@ LayoutViewBase::current_layer_changed_slot (const lay::LayerPropertiesConstItera
   current_layer_changed_event (iter);
 }
 
-void 
+void
+LayoutViewBase::selected_layers_changed_slot ()
+{
+  selected_layers_changed_event ();
+}
+
+void
 LayoutViewBase::add_new_layers (const LayerState &state)
 {
   std::vector <lay::ParsedLayerSource> actual;

--- a/src/laybasic/laybasic/layLayoutViewBase.h
+++ b/src/laybasic/laybasic/layLayoutViewBase.h
@@ -786,9 +786,17 @@ public:
 
   /**
    *  @brief An event signalling that the current layer has changed
+   *
+   *  The event is emitted when the user changes the current layer.
    */
   tl::event<const lay::LayerPropertiesConstIterator &> current_layer_changed_event;
 
+  /**
+   *  @brief An event signalling that the selected layers have changed
+   *
+   *  The event is emitted when the user changes the selection.
+   */
+  tl::Event selected_layers_changed_event;
 
   /**
    *  @brief An event signalling that the visibility of some cells has changed
@@ -2793,6 +2801,11 @@ public:
    *  @brief Called when the current layer changed
    */
   void current_layer_changed_slot (const lay::LayerPropertiesConstIterator &iter);
+
+  /**
+   *  @brief Called when the layer selection changed
+   */
+  void selected_layers_changed_slot ();
 
   //  zoom slots
   void zoom_fit ();

--- a/src/layui/layui/layLayerControlPanel.cc
+++ b/src/layui/layui/layLayerControlPanel.cc
@@ -2165,6 +2165,7 @@ LayerControlPanel::selection_changed (const QItemSelection &, const QItemSelecti
   if (m_layer_visibility_follows_selection) {
     m_do_update_visibility_dm ();
   }
+  emit selected_layers_changed ();
 }
 
 void

--- a/src/layui/layui/layLayerControlPanel.h
+++ b/src/layui/layui/layLayerControlPanel.h
@@ -296,6 +296,7 @@ signals:
   void order_changed ();
   void tab_changed ();
   void current_layer_changed (const lay::LayerPropertiesConstIterator &iter);
+  void selected_layers_changed ();
 
 public slots:
   void cm_new_tab ();

--- a/src/layview/layview/layLayoutView_qt.cc
+++ b/src/layview/layview/layLayoutView_qt.cc
@@ -358,6 +358,11 @@ void LayoutViewSignalConnector::current_layer_changed_slot (const lay::LayerProp
   mp_view->current_layer_changed_slot (iter);
 }
 
+void LayoutViewSignalConnector::selected_layers_changed_slot ()
+{
+  mp_view->selected_layers_changed_slot ();
+}
+
 void LayoutViewSignalConnector::timer ()
 {
   mp_view->timer ();
@@ -603,6 +608,7 @@ LayoutView::init_ui (db::Manager *mgr)
       QObject::connect (mp_control_panel, SIGNAL (tab_changed ()), mp_connector, SLOT (layer_tab_changed ()));
       QObject::connect (mp_control_panel, SIGNAL (order_changed ()), mp_connector, SLOT (layer_order_changed ()));
       QObject::connect (mp_control_panel, SIGNAL (current_layer_changed (const lay::LayerPropertiesConstIterator &)), mp_connector, SLOT (current_layer_changed_slot (const lay::LayerPropertiesConstIterator &)));
+      QObject::connect (mp_control_panel, SIGNAL (selected_layers_changed ()), mp_connector, SLOT (selected_layers_changed_slot ()));
 
       mp_toolbox_frame = new QFrame (0);
       mp_toolbox_frame->setObjectName (QString::fromUtf8 ("lt_frame"));

--- a/src/layview/layview/layLayoutView_qt.h
+++ b/src/layview/layview/layLayoutView_qt.h
@@ -109,6 +109,7 @@ public slots:
   void active_library_changed (int index);
   void side_panel_destroyed ();
   void current_layer_changed_slot (const lay::LayerPropertiesConstIterator &iter);
+  void selected_layers_changed_slot ();
   void layer_tab_changed ();
   void layer_order_changed ();
   void select_cell_dispatch (const cell_path_type &path, int cellview_index);


### PR DESCRIPTION
1.) LayoutView#on_current_layer_changed(iter)
"iter" is the iterator pointing to the new current layer Is called after the current layer (the highlighted layer) changed.

2.) LayoutView#on_selected_layers_changed
Is called after the selected layer set changed.