### PR TITLE
Use multiple drawing workers for image_with_options rendering

### DIFF
--- a/src/laybasic/laybasic/layLayoutCanvas.cc
+++ b/src/laybasic/laybasic/layLayoutCanvas.cc
@@ -855,7 +855,9 @@ LayoutCanvas::image_with_options (unsigned int width, unsigned int height, int l
   lay::RedrawThread redraw_thread (&rd_canvas, mp_view);
 
   //  render the layout
-  redraw_thread.start (0 /*synchronous*/, m_layers, vp, resolution, font_resolution, true);
+  int workers = mp_view->synchronous () ? 0 : mp_view->drawing_workers ();
+  redraw_thread.start (workers, m_layers, vp, resolution, font_resolution, true);
+  redraw_thread.wait ();
   redraw_thread.stop (); // safety
 
   //  paint the background objects. It uses "img" to paint on.


### PR DESCRIPTION
`LayoutCanvas::image_with_options` always rendered the layout with a single thread (workers = 0), which serialized image generation even on views configured for parallel drawing. Now it honors the view's `drawing_workers()` count when the view is not in synchronous mode, and waits for the asynchronous workers to finish before reading back the rendered bitmaps. This speeds up image export on large layouts while preserving the original single-threaded behavior in synchronous mode.