### PR TITLE
Add caching for KLayout microbits in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,13 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: '$(python.architecture)'
 
+  - task: Cache@2
+    inputs:
+      key: 'microbits | "4.0"'
+      path: $(Build.SourcesDirectory)/klayout-microbits
+      cacheHitVar: MICROBITS_CACHED
+    displayName: 'Cache KLayout microbits'
+
   # Add additional tasks to run using each Python version in the matrix above
 
   # PowerShell
@@ -62,9 +69,13 @@ jobs:
       #arguments: # Optional
       script: | # Required when targetType == Inline
         pwd
-        Invoke-WebRequest -Uri "https://www.klayout.org/downloads/klayout-microbits-4.0.zip" -OutFile klayout-microbits-4.0.zip
-        dir
-        Expand-Archive klayout-microbits-4.0.zip -DestinationPath klayout-microbits
+        if ("$(MICROBITS_CACHED)" -ne "true") {
+          Write-Host "Cache miss: downloading and extracting KLayout microbits..."
+          Invoke-WebRequest -Uri "https://www.klayout.org/downloads/klayout-microbits-4.0.zip" -OutFile klayout-microbits-4.0.zip
+          Expand-Archive klayout-microbits-4.0.zip -DestinationPath klayout-microbits
+        } else {
+          Write-Host "Cache hit: restored KLayout microbits from cache."
+        }
         dir klayout-microbits
       #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue
       #failOnStderr: false # Optional


### PR DESCRIPTION
This PR introduces caching for the klayout-microbits in the Windows build pipeline.                                                             
                                                                                                               
#### Changes                                                                                                        
 * Added Cache@2 task in azure-pipelines.yml to cache the extracted klayout-microbits directory under $(Build.SourcesDirectory).                                                                                  
 * Adjusted the PowerShell script to conditionally download and expand klayout-microbits-4.0.zip only on cache misses, restoring directly from the Azure Pipelines cache on hits.  
                                                                                                               
This shoudl help with random timeout failures like in https://dev.azure.com/klayout/klayout/_build/results?buildId=3353&view=logs&j=023fc726-910f-52b9-2466-adec1eae67d0&t=60dea761-7989-53a0-74cc-a05ee14f95b7&l=21
