### PR TITLE
Use `std::execution::par` in `dbEdgeProcessor` and `dbPolygonTools` sorts

### DIFF
--- a/src/db/db/db.pro
+++ b/src/db/db/db.pro
@@ -454,3 +454,7 @@ INCLUDEPATH += $$TL_INC $$GSI_INC
 DEPENDPATH += $$TL_INC $$GSI_INC
 LIBS += -L$$DESTDIR -lklayout_tl -lklayout_gsi
 
+packagesExist(tbb) {
+    LIBS += -ltbb
+}
+

--- a/src/db/db/dbEdgeProcessor.cc
+++ b/src/db/db/dbEdgeProcessor.cc
@@ -29,6 +29,13 @@
 #include "tlProgress.h"
 #include "gsi.h"
 
+#if defined(__cpp_lib_execution)
+#include <execution>
+#define PARALLEL_EXEC_POLICY std::execution::par,
+#else
+#define PARALLEL_EXEC_POLICY
+#endif
+
 #include <vector>
 #include <deque>
 #include <memory>
@@ -2237,7 +2244,7 @@ EdgeProcessor::redo_or_process (const std::vector<std::pair<db::EdgeSink *, db::
   } else {
 
     //  step 2: find intersections
-    std::sort (mp_work_edges->begin (), mp_work_edges->end (), edge_ymin_compare<db::Coord> ());
+    std::sort (PARALLEL_EXEC_POLICY mp_work_edges->begin (), mp_work_edges->end (), edge_ymin_compare<db::Coord> ());
 
     y = edge_ymin ((*mp_work_edges) [0]);
     future = mp_work_edges->begin ();
@@ -2422,7 +2429,7 @@ EdgeProcessor::redo_or_process (const std::vector<std::pair<db::EdgeSink *, db::
   gs.reset ();
   gs.reserve (n_props);
 
-  std::sort (mp_work_edges->begin (), mp_work_edges->end (), edge_ymin_compare<db::Coord> ());
+  std::sort (PARALLEL_EXEC_POLICY mp_work_edges->begin (), mp_work_edges->end (), edge_ymin_compare<db::Coord> ());
 
   y = edge_ymin ((*mp_work_edges) [0]);
 

--- a/src/db/db/dbEdgeProcessor.cc
+++ b/src/db/db/dbEdgeProcessor.cc
@@ -1,3 +1,14 @@
+#if __cplusplus >= 201703L
+  #if __has_include(<execution>)
+    #include <execution>
+  #endif
+#endif
+
+#if defined(__cpp_lib_execution)
+#define PARALLEL_EXEC_POLICY std::execution::par,
+#else
+#define PARALLEL_EXEC_POLICY
+#endif
 
 /*
 
@@ -29,12 +40,6 @@
 #include "tlProgress.h"
 #include "gsi.h"
 
-#if defined(__cpp_lib_execution)
-#include <execution>
-#define PARALLEL_EXEC_POLICY std::execution::par,
-#else
-#define PARALLEL_EXEC_POLICY
-#endif
 
 #include <vector>
 #include <deque>

--- a/src/db/db/dbPolygonTools.cc
+++ b/src/db/db/dbPolygonTools.cc
@@ -1,3 +1,14 @@
+#if __cplusplus >= 201703L
+  #if __has_include(<execution>)
+    #include <execution>
+  #endif
+#endif
+
+#if defined(__cpp_lib_execution)
+#define PARALLEL_EXEC_POLICY std::execution::par,
+#else
+#define PARALLEL_EXEC_POLICY
+#endif
 
 /*
 
@@ -28,12 +39,6 @@
 #include "tlLog.h"
 #include "tlInt128Support.h"
 
-#if defined(__cpp_lib_execution)
-#include <execution>
-#define PARALLEL_EXEC_POLICY std::execution::par,
-#else
-#define PARALLEL_EXEC_POLICY
-#endif
 
 #include <algorithm>
 #include <cmath>

--- a/src/db/db/dbPolygonTools.cc
+++ b/src/db/db/dbPolygonTools.cc
@@ -28,6 +28,13 @@
 #include "tlLog.h"
 #include "tlInt128Support.h"
 
+#if defined(__cpp_lib_execution)
+#include <execution>
+#define PARALLEL_EXEC_POLICY std::execution::par,
+#else
+#define PARALLEL_EXEC_POLICY
+#endif
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -1838,7 +1845,7 @@ rasterize_impl (const db::polygon<C> &polygon, db::area_map<C> &am)
   }
 
   //  sort edges
-  std::sort (edges.begin (), edges.end (), db::edge_ymin_compare<C> ());
+  std::sort (PARALLEL_EXEC_POLICY edges.begin (), edges.end (), db::edge_ymin_compare<C> ());
 
   typename std::vector <edge_type>::iterator c = edges.begin ();
 
@@ -2761,7 +2768,7 @@ decompose_convex_to_trapezoids (const db::SimplePolygon &sp, bool horizontal, db
     }
   }
 
-  std::sort (edges.begin (), edges.end (), db::edge_ymin_compare<db::Coord> ());
+  std::sort (PARALLEL_EXEC_POLICY edges.begin (), edges.end (), db::edge_ymin_compare<db::Coord> ());
 
   db::Coord y = db::edge_ymin (edges.front ());
 


### PR DESCRIPTION
Closes #1119

This PR introduces C++17 parallel sorting (`std::execution::par`) to the core database sorting operations within `dbEdgeProcessor.cc` and `dbPolygonTools.cc`. 

Flat operations (boolean and sizing) on extremely dense shape regions require heavy sorting of large edge arrays (e.g., sorting by `ymin` before scanline sweeps). Moving these from sequential `std::sort` to C++17 parallel sorting (backed by Intel TBB on GCC/Linux) should yield some performance boost for flat layout manipulation.

## Benchmark Results

This PR introduces parallel sorting using C++17 execution policies in `dbEdgeProcessor.cc` and `dbPolygonTools.cc`.

To verify the performance improvements, I created a test script that generates a large grid of $`1000 \times 1000`$ intersecting polygons and measures the execution time of boolean operations (`AND`) which relies heavily on edge processing and polygon tools.

### Benchmark Setup

* **Compiler / Environment:** GCC 14.2 with C++17, linked with Intel TBB
* **Test Command:** `taskset -c <cores> env LD_LIBRARY_PATH=./bin-release ./bin-release/klayout -b -r test_bool.rb`
* **Benchmarking Tool:** [`hyperfine`](https://github.com/sharkdp/hyperfine) (min 3 runs per thread count)
* **Thread Counts Swept:** 1, 2, 4, 6, 8

*Note: `taskset` was used to precisely limit the CPU cores available to TBB.*

### Results

The table below shows the execution times across different thread counts:

| Threads | Mean Time (s) | Std Dev (s) |
|--------:|--------------:|------------:|
|       1 |      10.62 |      0.08 |
|       2 |      10.28 |      0.02 |
|       4 |      10.02 |      0.09 |
|       6 |       9.96 |      0.05 |
|       8 |       9.95 |      0.05 |

<img width="800" height="500" alt="benchmark_plot" src="https://github.com/user-attachments/assets/05a0fe2e-3fb7-41ae-a57c-e3ca43b8b071" />


While the speedup scales incrementally with the thread count, the gains are modest (~7% speedup from 1 to 8 threads). The parallel sorting via TBB accelerates the sorting step itself but other sequential parts of the boolean operations still dominate the overall execution time. 

### Reproduction

The results were gathered using the following Python script with, which handles the `hyperfine` execution and plots the results.

<details>
<summary><b>Benchmark Script (`benchmark.py`)</b></summary>


```python
# /// script
# requires-python = ">=3.11"
# dependencies = [
#     "matplotlib",
#     "pandas",
#     "tabulate"
# ]
# ///
import json
import matplotlib.pyplot as plt
import pandas as pd
import sys
import subprocess

def run_benchmarks():
    commands = []
    threads = [1, 2, 4, 6, 8]
    for t in threads:
        # Limit to `t` cores using taskset
        cmd = f"taskset -c 0-{t-1} env LD_LIBRARY_PATH=./bin-release ./bin-release/klayout -b -r test_bool.rb"
        commands.append((t, cmd))
        
    hyperfine_cmd = ["hyperfine", "--export-json", "results.json", "--min-runs", "3"]
    for t, cmd in commands:
        hyperfine_cmd.extend(["-n", f"{t} Threads", cmd])
        
    print("Running hyperfine...")
    subprocess.run(hyperfine_cmd, check=True)
    
    with open("results.json") as f:
        data = json.load(f)
        
    results = []
    for i, t in enumerate(threads):
        res = data["results"][i]
        results.append({
            "Threads": t,
            "Mean Time (s)": res["mean"],
            "Std Dev (s)": res["stddev"]
        })
        
    df = pd.DataFrame(results)
    print(df.to_markdown(index=False))
    
    plt.figure(figsize=(8, 5))
    plt.errorbar(df["Threads"], df["Mean Time (s)"], yerr=df["Std Dev (s)"], marker='o', capsize=5)
    plt.xlabel("Number of Threads")
    plt.ylabel("Mean Execution Time (s)")
    plt.title("Parallel Edge Processor Benchmark")
    plt.grid(True)
    plt.xticks(threads)
    plt.savefig("benchmark_plot.png")
    print("Plot saved as benchmark_plot.png")

if __name__ == "__main__":
    run_benchmarks()
```
</details>

<details>
<summary><b>Test Case (`test_bool.rb`)</b></summary>

```ruby
ly = RBA::Layout::new
ly.dbu = 0.001
top = ly.add_cell("TOP")

l1 = ly.layer(1, 0)
l2 = ly.layer(2, 0)

n = 1000
puts "Generating data..."
n.times do |x|
  n.times do |y|
    ly.cell(top).shapes(l1).insert(RBA::Box::new(x*10, y*10, x*10+8, y*10+8))
    ly.cell(top).shapes(l2).insert(RBA::Box::new(x*10+4, y*10+4, x*10+12, y*10+12))
  end
end

puts "Running boolean..."
ep = RBA::EdgeProcessor::new
reg1 = RBA::Region::new(ly.cell(top).shapes(l1))
reg2 = RBA::Region::new(ly.cell(top).shapes(l2))

r = reg1 & reg2
puts "Result has #{r.size} polygons"
```
</details>

You can run it with `uv run benchmark.py` to  install dependencies and execute the benchmark in a folder with `./bin-release` containing a KLayout build.

### Compilation Notes
* To properly enable Intel TBB parallel execution via `<execution>`, the compilation needs to specify at least `-std=c++17`.
* I also had to add `LIBS += -ltbb` to link the Intel Threading Building Blocks library correctly. Not sure what would be a nice general solution for allowing other libraries to implement the execution policy from the standard library.