### PR TITLE
 CI/CD triggers to skip builds on non-source changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,34 @@ on:
     types: [published]
 
 jobs:
+  changes:
+    name: Check for source changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code == 'true' || github.event_name == 'release' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        if: github.event_name != 'release'
+        with:
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!samples/**'
+              - '!Jenkinsfile*'
+              - '!.travis.yml'
+              - '!dropbox-deployment.yml'
+              - '!.gitignore'
+              - '!LICENSE'
+              - '!COPYRIGHT'
+              - '!CONTRIB'
+              - '!Changelog*'
+
   build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -106,6 +133,8 @@ jobs:
   # The following was taken from https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/
   make_sdist:
     name: Make SDist
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,44 @@ trigger:
   tags:
     include:
       - 'v*'
+  paths:
+    exclude:
+    - '*.md'
+    - docs/*
+    - samples/*
+    - etc/*
+    - macbuild/*
+    - ci-scripts/*
+    - scripts/*
+    - .travis.yml
+    - Jenkinsfile*
+    - .gitignore
+    - LICENSE
+    - COPYRIGHT
+    - CONTRIB
+    - Changelog*
+
+pr:
+  branches:
+    include:
+    - master
+    - staging
+  paths:
+    exclude:
+    - '*.md'
+    - docs/*
+    - samples/*
+    - etc/*
+    - macbuild/*
+    - ci-scripts/*
+    - scripts/*
+    - .travis.yml
+    - Jenkinsfile*
+    - .gitignore
+    - LICENSE
+    - COPYRIGHT
+    - CONTRIB
+    - Changelog*
 
 jobs:
 - job: Build


### PR DESCRIPTION
Relating to https://github.com/KLayout/klayout/issues/2368#issuecomment-4625100031

Updates CI/CD pipelines to prevent expensive and slow Python wheel builds when changes are limited to documentation, samples, or legacy config files.

#### Changes
 - GitHub Actions (.github/workflows/build.yml): Added a changes filter job using [dorny/paths-filter](https://github.com/dorny/paths-filter). The `build` and `make_sdist` jobs now run conditionally. This uses job-level checks to ensure skipped builds report as successful and satisfy branch protection rules.
 - Azure Pipelines (azure-pipelines.yml): Added native trigger and pr path exclusions for non-source folders (docs/*, samples/*, macbuild/*, etc.) and project metadata files to skip Windows builds on unrelated modifications.

