### PR TITLE
Hash-based dedup in BoxScanner instead of `std::set<pair>`

### DIFF
--- a/src/db/db/dbBoxScanner.h
+++ b/src/db/db/dbBoxScanner.h
@@ -33,6 +33,8 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <unordered_map>
+#include <unordered_set>
 #include <functional>
 #include <memory>
 
@@ -394,7 +396,7 @@ private:
 
     } else {
 
-      std::set<std::pair<const Obj *, const Obj *> > seen;
+      std::unordered_map<const Obj *, std::unordered_set<const Obj *> > seen;
 
       std::sort (m_pp.begin (), m_pp.end (), bottom_side_compare_func (bc));
 
@@ -419,12 +421,7 @@ private:
 
         while (cc != current) {
           rec.finish (cc->first, cc->second);
-          auto s = seen.lower_bound (std::make_pair (cc->first, (const Obj *)0));
-          auto s0 = s;
-          while (s != seen.end () && s->first == cc->first) {
-            ++s;
-          }
-          seen.erase (s0, s);
+          seen.erase (cc->first);
           ++cc;
         }
 
@@ -469,12 +466,13 @@ private:
           for (iterator_type i = f0; i != f; ++i) {
             for (iterator_type j = c; j < i; ++j) {
               if (bs_boxes_overlap (bc (*i), bc (*j), enl)) {
-                std::pair<const Obj *, const Obj *> k (i->first, j->first);
-                if (k.first < k.second) {
-                  std::swap (k.first, k.second);
+                const Obj *k1 = i->first, *k2 = j->first;
+                if (k1 < k2) {
+                  std::swap (k1, k2);
                 }
-                if (seen.find (k) == seen.end ()) {
-                  seen.insert (k);
+                std::unordered_set<const Obj *> &sk = seen [k1];
+                if (sk.find (k2) == sk.end ()) {
+                  sk.insert (k2);
                   rec.add (i->first, i->second, j->first, j->second);
                   if (rec.stop ()) {
                     return false;
@@ -895,8 +893,8 @@ private:
 
     } else {
 
-      std::set<std::pair<const Obj1 *, const Obj2 *> > seen1;
-      std::set<std::pair<const Obj2 *, const Obj1 *> > seen2;
+      std::unordered_map<const Obj1 *, std::unordered_set<const Obj2 *> > seen1;
+      std::unordered_map<const Obj2 *, std::unordered_set<const Obj1 *> > seen2;
 
       std::sort (m_pp1.begin (), m_pp1.end (), bottom_side_compare_func1 (bc1));
       std::sort (m_pp2.begin (), m_pp2.end (), bottom_side_compare_func2 (bc2));
@@ -926,23 +924,13 @@ private:
 
         while (cc1 != current1) {
           rec.finish1 (cc1->first, cc1->second);
-          auto s = seen1.lower_bound (std::make_pair (cc1->first, (const Obj2 *)0));
-          auto s0 = s;
-          while (s != seen1.end () && s->first == cc1->first) {
-            ++s;
-          }
-          seen1.erase (s0, s);
+          seen1.erase (cc1->first);
           ++cc1;
         }
 
         while (cc2 != current2) {
           rec.finish2 (cc2->first, cc2->second);
-          auto s = seen2.lower_bound (std::make_pair (cc2->first, (const Obj1 *)0));
-          auto s0 = s;
-          while (s != seen2.end () && s->first == cc2->first) {
-            ++s;
-          }
-          seen2.erase (s0, s);
+          seen2.erase (cc2->first);
           ++cc2;
         }
 
@@ -1005,8 +993,8 @@ private:
               for (iterator_type1 i = c1; i != f1; ++i) {
                 for (iterator_type2 j = c2; j < f2; ++j) {
                   if (bs_boxes_overlap (bc1 (*i), bc2 (*j), enl)) {
-                    if (seen1.insert (std::make_pair (i->first, j->first)).second) {
-                      seen2.insert (std::make_pair (j->first, i->first));
+                    if (seen1 [i->first].insert (j->first).second) {
+                      seen2 [j->first].insert (i->first);
                       rec.add (i->first, i->second, j->first, j->second);
                       if (rec.stop ()) {
                         return false;


### PR DESCRIPTION
Before a `std::set<std::pair<Obj*, Obj*>>` was holding every reported pair. In this PR, we change it to a hash table keyed on one pointer, whose value is a hash set of the partners.

This makes the membership tests for candidate pairs a hash map check. Removal also becomes a simple `seen.erase(X)`.

### Results

Best of 9 runs, single core (`taskset -c 0`), `g++ 14.2 -O2 -std=c++17`, glibc 2.41. Time is the full `process()` call (ms):

| scenario             | boxes  | pairs reported | before | after  | speedup |
|----------------------|-------:|---------------:|-------:|-------:|--------:|
| sparse (low overlap) | 20 000 |             13 |   1.74 |   1.65 |  1.05×  |
| medium overlap       | 20 000 |          3 971 |   3.23 |   3.00 |  1.08×  |
| dense (high overlap) | 20 000 |        177 809 |  45.5  |  16.6  |  2.7×   |
| very dense           | 12 000 |      1 053 355 | 320    | 116    |  2.8×   |

The win scales with how large the `seen` set grows: light/sparse inputs (the common case) are neutral-to-slightly-better, while high-overlap inputs walked the tree more.

### Reproduce

```c++
//
//  Microbenchmark for db::box_scanner pair-reporting (the cross-band dedup path).
//
//  Build (run before and after change):
//    g++ -std=c++17 -O2 -I<hdr> -Isrc/db/db -Isrc/tl/tl -Isrc/gsi/gsi \
//        bench_boxscanner.cc -o bench -Lbin -lklayout_db -lklayout_tl
//

#include "dbBoxScanner.h"
#include "dbBox.h"

#include <cstdio>
#include <cstdint>
#include <string>
#include <vector>
#include <algorithm>
#include <chrono>

//  Provide the no-Qt translation fallback (the prebuilt libs use QObject::tr).
namespace tl { std::string tr_fallback (const char *s) { return std::string (s); } }

//  Minimal receiver: only counts reported pairs (and acts as a behaviour check).
struct CountingRecorder
{
  uint64_t pairs = 0;
  void initialize () {}
  void finalize (bool) {}
  void finish (const db::Box *, size_t) {}
  bool stop () const { return false; }
  void add (const db::Box *, size_t, const db::Box *, size_t) { ++pairs; }
};

//  Deterministic 64-bit LCG so layouts are identical across builds/runs.
struct Rng
{
  uint64_t s;
  explicit Rng (uint64_t seed) : s (seed) {}
  uint64_t next () { s = s * 6364136223846793005ULL + 1442695040888963407ULL; return s >> 17; }
  int range (int lo, int hi) { return lo + int (next () % uint64_t (hi - lo + 1)); }
};

//  Generate `n` axis-aligned boxes of side in [smin,smax] with lower-left placed
//  uniformly in a square of side `extent`. The ratio side/extent sets the overlap
//  density: large boxes in a small extent -> many mutually overlapping pairs that
//  recur across scan bands, which is exactly what the "seen" set tracks.
static std::vector<db::Box> make_boxes (int n, int extent, int smin, int smax, uint64_t seed)
{
  Rng rng (seed);
  std::vector<db::Box> bb;
  bb.reserve (n);
  for (int i = 0; i < n; ++i) {
    int x = rng.range (0, extent);
    int y = rng.range (0, extent);
    int w = rng.range (smin, smax);
    int h = rng.range (smin, smax);
    bb.push_back (db::Box (x, y, x + w, y + h));
  }
  return bb;
}

struct Scenario { const char *name; int n; int extent; int smin; int smax; };

static double run_once (const std::vector<db::Box> &bb, uint64_t &pairs_out)
{
  db::box_scanner<db::Box, size_t> bs;
  for (size_t i = 0; i < bb.size (); ++i) {
    bs.insert (&bb[i], i);
  }
  CountingRecorder rec;
  db::box_convert<db::Box> bc;
  auto t0 = std::chrono::steady_clock::now ();
  bs.process (rec, 1 /*enl: touching counts*/, bc);
  auto t1 = std::chrono::steady_clock::now ();
  pairs_out = rec.pairs;
  return std::chrono::duration<double, std::milli> (t1 - t0).count ();
}

int main (int argc, char **argv)
{
  int trials = (argc > 1) ? atoi (argv[1]) : 7;

  Scenario scns[] = {
    //  name                  n      extent  smin  smax
    { "sparse (low overlap)",  20000, 2000000, 200,  400 },
    { "medium overlap",        20000,  200000, 300,  600 },
    { "dense (high overlap)",  20000,   40000, 400,  800 },
    { "very dense",            12000,   12000, 500, 1000 },
  };

  printf ("%-24s %8s %12s %11s %11s\n", "scenario", "boxes", "pairs", "best ms", "median ms");
  printf ("%s\n", "------------------------------------------------------------------------");

  for (const Scenario &sc : scns) {
    std::vector<db::Box> bb = make_boxes (sc.n, sc.extent, sc.smin, sc.smax, 0x9e3779b97f4a7c15ULL);
    std::vector<double> ts;
    uint64_t pairs = 0, p0 = 0;
    for (int t = 0; t < trials; ++t) {
      ts.push_back (run_once (bb, pairs));
      if (t == 0) { p0 = pairs; }
      if (pairs != p0) { fprintf (stderr, "NONDETERMINISTIC pair count!\n"); return 1; }
    }
    std::sort (ts.begin (), ts.end ());
    double best = ts.front ();
    double median = ts[ts.size () / 2];
    printf ("%-24s %8d %12llu %11.2f %11.2f\n",
            sc.name, sc.n, (unsigned long long) pairs, best, median);
  }
  return 0;
}

```
