### PR TITLE
COPYRIGHT: Update license notice to that of GPL-3-or-later.

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -7,18 +7,19 @@ Authors:
 Copyright:
 	Copyright (C) 2006-2025 by Matthias Köfferlein.
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 or 3 of the License.
+    This program is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this package; if not, write to the Free Software Foundation,
-    Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+    along with this program. If not, see
+    <https://www.gnu.org/licenses/>.
 
   On Debian GNU/Linux systems, the complete text of the GNU General
   Public License can be found in `/usr/share/common-licenses/GPL'.


### PR DESCRIPTION
Based on the template for license notices documented at https://www.gnu.org/licenses/gpl-howto.html.

Fixes: #2233