### PR TITLE
Fixed issue #2201 (trace path)

### DIFF
--- a/src/edt/edt/edtService.cc
+++ b/src/edt/edt/edtService.cc
@@ -1327,6 +1327,13 @@ static std::string path_to_string (const db::Layout &layout, const lay::ObjectIn
 void 
 Service::display_status (bool transient)
 {
+  if (transient && view ()->canvas ()->begin_mouse_receivers () != view ()->canvas ()->end_mouse_receivers ()
+                && (*view ()->canvas ()->begin_mouse_receivers ())->claims_message_bar ()) {
+    //  do not display transient if there is a plugin active that has captured the mouse and claims the message bar -
+    //  this way we can use messages in active plugins and still get visual feedback by the transient selection.
+    return;
+  }
+
   EditableSelectionIterator r = transient ? begin_transient_selection () : begin_selection ();
   EditableSelectionIterator rr = r;
 

--- a/src/laybasic/laybasic/layFinder.h
+++ b/src/laybasic/laybasic/layFinder.h
@@ -97,6 +97,25 @@ public:
   }
 
   /**
+   *  @brief Gets a flag indicating that the viewport will be considered
+   */
+  bool consider_viewport () const
+  {
+    return m_consider_viewport;
+  }
+
+  /**
+   *  @brief Sets a flag indicating that the viewport will be considered
+   *  If this flag is true (the default), only shapes and instances will be considered
+   *  if edges (or polygons) or boundary edges (for instances) are visible in the
+   *  viewport. If this flag is false, shapes or instances are considered always.
+   */
+  void set_consider_viewport (bool f)
+  {
+    m_consider_viewport = f;
+  }
+
+  /**
    *  @brief Destructor (just provided to please the compiler)
    */
   virtual ~Finder ();
@@ -217,6 +236,7 @@ private:
   double m_distance;
   bool m_point_mode;
   bool m_catch_all;
+  bool m_consider_viewport;
   bool m_top_level_sel;
   db::box_convert <db::CellInst, false> m_box_convert;
   db::box_convert <db::Cell, false> m_cell_box_convert;

--- a/src/laybasic/laybasic/layViewObject.cc
+++ b/src/laybasic/laybasic/layViewObject.cc
@@ -621,7 +621,10 @@ END_PROTECTED
 void 
 ViewObjectUI::set_cursor (lay::Cursor::cursor_shape cursor)
 {
-  m_cursor = cursor;
+  if (m_cursor != cursor) {
+    m_cursor = cursor;
+    realize_cursor ();
+  }
 }
 
 void
@@ -629,15 +632,7 @@ ViewObjectUI::set_default_cursor (lay::Cursor::cursor_shape cursor)
 {
   if (cursor != m_default_cursor) {
     m_default_cursor = cursor;
-#if defined(HAVE_QT)
-    if (m_cursor == lay::Cursor::none && mp_widget) {
-      if (m_default_cursor == lay::Cursor::none) {
-        mp_widget->unsetCursor ();
-      } else {
-        mp_widget->setCursor (lay::Cursor::qcursor (m_default_cursor));
-      }
-    }
-#endif
+    realize_cursor ();
   }
 }
 
@@ -652,11 +647,17 @@ ViewObjectUI::ensure_entered ()
 void 
 ViewObjectUI::begin_mouse_event (lay::Cursor::cursor_shape cursor)
 {
-  m_cursor = cursor;
+  set_cursor (cursor);
 }
 
 void 
 ViewObjectUI::end_mouse_event ()
+{
+  realize_cursor ();
+}
+
+void
+ViewObjectUI::realize_cursor ()
 {
 #if defined(HAVE_QT)
   if (mp_widget) {

--- a/src/laybasic/laybasic/layViewObject.h
+++ b/src/laybasic/laybasic/layViewObject.h
@@ -286,6 +286,14 @@ public:
   virtual void drag_cancel () { }
 
   /**
+   *  @brief Gets a value indicating whether the mouse receiver claims the view message bar
+   *
+   *  If this method returns true, other services are not supposed to emit transient
+   *  messages.
+   */
+  virtual bool claims_message_bar () const { return false; }
+
+  /**
    *  @brief Gets a value indicating whether a cursor position it set
    */
   virtual bool has_tracking_position () const { return false; }
@@ -1121,6 +1129,7 @@ private:
   void objects_changed ();
   int widget_height () const;
   int widget_width () const;
+  void realize_cursor ();
 
   /**
    *  @brief Register a service

--- a/src/plugins/tools/net_tracer/lay_plugin/layNetTracerDialog.h
+++ b/src/plugins/tools/net_tracer/lay_plugin/layNetTracerDialog.h
@@ -60,6 +60,8 @@ public:
   NetTracerDialog (lay::Dispatcher *root, lay::LayoutViewBase *view);
   virtual ~NetTracerDialog ();
 
+  virtual void drag_cancel ();
+  virtual bool claims_message_bar () const;
   virtual bool mouse_move_event (const db::DPoint &p, unsigned int buttons, bool prio);
   virtual bool mouse_click_event (const db::DPoint &p, unsigned int buttons, bool prio);
   virtual void menu_activated (const std::string &symbol);


### PR DESCRIPTION
* you can zoom in now to select the end point. Problem was actually that zooming in was a problem when the start point went out of the viewport

In addition:
* Messages are sticky now ("Click on second point")
* "Esc" will cancel path trace mode
* The cursor switches back to normal after tracing