### PR TITLE
Add drag-and-drop reordering of layout view tabs

### DIFF
--- a/src/lay/lay/layControlWidgetStack.cc
+++ b/src/lay/lay/layControlWidgetStack.cc
@@ -127,6 +127,17 @@ void ControlWidgetStack::remove_widget(size_t index)
   update_geometry ();
 }
 
+void ControlWidgetStack::move_widget (size_t from, size_t to)
+{
+  if (from == to || from >= m_widgets.size () || to >= m_widgets.size ()) {
+    return;
+  }
+
+  QWidget *w = m_widgets [from];
+  m_widgets.erase (m_widgets.begin () + from);
+  m_widgets.insert (m_widgets.begin () + to, w);
+}
+
 void ControlWidgetStack::raise_widget(size_t index)
 {
   mp_current_widget = 0;

--- a/src/lay/lay/layControlWidgetStack.h
+++ b/src/lay/lay/layControlWidgetStack.h
@@ -45,6 +45,7 @@ public:
 
   void add_widget (QWidget *w);
   void remove_widget (size_t index);
+  void move_widget (size_t from, size_t to);
   void raise_widget (size_t index);
   QWidget *widget (size_t index);
   QWidget *background_widget ();

--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -248,6 +248,8 @@ MainWindow::MainWindow (QApplication *app, const char *name, bool undo_enabled)
   vbh_tab->addWidget (enh_tab_widget->menu_button ());
 
   connect (mp_tab_bar, SIGNAL (currentChanged (int)), this, SLOT (view_selected (int)));
+  mp_tab_bar->setMovable (true);
+  connect (mp_tab_bar, SIGNAL (tabMoved (int, int)), this, SLOT (tab_moved (int, int)));
 #if QT_VERSION >= 0x040500
   mp_tab_bar->setTabsClosable (true);
   connect (mp_tab_bar, SIGNAL (tabCloseRequested (int)), this, SLOT (tab_close_requested (int)));
@@ -2717,6 +2719,43 @@ void
 MainWindow::tab_close_requested (int index)
 {
   interactive_close_view (index, index + 1, false, true);
+}
+
+void
+MainWindow::tab_moved (int from, int to)
+{
+  if (from == to || from < 0 || to < 0 || from >= int (mp_views.size ()) || to >= int (mp_views.size ())) {
+    return;
+  }
+
+  //  The tab bar already reflects the new order. Reorder the backing view list
+  //  and all parallel widget stacks so that positional indices stay in sync with
+  //  the tab positions.
+  lay::LayoutViewWidget *w = mp_views [from];
+  mp_views.erase (mp_views.begin () + from);
+  mp_views.insert (mp_views.begin () + to, w);
+
+  mp_view_stack->move_widget (from, to);
+  mp_lp_stack->move_widget (from, to);
+  mp_layer_toolbox_stack->move_widget (from, to);
+  mp_hp_stack->move_widget (from, to);
+  mp_libs_stack->move_widget (from, to);
+  mp_eo_stack->move_widget (from, to);
+  mp_bm_stack->move_widget (from, to);
+
+  //  Qt emits tabMoved before currentChanged, so a subsequent view_selected will
+  //  operate on the already-reordered stacks. Re-raise the current widgets here to
+  //  cover the case where the current tab index did not change (no currentChanged).
+  int ci = mp_tab_bar->currentIndex ();
+  if (ci >= 0 && ci < int (mp_views.size ())) {
+    mp_view_stack->raise_widget (ci);
+    mp_lp_stack->raise_widget (ci);
+    mp_layer_toolbox_stack->raise_widget (ci);
+    mp_hp_stack->raise_widget (ci);
+    mp_libs_stack->raise_widget (ci);
+    mp_eo_stack->raise_widget (ci);
+    mp_bm_stack->raise_widget (ci);
+  }
 }
 
 void

--- a/src/lay/lay/layMainWindow.h
+++ b/src/lay/lay/layMainWindow.h
@@ -674,6 +674,7 @@ public slots:
   void close_all_views_right ();
   void clone ();
   void tab_close_requested (int);
+  void tab_moved (int from, int to);
   void open_recent (size_t n);
   void open_recent_session (size_t n);
   void open_recent_layer_properties (size_t n);

--- a/src/lay/lay/layViewWidgetStack.cc
+++ b/src/lay/lay/layViewWidgetStack.cc
@@ -68,6 +68,17 @@ void ViewWidgetStack::remove_widget (size_t index)
   }
 }
 
+void ViewWidgetStack::move_widget (size_t from, size_t to)
+{
+  if (from == to || from >= m_widgets.size () || to >= m_widgets.size ()) {
+    return;
+  }
+
+  LayoutViewWidget *w = m_widgets [from];
+  m_widgets.erase (m_widgets.begin () + from);
+  m_widgets.insert (m_widgets.begin () + to, w);
+}
+
 void ViewWidgetStack::raise_widget (size_t index)
 {
   if (index < m_widgets.size ()) {

--- a/src/lay/lay/layViewWidgetStack.h
+++ b/src/lay/lay/layViewWidgetStack.h
@@ -43,6 +43,7 @@ public:
 
   void add_widget (lay::LayoutViewWidget *w);
   void remove_widget (size_t index);
+  void move_widget (size_t from, size_t to);
   void raise_widget (size_t index);
   LayoutViewWidget *widget (size_t index);
   QWidget *background_widget ();


### PR DESCRIPTION
## Summary

Enables drag-and-drop reordering of the layout view tabs in the main window. Previously the tabs could not be rearranged; this makes the tab bar movable and keeps the underlying view model in sync when tabs are dragged.

## Details

The tab index is used as a positional key into `mp_views` and the seven parallel widget stacks (view / layer-control / layer-toolbox / hierarchy / libraries / editor-options / bookmarks), so reordering the `QTabBar` alone would desync them.

- `MainWindow`: enable `QTabBar::setMovable(true)` and connect `QTabBar::tabMoved(int,int)` to a new `MainWindow::tab_moved(from, to)` slot that reorders `mp_views` and every widget stack to match the new tab order, then re-raises the current widgets.
  - Qt emits `tabMoved` before `currentChanged`, so any subsequent view selection operates on the already-reordered stacks.
  - The current view is tracked by object (`LayoutView::current()`), so it is never lost across a reorder — only its index changes.
- `ViewWidgetStack` and `ControlWidgetStack`: add a `move_widget(from, to)` helper that reorders the internal widget vector.

Net change is additive: 6 files, +64 lines.

## Testing

- Built on macOS (Qt 6, `build4mac.py`).
- Full unit-test suite (`ut_runner` via `macQAT.py`) run before and after: the same pre-existing set of failures (unrelated `rba`/`lvs`/`drc`/`tl` reference-data and environment-specific tests) appears with and without this change; no new failures are introduced.
- Manually verified: drag to reorder, then switch / clone / close tabs — the tab↔view mapping stays consistent.

## Known cosmetic note

On macOS, while a tab is actively being dragged, Qt's built-in movable-tab drag rendering tints the tabs flanking the lifted tab blue (the platform style's `dragInProgress` paint path, using a grabbed-pixmap overlay for the moving tab). This is Qt-native behavior triggered simply by enabling `setMovable(true)` — it occurs before any reorder logic runs, is purely visual, and reverts on drop. Left as-is.