### PR TITLE
Leverage execution policies for LVS equivalence

### DIFF
--- a/src/db/db/db.pro
+++ b/src/db/db/db.pro
@@ -454,3 +454,7 @@ INCLUDEPATH += $$TL_INC $$GSI_INC
 DEPENDPATH += $$TL_INC $$GSI_INC
 LIBS += -L$$DESTDIR -lklayout_tl -lklayout_gsi
 
+packagesExist(tbb) {
+    LIBS += -ltbb
+}
+

--- a/src/db/db/dbNetlistCompare.cc
+++ b/src/db/db/dbNetlistCompare.cc
@@ -1,4 +1,18 @@
 
+//  NOTE: <execution> must be included before any Qt header, otherwise TBB's
+//  emit() method collides with Qt's "emit" keyword macro.
+#if __cplusplus >= 201703L
+  #if __has_include(<execution>)
+    #include <execution>
+  #endif
+#endif
+
+#if defined(__cpp_lib_execution)
+#define PARALLEL_EXEC_POLICY std::execution::par,
+#else
+#define PARALLEL_EXEC_POLICY
+#endif
+
 /*
 
   KLayout Layout Viewer
@@ -33,6 +47,7 @@
 #include "tlInternational.h"
 
 #include <cstring>
+#include <algorithm>
 
 namespace db
 {
@@ -507,7 +522,7 @@ static std::vector<std::string> unverified_names (const db::Circuit *c, const st
     }
   }
 
-  std::sort (names.begin (), names.end ());
+  std::sort (PARALLEL_EXEC_POLICY names.begin (), names.end ());
   return names;
 }
 
@@ -563,7 +578,7 @@ compute_device_key_for_this (const db::Device &device, const db::NetGraph &g, bo
     }
   }
 
-  std::sort (k.begin (), k.end ());
+  std::sort (PARALLEL_EXEC_POLICY k.begin (), k.end ());
   return k;
 }
 
@@ -582,7 +597,7 @@ compute_device_key_for_other (const db::Device &device, const db::NetGraph &g, b
     }
   }
 
-  std::sort (k.begin (), k.end ());
+  std::sort (PARALLEL_EXEC_POLICY k.begin (), k.end ());
   return k;
 }
 
@@ -636,7 +651,7 @@ compute_subcircuit_key_for_this (const db::SubCircuit &subcircuit, const db::Net
     }
   }
 
-  std::sort (k.begin (), k.end ());
+  std::sort (PARALLEL_EXEC_POLICY k.begin (), k.end ());
   return k;
 }
 
@@ -658,7 +673,7 @@ compute_subcircuit_key_for_other (const db::SubCircuit &subcircuit, const db::Ne
     }
   }
 
-  std::sort (k.begin (), k.end ());
+  std::sort (PARALLEL_EXEC_POLICY k.begin (), k.end ());
   return k;
 }
 
@@ -1122,8 +1137,8 @@ NetlistComparer::compare_circuits (const db::Circuit *c1, const db::Circuit *c2,
         break;
       }
 
-      std::sort (nodes.begin (), nodes.end (), CompareNodeEdgePair ());
-      std::sort (other_nodes.begin (), other_nodes.end (), CompareNodeEdgePair ());
+      std::sort (PARALLEL_EXEC_POLICY nodes.begin (), nodes.end (), CompareNodeEdgePair ());
+      std::sort (PARALLEL_EXEC_POLICY other_nodes.begin (), other_nodes.end (), CompareNodeEdgePair ());
 
       size_t ni = compare.derive_node_identities_from_node_set (nodes, other_nodes);
       if (ni > 0 && ni != failed_match) {
@@ -1624,8 +1639,8 @@ NetlistComparer::do_device_assignment (const db::Circuit *c1, const db::NetGraph
 
       DeviceParametersCompare cmp;
 
-      std::sort (unmatched_a.begin (), unmatched_a.end (), cmp);
-      std::sort (unmatched_b.begin (), unmatched_b.end (), cmp);
+      std::sort (PARALLEL_EXEC_POLICY unmatched_a.begin (), unmatched_a.end (), cmp);
+      std::sort (PARALLEL_EXEC_POLICY unmatched_b.begin (), unmatched_b.end (), cmp);
 
       for (unmatched_list::iterator i = unmatched_a.begin (), j = unmatched_b.begin (); i != unmatched_a.end () || j != unmatched_b.end (); ) {
 
@@ -1846,8 +1861,8 @@ NetlistComparer::do_subcircuit_assignment (const db::Circuit *c1, const db::NetG
 
     } else {
 
-      std::sort (unmatched_a.begin (), unmatched_a.end (), KeySize ());
-      std::sort (unmatched_b.begin (), unmatched_b.end (), KeySize ());
+      std::sort (PARALLEL_EXEC_POLICY unmatched_a.begin (), unmatched_a.end (), KeySize ());
+      std::sort (PARALLEL_EXEC_POLICY unmatched_b.begin (), unmatched_b.end (), KeySize ());
 
       for (unmatched_list::iterator i = unmatched_a.begin (), j = unmatched_b.begin (); i != unmatched_a.end () || j != unmatched_b.end (); ) {
 
@@ -1952,7 +1967,7 @@ static bool derive_symmetry_groups (const db::NetGraph &graph, const tl::equival
 
       //  all other edges need to have identical destinations for the symmetry group to be
       //  actually symmetric
-      std::sort (common_nodes.begin (), common_nodes.end ());
+      std::sort (PARALLEL_EXEC_POLICY common_nodes.begin (), common_nodes.end ());
       if (g == symmetry_group.begin ()) {
         common_nodes_first.swap (common_nodes);
       } else if (common_nodes_first != common_nodes) {
@@ -2020,7 +2035,7 @@ NetlistComparer::join_symmetric_nets (db::Circuit *circuit)
     }
   }
 
-  std::sort (nodes.begin (), nodes.end (), CompareNodeEdgePair ());
+  std::sort (PARALLEL_EXEC_POLICY nodes.begin (), nodes.end (), CompareNodeEdgePair ());
 
   //  Identical nodes leading to the same nodes on the other side are candidates for symmetry.
 
@@ -2054,7 +2069,7 @@ NetlistComparer::join_symmetric_nets (db::Circuit *circuit)
 
   }
 
-  std::sort (symmetry_groups.begin (), symmetry_groups.end ());
+  std::sort (PARALLEL_EXEC_POLICY symmetry_groups.begin (), symmetry_groups.end ());
   symmetry_groups.erase (std::unique (symmetry_groups.begin (), symmetry_groups.end ()), symmetry_groups.end ());
 
   if (! symmetry_groups.empty () && tl::verbosity () >= 30) {

--- a/src/db/db/dbNetlistCompareCore.cc
+++ b/src/db/db/dbNetlistCompareCore.cc
@@ -1,4 +1,18 @@
 
+//  NOTE: <execution> must be included before any Qt header, otherwise TBB's
+//  emit() method collides with Qt's "emit" keyword macro.
+#if __cplusplus >= 201703L
+  #if __has_include(<execution>)
+    #include <execution>
+  #endif
+#endif
+
+#if defined(__cpp_lib_execution)
+#define PARALLEL_EXEC_POLICY std::execution::par,
+#else
+#define PARALLEL_EXEC_POLICY
+#endif
+
 /*
 
   KLayout Layout Viewer
@@ -32,6 +46,8 @@
 #include "tlAssert.h"
 #include "tlLog.h"
 #include "tlInternational.h"
+
+#include <algorithm>
 
 namespace db
 {
@@ -354,8 +370,8 @@ static bool edges_are_compatible (const NetGraphNode::edge_type &e, const NetGra
       ++t2;
     }
 
-    std::sort (p1.begin (), p1.end ());
-    std::sort (p2.begin (), p2.end ());
+    std::sort (PARALLEL_EXEC_POLICY p1.begin (), p1.end ());
+    std::sort (PARALLEL_EXEC_POLICY p2.begin (), p2.end ());
 
     if (p1 != p2) {
       return false;
@@ -464,8 +480,8 @@ NetlistCompareCore::derive_node_identities_for_edges (NetGraphNode::edge_iterato
 
   }
 
-  std::sort (nodes.begin (), nodes.end (), CompareNodeEdgePair ());
-  std::sort (other_nodes.begin (), other_nodes.end (), CompareNodeEdgePair ());
+  std::sort (PARALLEL_EXEC_POLICY nodes.begin (), nodes.end (), CompareNodeEdgePair ());
+  std::sort (PARALLEL_EXEC_POLICY other_nodes.begin (), other_nodes.end (), CompareNodeEdgePair ());
 
   if (db::NetlistCompareGlobalOptions::options ()->debug_netcompare) {
 
@@ -643,8 +659,8 @@ NetlistCompareCore::derive_node_identities (size_t net_index, size_t depth, size
         }
       }
 
-      std::sort (nodes.begin (), nodes.end ());
-      std::sort (other_nodes_translated.begin (), other_nodes_translated.end ());
+      std::sort (PARALLEL_EXEC_POLICY nodes.begin (), nodes.end ());
+      std::sort (PARALLEL_EXEC_POLICY other_nodes_translated.begin (), other_nodes_translated.end ());
 
       //  No fit, we can shortcut
       if (nodes != other_nodes_translated) {
@@ -1460,8 +1476,8 @@ NetlistCompareCore::analyze_failed_matches () const
     }
   }
 
-  std::sort (nodes.begin (), nodes.end (), CompareNodeEdgePair ());
-  std::sort (other_nodes.begin (), other_nodes.end (), CompareNodeEdgePair ());
+  std::sort (PARALLEL_EXEC_POLICY nodes.begin (), nodes.end (), CompareNodeEdgePair ());
+  std::sort (PARALLEL_EXEC_POLICY other_nodes.begin (), other_nodes.end (), CompareNodeEdgePair ());
 
   auto n1 = nodes.begin ();
   auto n2 = other_nodes.begin ();


### PR DESCRIPTION
Similar to #2364 but for LVS: annotates the `std::sort` calls in the netlist comparer (`dbNetlistCompare.cc`, `dbNetlistCompareCore.cc`) with `std::execution::par` so the large per-circuit sorts can run in parallel.

## Benchmark

A flat, highly-symmetric resistor mesh (`G=500` → 250k nets, 499k resistors) is built via the Ruby API and compared against an identical copy (self-compare, all runs `matched=true`). The timed region is `compare()` only. Baseline is a separately built **serial** library (= `master`). Using g++ 14.2, oneTBB 2022.1.

| Build (`compare()`, vs serial) | speedup |
|:------------------------------|--------:|
| serial (`master`)             | 1.00×   |
| par — 1 core                  | 1.66×   |
| par — 2 cores                 | 1.97×   |
| par — 4 cores                 | 2.19×   |
| par — 8 cores                 | **2.23×** |

<img width="830" height="563" alt="benchmark_plot" src="https://github.com/user-attachments/assets/2c88b56f-818f-43b1-bcef-8762ba9940a8" />

Pinned to one core (`taskset -c 0`), `par` is still **1.66×** over serial but I don't know why. Would need to check TBB's sorting implementation.

## Reproduction

Build `bin-release` with the C++17 + TBB flags and the corrected guard, then `uv run benchmark.py`. Both scripts are below.

<details>
<summary><code>test_lvs.rb</code> — netlist generator + self-compare (timed)</summary>

```ruby
# Builds a large, flat, highly-symmetric 2-D resistor mesh as a single circuit
# and compares it against an identical copy (self-compare). The regular mesh
# maximises the number of nets per circuit (-> large per-circuit node-set sorts)
# and drives the symmetry / ambiguity paths -- the std::sort call sites this PR
# parallelises.
g = (ENV["MESH"] || "500").to_i

def build_netlist(g)
  nl = RBA::Netlist::new
  rcls = RBA::DeviceClassResistor::new
  rcls.name = "RES"
  nl.add(rcls)
  circuit = RBA::Circuit::new
  circuit.name = "MESH"
  nl.add(circuit)

  nets = []
  g.times do |y|
    row = []
    g.times { |x| row << circuit.create_net("n_#{x}_#{y}") }
    nets << row
  end

  idx = 0
  g.times do |y|
    g.times do |x|
      if x + 1 < g
        d = circuit.create_device(rcls, "RH_#{x}_#{y}")
        d.set_parameter("R", 100.0 + ((x + y) % 16))
        d.connect_terminal("A", nets[y][x]); d.connect_terminal("B", nets[y][x + 1])
        idx += 1
      end
      if y + 1 < g
        d = circuit.create_device(rcls, "RV_#{x}_#{y}")
        d.set_parameter("R", 100.0 + ((x + y) % 16))
        d.connect_terminal("A", nets[y][x]); d.connect_terminal("B", nets[y + 1][x])
        idx += 1
      end
    end
  end
  [nl, circuit, idx]
end

t0 = Time.now
nl1, _c1, ndev = build_netlist(g)
nl2, _c2, _    = build_netlist(g)
t1 = Time.now
$stderr.puts "mesh G=#{g}  nets/circuit=#{g*g}  resistors/circuit=#{ndev}  build=#{'%.3f' % (t1 - t0)}s"

comp = RBA::NetlistComparer::new
tc0 = Time.now
ok = comp.compare(nl1, nl2)
tc1 = Time.now
$stderr.puts "compare matched=#{ok}  compare_time=#{'%.3f' % (tc1 - tc0)}s"
```
</details>

<details>
<summary><code>benchmark.py</code> — taskset thread sweep (isolated <code>compare()</code> + end-to-end hyperfine)</summary>

```python
# /// script
# requires-python = ">=3.11"
# dependencies = ["matplotlib", "pandas", "tabulate"]
# ///
import json, os, re, statistics, subprocess
import matplotlib; matplotlib.use("Agg")
import matplotlib.pyplot as plt
import pandas as pd

REPO = "."                       # run from the klayout checkout root
SCRIPT = "test_lvs.rb"
THREADS = [1, 2, 4, 6, 8]
MESH = os.environ.get("MESH", "500")
RUNS = 6

def cmd(t):
    return (f"taskset -c 0-{t-1} env MESH={MESH} LD_LIBRARY_PATH={REPO}/bin-release "
            f"{REPO}/bin-release/klayout -b -r {SCRIPT}")

samples = {t: [] for t in THREADS}
for _ in range(RUNS):
    for t in THREADS:
        out = subprocess.run(cmd(t), shell=True, capture_output=True, text=True)
        m = re.search(r"compare_time=([0-9.]+)s", out.stderr + out.stdout)
        if m: samples[t].append(float(m.group(1)))
base = statistics.median(samples[THREADS[0]])
iso = pd.DataFrame([{"Threads": t, "Median (s)": round(statistics.median(samples[t]), 3),
                     "Std (s)": round(statistics.pstdev(samples[t]), 3),
                     "Speedup": round(base / statistics.median(samples[t]), 2)} for t in THREADS])
print(iso.to_markdown(index=False))


plt.plot(iso["Threads"], iso["Speedup"], marker="o", label="Isolated compare()")
plt.plot(THREADS, THREADS, ":", color="gray", label="Ideal")
plt.xlabel("Threads"); plt.ylabel("Speedup"); plt.legend(); plt.grid(True)
plt.savefig("benchmark_plot.png", dpi=120, bbox_inches="tight")
```
</details>


