### PR TITLE
Avoid crashing when clicking reload

### DIFF
--- a/src/lay/lay/layMacroEditorPage.cc
+++ b/src/lay/lay/layMacroEditorPage.cc
@@ -124,10 +124,14 @@ MacroEditorNotificationWidget::MacroEditorNotificationWidget (MacroEditorPage *p
 void
 MacroEditorNotificationWidget::action_triggered ()
 {
+  BEGIN_PROTECTED
+
   auto a = m_action_buttons.find (sender ());
   if (a != m_action_buttons.end ()) {
     mp_parent->notification_action (*mp_notification, a->second);
   }
+
+  END_PROTECTED_W (this)
 }
 
 void

--- a/src/layview/layview/layLayoutView_qt.cc
+++ b/src/layview/layview/layLayoutView_qt.cc
@@ -139,10 +139,14 @@ LayoutViewNotificationWidget::LayoutViewNotificationWidget (LayoutViewWidget *pa
 void
 LayoutViewNotificationWidget::action_triggered ()
 {
+  BEGIN_PROTECTED
+
   auto a = m_action_buttons.find (sender ());
   if (a != m_action_buttons.end ()) {
     mp_parent->notification_action (*mp_notification, a->second);
   }
+
+  END_PROTECTED_W (this)
 }
 
 void


### PR DESCRIPTION
For context, this was happening to me on macOS with files being written to a temporary directory and no longer existing there. I would attempt to reload with the notification and KLayout would crash instead of giving an error message.