### PR TITLE
Issue #2219 (drawing of empty cells)

### DIFF
--- a/src/laybasic/laybasic/layLayoutViewBase.cc
+++ b/src/laybasic/laybasic/layLayoutViewBase.cc
@@ -342,6 +342,7 @@ LayoutViewBase::init (db::Manager *mgr)
   m_box_text_transform = true;
   m_box_font = 0;
   m_min_size_for_label = 16;
+  m_empty_cell_dimension = 4.0;
   m_cell_box_visible = true;
   m_ghost_cells_visible = true;
   m_text_visible = true;
@@ -942,6 +943,13 @@ LayoutViewBase::configure (const std::string &name, const std::string &value)
     int n;
     tl::from_string (value, n);
     min_inst_label_size (n);
+    return true;
+
+  } else if (name == cfg_empty_cell_dimension) {
+
+    double n;
+    tl::from_string (value, n);
+    empty_cell_dimension (n);
     return true;
 
   } else if (name == cfg_cell_box_text_font) {
@@ -5403,7 +5411,16 @@ LayoutViewBase::min_inst_label_size (int px)
   }
 }
 
-void 
+void
+LayoutViewBase::empty_cell_dimension (double um)
+{
+  if (m_empty_cell_dimension != um) {
+    m_empty_cell_dimension = um;
+    redraw ();
+  }
+}
+
+void
 LayoutViewBase::text_visible (bool vis)
 {
   if (m_text_visible != vis) {

--- a/src/laybasic/laybasic/layLayoutViewBase.h
+++ b/src/laybasic/laybasic/layLayoutViewBase.h
@@ -1149,7 +1149,20 @@ public:
     return m_min_size_for_label;
   }
 
-  /** 
+  /**
+   *  @brief Empty cell dimension for the purpose of label generation setter
+   */
+  void empty_cell_dimension (double um);
+
+  /**
+   *  @brief Empty cell dimension for the purpose of label generation getter
+   */
+  int empty_cell_dimension () const
+  {
+    return m_empty_cell_dimension;
+  }
+
+  /**
    *  @brief Visibility of text objects
    */
   void text_visible (bool vis);
@@ -2941,6 +2954,7 @@ private:
   bool m_box_text_transform;
   unsigned int m_box_font;
   int m_min_size_for_label;
+  double m_empty_cell_dimension;
   bool m_cell_box_visible;
   bool m_ghost_cells_visible;
 

--- a/src/laybasic/laybasic/layLayoutViewConfig.cc
+++ b/src/laybasic/laybasic/layLayoutViewConfig.cc
@@ -55,6 +55,7 @@ public:
     options.push_back (std::pair<std::string, std::string> (cfg_current_lib_view, ""));
     options.push_back (std::pair<std::string, std::string> (cfg_hide_empty_layers, "false"));
     options.push_back (std::pair<std::string, std::string> (cfg_min_inst_label_size, "16"));
+    options.push_back (std::pair<std::string, std::string> (cfg_empty_cell_dimension, "4"));
     options.push_back (std::pair<std::string, std::string> (cfg_cell_box_text_font, "0"));
     options.push_back (std::pair<std::string, std::string> (cfg_cell_box_text_transform, "true"));
     options.push_back (std::pair<std::string, std::string> (cfg_cell_box_color, "auto"));

--- a/src/laybasic/laybasic/layRedrawThreadWorker.h
+++ b/src/laybasic/laybasic/layRedrawThreadWorker.h
@@ -185,13 +185,13 @@ private:
   void draw_boxes_for_ghosts (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level);
   void draw_boxes (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level);
   void draw_boxes_impl (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level, bool for_ghosts);
-  void draw_boxes_impl (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const db::Box &redraw_region, int level, bool for_ghosts);
+  void draw_boxes_impl (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const db::Box &redraw_region, int level, bool for_ghosts, Bitmap *opt_bitmap);
   void draw_box_properties_for_ghosts (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level);
   void draw_box_properties (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level);
   void draw_box_properties_impl (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level, bool for_ghosts);
   void draw_box_properties_impl (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const std::vector <db::Box> &redraw_regions, int level, db::properties_id_type prop_id, bool for_ghosts);
   void draw_box_properties_impl (bool drawing_context, db::cell_index_type ci, const db::CplxTrans &trans, const db::Box &redraw_box, int level, db::properties_id_type prop_id, bool for_ghosts);
-  void draw_cell (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, bool empty_cell, const std::string &txt);
+  void draw_cell (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, const db::Box &box_for_label, bool empty_cell, const std::string &txt, Bitmap *opt_bitmap);
   void draw_cell_properties (bool drawing_context, int level, const db::CplxTrans &trans, const db::Box &box, db::properties_id_type prop_id);
   void draw_cell_shapes (const db::CplxTrans &trans, const db::Cell &cell, const db::Box &vp, lay::CanvasPlane *fill, lay::CanvasPlane *frame, lay::CanvasPlane *vertex, lay::CanvasPlane *text);
   void test_snapshot (const UpdateSnapshotCallback *update_snapshot);
@@ -216,6 +216,7 @@ private:
   int m_from_level, m_to_level;
   int m_from_level_default, m_to_level_default;
   int m_min_size_for_label;
+  double m_empty_cell_dimension;
   bool m_box_text_transform;
   unsigned int m_box_font;
   unsigned int m_text_font;

--- a/src/laybasic/laybasic/laybasicConfig.h
+++ b/src/laybasic/laybasic/laybasicConfig.h
@@ -91,6 +91,7 @@ static const std::string cfg_crosshair_cursor_enabled ("crosshair-cursor-enabled
 static const std::string cfg_markers_visible ("markers-visible");
 
 static const std::string cfg_min_inst_label_size ("min-inst-label-size");
+static const std::string cfg_empty_cell_dimension ("empty-cell-dimension");
 static const std::string cfg_cell_box_text_font ("inst-label-font");
 static const std::string cfg_cell_box_text_transform ("inst-label-transform");
 static const std::string cfg_cell_box_color ("inst-color");

--- a/src/layui/layui/LayoutViewConfigPage2a.ui
+++ b/src/layui/layui/LayoutViewConfigPage2a.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>656</width>
-    <height>397</height>
+    <height>451</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,85 +49,14 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout">
-      <property name="margin" stdset="0">
-       <number>9</number>
-      </property>
       <property name="spacing">
        <number>6</number>
       </property>
-      <item row="1" column="1">
-       <widget class="QFrame" name="frame_3">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
+      <item row="2" column="0">
+       <widget class="QLabel" name="textLabel1_3">
+        <property name="text">
+         <string>Label font</string>
         </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QHBoxLayout">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="margin" stdset="0">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QComboBox" name="cell_font_cb"/>
-         </item>
-         <item>
-          <spacer>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>141</width>
-             <height>21</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QFrame" name="frame_2">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QHBoxLayout">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="margin" stdset="0">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="lay::ColorButton" name="cell_box_color_pb">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
        </widget>
       </item>
       <item row="0" column="1">
@@ -190,6 +119,20 @@
         </layout>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="textLabel3">
+        <property name="text">
+         <string>Cell box color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="cell_xform_text_cbx">
+        <property name="text">
+         <string>Transform text with cell instance (not available for &quot;Default&quot; font)</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="textLabel1_2_2">
         <property name="text">
@@ -197,21 +140,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="textLabel1_3">
-        <property name="text">
-         <string>Label font</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="textLabel3">
-        <property name="text">
-         <string>Cell box color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <spacer>
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -227,10 +156,139 @@
         </property>
        </spacer>
       </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="cell_xform_text_cbx">
+      <item row="3" column="1">
+       <widget class="QFrame" name="frame_2">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="margin" stdset="0">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="lay::ColorButton" name="cell_box_color_pb">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QFrame" name="frame_3">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="margin" stdset="0">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QComboBox" name="cell_font_cb"/>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>141</width>
+             <height>21</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QFrame" name="frame_4">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="empty_cell_dimension">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>µm (for label scaling)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>159</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Transform text with cell instance (not available for &quot;Default&quot; font)</string>
+         <string>Empty cell virtual size</string>
         </property>
        </widget>
       </item>

--- a/src/layui/layui/layLayoutViewConfigPages.cc
+++ b/src/layui/layui/layLayoutViewConfigPages.cc
@@ -227,6 +227,10 @@ LayoutViewConfigPage2a::setup (lay::Dispatcher *root)
   root->config_get (cfg_min_inst_label_size, n);
   mp_ui->cell_min_size_for_label_edit->setText (tl::to_qstring (tl::to_string (n)));
 
+  double ecd = 0;
+  root->config_get (cfg_empty_cell_dimension, ecd);
+  mp_ui->empty_cell_dimension->setText (tl::to_qstring (tl::to_string (ecd)));
+
   bool gs_visible = true;
   root->config_get (cfg_guiding_shape_visible, gs_visible);
   mp_ui->pcell_gs_group->setChecked (gs_visible);
@@ -262,6 +266,12 @@ LayoutViewConfigPage2a::commit (lay::Dispatcher *root)
     int n;
     tl::from_string_ext (tl::to_string (mp_ui->cell_min_size_for_label_edit->text ()), n);
     root->config_set (cfg_min_inst_label_size, n);
+  } catch (...) { }
+
+  try {
+    double ecd;
+    tl::from_string_ext (tl::to_string (mp_ui->empty_cell_dimension->text ()), ecd);
+    root->config_set (cfg_empty_cell_dimension, ecd);
   } catch (...) { }
 }
 


### PR DESCRIPTION
1. Optimiziation - not more than one empty cell per pixel This is not very efficient on the available test cases.
2. Introducing a virtual dimension for the empty cells for the purpose of label scaling. With this, the labels are scaled (if a scalable font is selected) and not drawn when becoming very small. The parameter is found in the setup pages under Display/Cells.