### PR TITLE
Don't build wheels for end of life python 3.9 and 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ test-command = [
   "TESTSRC={package} python {package}/testdata/pymod/pya_tests.py"
 ]
 # Disable building PyPy wheels on all platforms
-skip = "pp* cp36-* cp37-*"
+skip = "pp* cp36-* cp37-* cp38-* cp39-*"
 
 [tool.cibuildwheel.linux]
 # beware: the before-all script does not persist environment variables!


### PR DESCRIPTION
this will help with https://github.com/KLayout/klayout/issues/2296

